### PR TITLE
fix(infra): harden AgentCore production cutovers

### DIFF
--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1921,6 +1921,16 @@ export class AgentPlatformStack extends cdk.Stack {
         ? agentcore.AgentRuntimeArtifact.fromEcrRepository(resources.ecrRepository, imageTag)
         : undefined;
 
+    // Keep the Runtime security group independent of the image-gated Runtime.
+    // AgentCore ENIs can survive Runtime deletion for hours, so deleting this
+    // group in the same deployment can leave CloudFormation waiting on an
+    // in-use security group. The construct ID intentionally matches the ID the
+    // AgentCore L2 previously created implicitly, preserving its logical ID.
+    const runtimeSecurityGroup = new ec2.SecurityGroup(this, 'SecurityGroup', {
+      vpc: resources.vpc,
+      allowAllOutbound: true,
+    });
+
     if (artifact) {
       resources.runtime = new agentcore.Runtime(this, 'AgentCoreRuntime', {
         runtimeName: `psd_agent_${environment}`,
@@ -1937,6 +1947,7 @@ export class AgentPlatformStack extends cdk.Stack {
             subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
             availabilityZones: ['us-east-1b', 'us-east-1c'],
           },
+          securityGroups: [runtimeSecurityGroup],
         }),
         description: `PSD AI Agent Platform runtime (${environment})`,
         environmentVariables: runtimeEnvVars,

--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -193,14 +193,15 @@
       }
     },
     {
-      "Sid": "RequireMFAForDynamoDBDeleteExceptAgentLocks",
-      "_comment": "The agent router (a Lambda service role, never MFA-present) must DeleteItem to release per-session locks (agent-router index.ts releaseSessionLock). The blanket MFA-deny above previously blocked it, so locks only expired via TTL (14m) causing same-session serialization. Keep the MFA requirement for every other table; carve out only the session-locks tables.",
+      "Sid": "RequireMFAForDynamoDBDeleteExceptAgentState",
+      "_comment": "The agent router (a Lambda service role, never MFA-present) must DeleteItem to release per-session locks and message-dedup claims used by durable workspace deferral. Keep the MFA requirement for every other table; carve out only those two narrowly named agent-state tables.",
       "Effect": "Deny",
       "Action": [
         "dynamodb:DeleteItem"
       ],
       "NotResource": [
-        "arn:aws:dynamodb:*:*:table/psd-agent-session-locks-*"
+        "arn:aws:dynamodb:*:*:table/psd-agent-session-locks-*",
+        "arn:aws:dynamodb:*:*:table/psd-agent-message-dedup-*"
       ],
       "Condition": {
         "BoolIfExists": {

--- a/infra/test/agent-platform-runtime-security-group.test.ts
+++ b/infra/test/agent-platform-runtime-security-group.test.ts
@@ -1,0 +1,152 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { AgentPlatformStack } from '../lib/agent-platform-stack';
+import { EnvironmentConfig } from '../lib/constructs';
+
+const TEST_ACCOUNT = '123456789012';
+const REGION = 'us-east-1';
+const ENV = 'prod';
+const RUNTIME_SECURITY_GROUP_LOGICAL_ID = 'SecurityGroupDD263621';
+const REAL_VPC_KEY =
+  'vpc-provider:account=390844780692:filter.tag:Name=aistudio-prod-vpc:' +
+  'region=us-east-1:returnAsymmetricSubnets=true';
+const TEST_VPC_KEY =
+  `vpc-provider:account=${TEST_ACCOUNT}:filter.tag:Name=aistudio-${ENV}-vpc:` +
+  `region=${REGION}:returnAsymmetricSubnets=true`;
+
+type CfnResource = {
+  Type: string;
+  Properties?: Record<string, unknown>;
+  DeletionPolicy?: string;
+  UpdateReplacePolicy?: string;
+};
+
+function buildTemplate(imageTag?: string): Template {
+  const cdkContext = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'cdk.context.json'), 'utf8')
+  ) as Record<string, unknown>;
+  const vpcBlob = JSON.parse(JSON.stringify(cdkContext[REAL_VPC_KEY])) as unknown;
+  const app = new cdk.App({
+    context: {
+      ...cdkContext,
+      [TEST_VPC_KEY]: vpcBlob,
+      'aws:cdk:bundling-stacks': [],
+      ...(imageTag ? { agentImageTag: imageTag } : {}),
+    },
+  });
+  const stack = new AgentPlatformStack(
+    app,
+    `AIStudio-AgentPlatformStack-${ENV}`,
+    {
+      environment: ENV,
+      config: EnvironmentConfig.get(ENV),
+      databaseResourceArn:
+        `arn:aws:rds:${REGION}:${TEST_ACCOUNT}:cluster:aistudio-${ENV}`,
+      databaseSecretArn:
+        `arn:aws:secretsmanager:${REGION}:${TEST_ACCOUNT}:` +
+        `secret:aistudio-${ENV}-db-AbCdEf`,
+      databaseHost:
+        `aistudio-${ENV}.cluster-abc.${REGION}.rds.amazonaws.com`,
+      databaseName: 'aistudio',
+      guardrailArn:
+        `arn:aws:bedrock:${REGION}:${TEST_ACCOUNT}:guardrail/test`,
+      guardrailId: 'test-guardrail-id',
+      alertEmail: 'alerts@psd401.net',
+      appBaseUrl: `https://${ENV}.aistudio.psd401.ai`,
+      env: { account: TEST_ACCOUNT, region: REGION },
+    }
+  );
+  return Template.fromStack(stack);
+}
+
+function resourcesOf(template: Template): Record<string, CfnResource> {
+  return template.toJSON().Resources as Record<string, CfnResource>;
+}
+
+function workspaceBucketOf(template: Template): [string, CfnResource] {
+  const buckets = Object.entries(resourcesOf(template)).filter(
+    ([logicalId, resource]) =>
+      logicalId.startsWith('AgentWorkspaceBucket') &&
+      resource.Type === 'AWS::S3::Bucket'
+  );
+  expect(buckets).toHaveLength(1);
+  return buckets[0];
+}
+
+function withoutCustomResourceOwnershipTags(resource: CfnResource): CfnResource {
+  const normalized = JSON.parse(JSON.stringify(resource)) as CfnResource;
+  const tags = normalized.Properties?.Tags;
+  if (Array.isArray(tags)) {
+    normalized.Properties!.Tags = tags.filter((tag) => {
+      if (tag === null || typeof tag !== 'object') return true;
+      const key = (tag as { Key?: unknown }).Key;
+      return typeof key !== 'string' || !key.startsWith('aws-cdk:cr-owned:');
+    });
+  }
+  return normalized;
+}
+
+describe('AgentPlatformStack — persistent AgentCore Runtime security group', () => {
+  let withoutRuntime: Template;
+  let withRuntime: Template;
+
+  beforeAll(() => {
+    withoutRuntime = buildTemplate();
+    withRuntime = buildTemplate('test-image-tag');
+  });
+
+  it('keeps the existing Runtime security group when image context is omitted', () => {
+    const resources = resourcesOf(withoutRuntime);
+
+    expect(resources[RUNTIME_SECURITY_GROUP_LOGICAL_ID]).toEqual(
+      expect.objectContaining({ Type: 'AWS::EC2::SecurityGroup' })
+    );
+    expect(withoutRuntime.findResources('AWS::BedrockAgentCore::Runtime')).toEqual({});
+  });
+
+  it('wires the forward Runtime to the same preserved security group', () => {
+    const resources = resourcesOf(withRuntime);
+    const runtimes = withRuntime.findResources('AWS::BedrockAgentCore::Runtime');
+
+    expect(resources[RUNTIME_SECURITY_GROUP_LOGICAL_ID]).toEqual(
+      resourcesOf(withoutRuntime)[RUNTIME_SECURITY_GROUP_LOGICAL_ID]
+    );
+    expect(Object.keys(runtimes)).toHaveLength(1);
+    expect(Object.values(runtimes)[0]).toEqual(
+      expect.objectContaining({
+        Properties: expect.objectContaining({
+          NetworkConfiguration: expect.objectContaining({
+            NetworkMode: 'VPC',
+            NetworkModeConfig: expect.objectContaining({
+              SecurityGroups: [
+                {
+                  'Fn::GetAtt': [
+                    RUNTIME_SECURITY_GROUP_LOGICAL_ID,
+                    'GroupId',
+                  ],
+                },
+              ],
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  it('leaves the retained production workspace bucket unchanged', () => {
+    const withoutRuntimeBucket = workspaceBucketOf(withoutRuntime);
+    const withRuntimeBucket = workspaceBucketOf(withRuntime);
+
+    expect(withRuntimeBucket[0]).toBe(withoutRuntimeBucket[0]);
+    // Bundled-skill custom resources add an image-tag-specific ownership tag
+    // to this shared bucket. Ignore only those CDK bookkeeping tags; every
+    // persistent bucket property and policy must remain identical.
+    expect(withoutCustomResourceOwnershipTags(withRuntimeBucket[1])).toEqual(
+      withoutCustomResourceOwnershipTags(withoutRuntimeBucket[1])
+    );
+    expect(withoutRuntimeBucket[1].DeletionPolicy).toBe('Retain');
+    expect(withoutRuntimeBucket[1].UpdateReplacePolicy).toBe('Retain');
+  });
+});

--- a/infra/test/unit/permission-boundary-construct.test.ts
+++ b/infra/test/unit/permission-boundary-construct.test.ts
@@ -5,9 +5,10 @@ import { PermissionBoundaryConstruct } from "../../lib/constructs/security/permi
 type PolicyStatement = {
   Sid?: string;
   Action?: string | string[];
+  NotResource?: string | string[];
 };
 
-function allowedActions(environment: "dev" | "prod"): string[] {
+function policyStatements(environment: "dev" | "prod"): PolicyStatement[] {
   const app = new cdk.App();
   const stack = new cdk.Stack(app, `PermissionBoundary-${environment}`, {
     env: { account: "123456789012", region: "us-east-1" },
@@ -17,9 +18,13 @@ function allowedActions(environment: "dev" | "prod"): string[] {
   const policies = Template.fromStack(stack).findResources(
     "AWS::IAM::ManagedPolicy"
   );
-  const statements = Object.values(policies).flatMap((policy) =>
+  return Object.values(policies).flatMap((policy) =>
     (policy.Properties?.PolicyDocument?.Statement ?? []) as PolicyStatement[]
   );
+}
+
+function allowedActions(environment: "dev" | "prod"): string[] {
+  const statements = policyStatements(environment);
   const allowedServices = statements.find(
     (statement) => statement.Sid === "AllowedServices"
   );
@@ -52,6 +57,19 @@ describe("PermissionBoundaryConstruct", () => {
         "s3:ListBucketVersions",
       ])
     );
+  });
+
+  test("prod permits service roles to release only the two agent DynamoDB claim tables", () => {
+    const statement = policyStatements("prod").find(
+      (candidate) =>
+        candidate.Sid === "RequireMFAForDynamoDBDeleteExceptAgentState"
+    );
+
+    expect(statement?.Action).toBe("dynamodb:DeleteItem");
+    expect(statement?.NotResource).toEqual([
+      "arn:aws:dynamodb:*:*:table/psd-agent-session-locks-*",
+      "arn:aws:dynamodb:*:*:table/psd-agent-message-dedup-*",
+    ]);
   });
 
   test.each(["dev", "prod"] as const)(


### PR DESCRIPTION
## Summary
- preserve the AgentCore runtime security group when image context is intentionally absent
- permit the production router to release durable-deferral dedup claims on the narrowly scoped message-dedup table
- add synthesized-template regression coverage for both lifecycle contracts

## Production evidence
- Runtime-less and Runtime-present templates preserve `SecurityGroupDD263621`
- live IAM simulation allows `DeleteItem` only on session-locks and message-dedup; users table remains explicitly denied
- production PermissionBoundary stack deployed successfully

## Verification
- `bun run lint`
- `bunx tsc --noEmit --incremental false`
- 12/12 focused infrastructure tests
- Claude/Fable review: no blocking findings
- independent review: no blocking findings

E2E intentionally skipped for this infrastructure cutover.