### PR TITLE
fix(repositories): garbage-collect superseded index generations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,11 @@ jobs:
       env:
         CI: true
 
+    - name: Run repository generation-retention smoke
+      run: bun run test:smoke:generation-retention
+      env:
+        CI: true
+
     - name: Run OAuth client trust audit smoke
       run: bun run test:smoke:oauth-client-trust-audit
       env:

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -162,6 +162,7 @@
     "169-agentic-model-readiness.sql",
     "170-nexus-durable-repository-bindings.sql",
     "171-workspace-upload-zero-byte-files.sql",
-    "172-content-data-records.sql"
+    "172-content-data-records.sql",
+    "173-repository-index-generation-retention.sql"
   ]
 }

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -4,7 +4,8 @@
 --
 -- Record the transition time independently of generation creation so a
 -- long-lived active generation always gets a full rollback window after it is
--- replaced. Existing rows start a conservative new window at deployment.
+-- replaced. Existing rows start a conservative new window in bounded
+-- post-deployment maintenance batches.
 -- ============================================================================
 
 -- Keep the body on one single-quoted line. The db-init Lambda's line-based SQL
@@ -12,31 +13,20 @@
 CREATE OR REPLACE FUNCTION set_repository_index_generation_superseded_at() RETURNS trigger AS 'BEGIN IF NEW.status <> ''superseded'' THEN NEW.superseded_at := NULL; ELSIF TG_OP = ''INSERT'' THEN NEW.superseded_at := clock_timestamp(); ELSIF OLD.status IS DISTINCT FROM ''superseded'' THEN NEW.superseded_at := clock_timestamp(); END IF; RETURN NEW; END;' LANGUAGE plpgsql;
 
 ALTER TABLE repository_index_generations
-  ADD COLUMN IF NOT EXISTS superseded_at timestamptz
-  DEFAULT statement_timestamp();
+  ADD COLUMN IF NOT EXISTS superseded_at timestamptz;
 
 CREATE OR REPLACE TRIGGER trg_repository_index_generation_superseded_at
 BEFORE INSERT OR UPDATE OF status ON repository_index_generations
 FOR EACH ROW
 EXECUTE FUNCTION set_repository_index_generation_superseded_at();
 
--- PostgreSQL stores a non-volatile ADD COLUMN default in table metadata instead
--- of rewriting the backlog. Once the trigger is protecting transitions, remove
--- the temporary default and conservatively start a fresh window for every
--- existing superseded row. clock_timestamp() also repairs a transition that
--- raced between the ADD COLUMN commit and trigger installation without making
--- its rollback window expire early.
-ALTER TABLE repository_index_generations
-  ALTER COLUMN superseded_at DROP DEFAULT;
-
-UPDATE repository_index_generations
-SET superseded_at = clock_timestamp()
-WHERE status = 'superseded';
-
-UPDATE repository_index_generations
-SET superseded_at = NULL
-WHERE status <> 'superseded'
-  AND superseded_at IS NOT NULL;
+-- Existing superseded rows, including a transition that races between the ADD
+-- COLUMN commit and trigger installation, remain NULL here. The scheduled
+-- collector gives them a conservative new rollback window in bounded batches;
+-- migration 173 never rewrites the complete generation table in one statement.
+CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_backfill
+  ON repository_index_generations (id)
+  WHERE status = 'superseded' AND superseded_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_retention
   ON repository_index_generations (repository_id, superseded_at DESC, created_at DESC, id DESC)
@@ -58,6 +48,7 @@ ON CONFLICT (key) DO NOTHING;
 
 -- ROLLBACK SQL (for manual rollback if needed)
 -- DROP INDEX IF EXISTS idx_repository_index_generations_superseded_retention;
+-- DROP INDEX IF EXISTS idx_repository_index_generations_superseded_backfill;
 -- DROP INDEX IF EXISTS idx_knowledge_repositories_active_index_generation;
 -- DROP TRIGGER IF EXISTS trg_repository_index_generation_superseded_at ON repository_index_generations;
 -- DROP FUNCTION IF EXISTS set_repository_index_generation_superseded_at();

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -1,0 +1,15 @@
+-- ============================================================================
+-- 173: bounded retention for superseded repository index generations (#1527)
+-- ============================================================================
+--
+-- The scheduled collector ranks superseded generations per repository by this
+-- ordering, retains the newest three and a 24-hour safety window, then deletes
+-- old chunks and childless generation rows in bounded batches.
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_retention
+  ON repository_index_generations (repository_id, created_at DESC, id DESC)
+  WHERE status = 'superseded';
+
+-- ROLLBACK SQL (for manual rollback if needed)
+-- DROP INDEX IF EXISTS idx_repository_index_generations_superseded_retention;

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -25,7 +25,7 @@ EXECUTE FUNCTION set_repository_index_generation_superseded_at();
 -- collector gives them a conservative new rollback window in bounded batches;
 -- migration 173 never rewrites the complete generation table in one statement.
 CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_backfill
-  ON repository_index_generations (id)
+  ON repository_index_generations (created_at, id)
   WHERE status = 'superseded' AND superseded_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_retention

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -48,6 +48,14 @@ CREATE INDEX IF NOT EXISTS idx_knowledge_repositories_active_index_generation
   ON knowledge_repositories (active_index_generation_id)
   WHERE active_index_generation_id IS NOT NULL;
 
+-- The production runner commits statements individually. Close the only gap
+-- (default removed, trigger not installed yet) after the trigger is active so
+-- no superseded row can remain permanently ineligible with a NULL timestamp.
+UPDATE repository_index_generations
+SET superseded_at = statement_timestamp()
+WHERE status = 'superseded'
+  AND superseded_at IS NULL;
+
 -- ROLLBACK SQL (for manual rollback if needed)
 -- DROP INDEX IF EXISTS idx_repository_index_generations_superseded_retention;
 -- DROP INDEX IF EXISTS idx_knowledge_repositories_active_index_generation;

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -8,24 +8,35 @@
 -- ============================================================================
 
 ALTER TABLE repository_index_generations
-  ADD COLUMN IF NOT EXISTS superseded_at timestamptz;
+  ADD COLUMN IF NOT EXISTS superseded_at timestamptz
+  DEFAULT statement_timestamp();
+
+-- PostgreSQL stores a non-volatile ADD COLUMN default in table metadata instead
+-- of rewriting the backlog. New application rows rely on the trigger below.
+ALTER TABLE repository_index_generations
+  ALTER COLUMN superseded_at DROP DEFAULT;
 
 UPDATE repository_index_generations
-SET superseded_at = now()
+SET superseded_at = statement_timestamp()
 WHERE status = 'superseded'
   AND superseded_at IS NULL;
+
+UPDATE repository_index_generations
+SET superseded_at = NULL
+WHERE status <> 'superseded'
+  AND superseded_at IS NOT NULL;
 
 CREATE OR REPLACE FUNCTION set_repository_index_generation_superseded_at()
 RETURNS trigger
 LANGUAGE plpgsql
 AS $$
 BEGIN
-  IF NEW.status = 'superseded' THEN
-    IF TG_OP = 'INSERT' OR OLD.status IS DISTINCT FROM 'superseded' THEN
-      NEW.superseded_at = now();
-    END IF;
-  ELSE
+  IF NEW.status <> 'superseded' THEN
     NEW.superseded_at = NULL;
+  ELSIF TG_OP = 'INSERT' THEN
+    NEW.superseded_at = clock_timestamp();
+  ELSIF OLD.status IS DISTINCT FROM 'superseded' THEN
+    NEW.superseded_at = clock_timestamp();
   END IF;
   RETURN NEW;
 END;

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -2,14 +2,48 @@
 -- 173: bounded retention for superseded repository index generations (#1527)
 -- ============================================================================
 --
--- The scheduled collector ranks superseded generations per repository by this
--- ordering, retains the newest three and a 24-hour safety window, then deletes
--- old chunks and childless generation rows in bounded batches.
+-- Record the transition time independently of generation creation so a
+-- long-lived active generation always gets a full rollback window after it is
+-- replaced. Existing rows start a conservative new window at deployment.
 -- ============================================================================
 
+ALTER TABLE repository_index_generations
+  ADD COLUMN IF NOT EXISTS superseded_at timestamptz;
+
+UPDATE repository_index_generations
+SET superseded_at = now()
+WHERE status = 'superseded'
+  AND superseded_at IS NULL;
+
+CREATE OR REPLACE FUNCTION set_repository_index_generation_superseded_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.status = 'superseded' THEN
+    IF TG_OP = 'INSERT' OR OLD.status IS DISTINCT FROM 'superseded' THEN
+      NEW.superseded_at = now();
+    END IF;
+  ELSE
+    NEW.superseded_at = NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_repository_index_generation_superseded_at
+  ON repository_index_generations;
+CREATE TRIGGER trg_repository_index_generation_superseded_at
+BEFORE INSERT OR UPDATE OF status ON repository_index_generations
+FOR EACH ROW
+EXECUTE FUNCTION set_repository_index_generation_superseded_at();
+
 CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_retention
-  ON repository_index_generations (repository_id, created_at DESC, id DESC)
+  ON repository_index_generations (repository_id, superseded_at DESC, id DESC)
   WHERE status = 'superseded';
 
 -- ROLLBACK SQL (for manual rollback if needed)
 -- DROP INDEX IF EXISTS idx_repository_index_generations_superseded_retention;
+-- DROP TRIGGER IF EXISTS trg_repository_index_generation_superseded_at ON repository_index_generations;
+-- DROP FUNCTION IF EXISTS set_repository_index_generation_superseded_at();
+-- ALTER TABLE repository_index_generations DROP COLUMN IF EXISTS superseded_at;

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -16,6 +16,9 @@ ALTER TABLE repository_index_generations
 ALTER TABLE repository_index_generations
   ALTER COLUMN superseded_at DROP DEFAULT;
 
+-- The normal historical backlog already has the fast-default value. This is
+-- only an idempotent recovery for a partial run or a row written during the
+-- short interval between removing the default and installing the trigger.
 UPDATE repository_index_generations
 SET superseded_at = statement_timestamp()
 WHERE status = 'superseded'

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -26,21 +26,9 @@ SET superseded_at = NULL
 WHERE status <> 'superseded'
   AND superseded_at IS NOT NULL;
 
-CREATE OR REPLACE FUNCTION set_repository_index_generation_superseded_at()
-RETURNS trigger
-LANGUAGE plpgsql
-AS $$
-BEGIN
-  IF NEW.status <> 'superseded' THEN
-    NEW.superseded_at = NULL;
-  ELSIF TG_OP = 'INSERT' THEN
-    NEW.superseded_at = clock_timestamp();
-  ELSIF OLD.status IS DISTINCT FROM 'superseded' THEN
-    NEW.superseded_at = clock_timestamp();
-  END IF;
-  RETURN NEW;
-END;
-$$;
+-- Keep the body on one single-quoted line. The db-init Lambda's line-based SQL
+-- splitter treats an interior line ending in ");" as the end of a function.
+CREATE OR REPLACE FUNCTION set_repository_index_generation_superseded_at() RETURNS trigger AS 'BEGIN IF NEW.status <> ''superseded'' THEN NEW.superseded_at := NULL; ELSIF TG_OP = ''INSERT'' THEN NEW.superseded_at := clock_timestamp(); ELSIF OLD.status IS DISTINCT FROM ''superseded'' THEN NEW.superseded_at := clock_timestamp(); END IF; RETURN NEW; END;' LANGUAGE plpgsql;
 
 DROP TRIGGER IF EXISTS trg_repository_index_generation_superseded_at
   ON repository_index_generations;
@@ -53,8 +41,13 @@ CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_retention
   ON repository_index_generations (repository_id, superseded_at DESC, id DESC)
   WHERE status = 'superseded';
 
+CREATE INDEX IF NOT EXISTS idx_knowledge_repositories_active_index_generation
+  ON knowledge_repositories (active_index_generation_id)
+  WHERE active_index_generation_id IS NOT NULL;
+
 -- ROLLBACK SQL (for manual rollback if needed)
 -- DROP INDEX IF EXISTS idx_repository_index_generations_superseded_retention;
+-- DROP INDEX IF EXISTS idx_knowledge_repositories_active_index_generation;
 -- DROP TRIGGER IF EXISTS trg_repository_index_generation_superseded_at ON repository_index_generations;
 -- DROP FUNCTION IF EXISTS set_repository_index_generation_superseded_at();
 -- ALTER TABLE repository_index_generations DROP COLUMN IF EXISTS superseded_at;

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -41,7 +41,7 @@ FOR EACH ROW
 EXECUTE FUNCTION set_repository_index_generation_superseded_at();
 
 CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_retention
-  ON repository_index_generations (repository_id, superseded_at DESC, id DESC)
+  ON repository_index_generations (repository_id, superseded_at DESC, created_at DESC, id DESC)
   WHERE status = 'superseded';
 
 CREATE INDEX IF NOT EXISTS idx_knowledge_repositories_active_index_generation

--- a/infra/database/schema/173-repository-index-generation-retention.sql
+++ b/infra/database/schema/173-repository-index-generation-retention.sql
@@ -7,38 +7,36 @@
 -- replaced. Existing rows start a conservative new window at deployment.
 -- ============================================================================
 
+-- Keep the body on one single-quoted line. The db-init Lambda's line-based SQL
+-- splitter treats an interior line ending in ");" as the end of a function.
+CREATE OR REPLACE FUNCTION set_repository_index_generation_superseded_at() RETURNS trigger AS 'BEGIN IF NEW.status <> ''superseded'' THEN NEW.superseded_at := NULL; ELSIF TG_OP = ''INSERT'' THEN NEW.superseded_at := clock_timestamp(); ELSIF OLD.status IS DISTINCT FROM ''superseded'' THEN NEW.superseded_at := clock_timestamp(); END IF; RETURN NEW; END;' LANGUAGE plpgsql;
+
 ALTER TABLE repository_index_generations
   ADD COLUMN IF NOT EXISTS superseded_at timestamptz
   DEFAULT statement_timestamp();
 
+CREATE OR REPLACE TRIGGER trg_repository_index_generation_superseded_at
+BEFORE INSERT OR UPDATE OF status ON repository_index_generations
+FOR EACH ROW
+EXECUTE FUNCTION set_repository_index_generation_superseded_at();
+
 -- PostgreSQL stores a non-volatile ADD COLUMN default in table metadata instead
--- of rewriting the backlog. New application rows rely on the trigger below.
+-- of rewriting the backlog. Once the trigger is protecting transitions, remove
+-- the temporary default and conservatively start a fresh window for every
+-- existing superseded row. clock_timestamp() also repairs a transition that
+-- raced between the ADD COLUMN commit and trigger installation without making
+-- its rollback window expire early.
 ALTER TABLE repository_index_generations
   ALTER COLUMN superseded_at DROP DEFAULT;
 
--- The normal historical backlog already has the fast-default value. This is
--- only an idempotent recovery for a partial run or a row written during the
--- short interval between removing the default and installing the trigger.
 UPDATE repository_index_generations
-SET superseded_at = statement_timestamp()
-WHERE status = 'superseded'
-  AND superseded_at IS NULL;
+SET superseded_at = clock_timestamp()
+WHERE status = 'superseded';
 
 UPDATE repository_index_generations
 SET superseded_at = NULL
 WHERE status <> 'superseded'
   AND superseded_at IS NOT NULL;
-
--- Keep the body on one single-quoted line. The db-init Lambda's line-based SQL
--- splitter treats an interior line ending in ");" as the end of a function.
-CREATE OR REPLACE FUNCTION set_repository_index_generation_superseded_at() RETURNS trigger AS 'BEGIN IF NEW.status <> ''superseded'' THEN NEW.superseded_at := NULL; ELSIF TG_OP = ''INSERT'' THEN NEW.superseded_at := clock_timestamp(); ELSIF OLD.status IS DISTINCT FROM ''superseded'' THEN NEW.superseded_at := clock_timestamp(); END IF; RETURN NEW; END;' LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS trg_repository_index_generation_superseded_at
-  ON repository_index_generations;
-CREATE TRIGGER trg_repository_index_generation_superseded_at
-BEFORE INSERT OR UPDATE OF status ON repository_index_generations
-FOR EACH ROW
-EXECUTE FUNCTION set_repository_index_generation_superseded_at();
 
 CREATE INDEX IF NOT EXISTS idx_repository_index_generations_superseded_retention
   ON repository_index_generations (repository_id, superseded_at DESC, created_at DESC, id DESC)
@@ -48,13 +46,15 @@ CREATE INDEX IF NOT EXISTS idx_knowledge_repositories_active_index_generation
   ON knowledge_repositories (active_index_generation_id)
   WHERE active_index_generation_id IS NOT NULL;
 
--- The production runner commits statements individually. Close the only gap
--- (default removed, trigger not installed yet) after the trigger is active so
--- no superseded row can remain permanently ineligible with a NULL timestamp.
-UPDATE repository_index_generations
-SET superseded_at = statement_timestamp()
-WHERE status = 'superseded'
-  AND superseded_at IS NULL;
+INSERT INTO settings (key, value, description, category, is_secret)
+VALUES (
+  'REPOSITORY_GENERATION_GC_CURSOR',
+  '0',
+  'Internal checkpoint: last repository ID probed by generation retention',
+  'repositories',
+  false
+)
+ON CONFLICT (key) DO NOTHING;
 
 -- ROLLBACK SQL (for manual rollback if needed)
 -- DROP INDEX IF EXISTS idx_repository_index_generations_superseded_retention;

--- a/infra/lambdas/embedding-generator/__tests__/collected-generation-ack.test.ts
+++ b/infra/lambdas/embedding-generator/__tests__/collected-generation-ack.test.ts
@@ -1,0 +1,41 @@
+import type { SQSEvent } from 'aws-lambda';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const mockGetDb = mock();
+const mockCloseDb = mock();
+mock.module('../db-client', () => ({
+  getDb: mockGetDb,
+  closeDb: mockCloseDb,
+}));
+
+const { handler } = await import('../index');
+
+describe('collected generation acknowledgement', () => {
+  beforeEach(() => {
+    mockGetDb.mockReset();
+    mockCloseDb.mockReset();
+    mockCloseDb.mockResolvedValue();
+  });
+
+  test('acks a missing generation without starting downstream embedding work', async () => {
+    const execute = mock().mockResolvedValue([]);
+    mockGetDb.mockResolvedValue({ execute });
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            itemId: 42,
+            generationId: '11111111-2222-4333-8444-555555555555',
+            chunkIds: [7],
+            texts: ['stale chunk'],
+          }),
+        },
+      ],
+    } as unknown as SQSEvent;
+
+    await expect(handler(event)).resolves.toBeUndefined();
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(mockCloseDb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/infra/lambdas/embedding-generator/__tests__/generation-lifecycle.test.ts
+++ b/infra/lambdas/embedding-generator/__tests__/generation-lifecycle.test.ts
@@ -41,7 +41,8 @@ describe('canonical embedding generation lifecycle', () => {
     ).toThrow('invalid or mismatched chunk data');
   });
 
-  test('acknowledges superseded and failed generations as stale', () => {
+  test('acknowledges collected, superseded, and failed generations as stale', () => {
+    expect(shouldSkipCanonicalGeneration(null)).toBe(true);
     expect(shouldSkipCanonicalGeneration('superseded')).toBe(true);
     expect(shouldSkipCanonicalGeneration('failed')).toBe(true);
     expect(shouldSkipCanonicalGeneration('building')).toBe(false);

--- a/infra/lambdas/embedding-generator/generation-lifecycle.ts
+++ b/infra/lambdas/embedding-generator/generation-lifecycle.ts
@@ -166,9 +166,9 @@ export function assertValidEmbeddingMessage(
 
 /** Stale generations must acknowledge queued batches without doing model work. */
 export function shouldSkipCanonicalGeneration(
-  status: CanonicalGenerationStatus
+  status: CanonicalGenerationStatus | null
 ): boolean {
-  return status === 'superseded' || status === 'failed';
+  return status === null || status === 'superseded' || status === 'failed';
 }
 
 /**

--- a/infra/lambdas/embedding-generator/index.ts
+++ b/infra/lambdas/embedding-generator/index.ts
@@ -463,7 +463,8 @@ async function resolveRecordEmbeddingSettings(
     LIMIT 1
   `);
   if (!generation) {
-    throw new Error(`Index generation ${message.generationId} was not found`);
+    log.info(`Skipping collected embedding generation ${message.generationId}`);
+    return null;
   }
   if (shouldSkipCanonicalGeneration(generation.status)) {
     log.info(`Skipping stale embedding generation ${message.generationId}`, {

--- a/infra/lambdas/unified-content-processor/__tests__/scheduled-maintenance.test.ts
+++ b/infra/lambdas/unified-content-processor/__tests__/scheduled-maintenance.test.ts
@@ -1,4 +1,6 @@
 import { runScheduledMaintenance } from "../scheduled-maintenance";
+import fs from "node:fs";
+import path from "node:path";
 
 describe("scheduled unified-content maintenance", () => {
   test("continues every recovery stage and reports all failures", async () => {
@@ -56,5 +58,49 @@ describe("scheduled unified-content maintenance", () => {
       "legacy-source-recovery",
       "embedding-recovery",
     ]);
+  });
+
+  test("registers generation retention last and isolates its failure", async () => {
+    const runtimeSource = fs.readFileSync(
+      path.join(__dirname, "../index.ts"),
+      "utf8",
+    );
+    const priorTask = runtimeSource.indexOf(
+      'name: "embedding-dlq-reconciliation"',
+    );
+    const retentionTask = runtimeSource.indexOf(
+      'name: "superseded-generation-retention"',
+    );
+    expect(priorTask).toBeGreaterThanOrEqual(0);
+    expect(retentionTask).toBeGreaterThan(priorTask);
+
+    const completed: string[] = [];
+    const errors: string[] = [];
+    await expect(
+      runScheduledMaintenance(
+        [
+          {
+            name: "embedding-dlq-reconciliation",
+            run: async () => {
+              completed.push("embedding-dlq-reconciliation");
+            },
+          },
+          {
+            name: "superseded-generation-retention",
+            run: async () => {
+              completed.push("superseded-generation-retention");
+              throw new Error("database unavailable");
+            },
+          },
+        ],
+        (name) => errors.push(name),
+      ),
+    ).rejects.toThrow("1 unified-content maintenance stage(s) failed");
+
+    expect(completed).toEqual([
+      "embedding-dlq-reconciliation",
+      "superseded-generation-retention",
+    ]);
+    expect(errors).toEqual(["superseded-generation-retention"]);
   });
 });

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -2022,8 +2022,13 @@ function isSqsEvent(event: SQSEvent | EventBridgeEvent<string, unknown>): event 
 
 async function runSupersededGenerationRetention(): Promise<void> {
   const result = await collectSupersededRepositoryGenerations();
-  if (result.chunksDeleted > 0 || result.generationsDeleted > 0) {
+  if (
+    result.generationsTimestamped > 0 ||
+    result.chunksDeleted > 0 ||
+    result.generationsDeleted > 0
+  ) {
     log.info("Collected superseded repository index generations", {
+      generationsTimestamped: result.generationsTimestamped,
       chunksDeleted: result.chunksDeleted,
       generationsDeleted: result.generationsDeleted,
     });

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -167,6 +167,7 @@ import { cleanupExpiredContentIdempotencyRecords } from "../../../lib/content/id
 import { processNextRepositoryMigrationBatch } from "../../../lib/repositories/content-platform/migration-runner";
 import { createS3RepositoryMigrationStorage } from "../../../lib/repositories/content-platform/migration-s3-storage";
 import { cleanupRepositoryRetrievalShadow } from "../../../lib/repositories/content-platform/retrieval-shadow";
+import { collectSupersededRepositoryGenerations } from "../../../lib/repositories/content-platform/generation-retention";
 import {
   CONTENT_PLATFORM_METRIC_UNITS,
   contentPlatformMetricValues,
@@ -2019,6 +2020,16 @@ function isSqsEvent(event: SQSEvent | EventBridgeEvent<string, unknown>): event 
   return "Records" in event;
 }
 
+async function runSupersededGenerationRetention(): Promise<void> {
+  const result = await collectSupersededRepositoryGenerations();
+  if (result.chunksDeleted > 0 || result.generationsDeleted > 0) {
+    log.info("Collected superseded repository index generations", {
+      chunksDeleted: result.chunksDeleted,
+      generationsDeleted: result.generationsDeleted,
+    });
+  }
+}
+
 export async function handler(
   event: SQSEvent | EventBridgeEvent<string, unknown>,
   context: Context
@@ -2127,6 +2138,7 @@ export async function handler(
           name: "embedding-dlq-reconciliation",
           run: drainRecoveredEmbeddingDlq,
         },
+        { name: "superseded-generation-retention", run: runSupersededGenerationRetention },
       ],
       (taskName, error) => {
         log.error("Unified content maintenance stage failed", {

--- a/infra/package.json
+++ b/infra/package.json
@@ -10,7 +10,7 @@
     "build:all": "bun run build && bun run build:lambdas",
     "watch": "tsc -w",
     "test": "jest",
-    "test:lambdas": "cd lambdas/agent-skill-builder && bun install && bun run test",
+    "test:lambdas": "bun test lambdas/embedding-generator/__tests__ && cd lambdas/agent-skill-builder && bun install && bun run test",
     "typecheck:unified-content": "tsc --project lambdas/unified-content-processor/tsconfig.json",
     "cdk": "cdk"
   },

--- a/lib/db/schema/tables/knowledge-repositories.ts
+++ b/lib/db/schema/tables/knowledge-repositories.ts
@@ -5,6 +5,7 @@
 
 import {
   boolean,
+  index,
   integer,
   jsonb,
   pgTable,
@@ -15,6 +16,7 @@ import {
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { users } from "./users";
 
 export const knowledgeRepositories = pgTable(
@@ -48,5 +50,8 @@ export const knowledgeRepositories = pgTable(
       table.id,
       table.ownerId
     ),
+    index("idx_knowledge_repositories_active_index_generation")
+      .on(table.activeIndexGenerationId)
+      .where(sql`${table.activeIndexGenerationId} IS NOT NULL`),
   ]
 );

--- a/lib/db/schema/tables/repository-index-generations.ts
+++ b/lib/db/schema/tables/repository-index-generations.ts
@@ -64,7 +64,12 @@ export const repositoryIndexGenerations = pgTable(
       )
       .where(sql`${t.status} IN ('building', 'active', 'failed')`),
     index("idx_repository_index_generations_superseded_retention")
-      .on(t.repositoryId, t.supersededAt.desc(), t.id.desc())
+      .on(
+        t.repositoryId,
+        t.supersededAt.desc(),
+        t.createdAt.desc(),
+        t.id.desc()
+      )
       .where(sql`${t.status} = 'superseded'`),
   ]
 );

--- a/lib/db/schema/tables/repository-index-generations.ts
+++ b/lib/db/schema/tables/repository-index-generations.ts
@@ -62,6 +62,9 @@ export const repositoryIndexGenerations = pgTable(
         t.id
       )
       .where(sql`${t.status} IN ('building', 'active', 'failed')`),
+    index("idx_repository_index_generations_superseded_retention")
+      .on(t.repositoryId, t.createdAt.desc(), t.id.desc())
+      .where(sql`${t.status} = 'superseded'`),
   ]
 );
 

--- a/lib/db/schema/tables/repository-index-generations.ts
+++ b/lib/db/schema/tables/repository-index-generations.ts
@@ -71,6 +71,9 @@ export const repositoryIndexGenerations = pgTable(
         t.id.desc()
       )
       .where(sql`${t.status} = 'superseded'`),
+    index("idx_repository_index_generations_superseded_backfill")
+      .on(t.id)
+      .where(sql`${t.status} = 'superseded' AND ${t.supersededAt} IS NULL`),
   ]
 );
 

--- a/lib/db/schema/tables/repository-index-generations.ts
+++ b/lib/db/schema/tables/repository-index-generations.ts
@@ -72,7 +72,7 @@ export const repositoryIndexGenerations = pgTable(
       )
       .where(sql`${t.status} = 'superseded'`),
     index("idx_repository_index_generations_superseded_backfill")
-      .on(t.id)
+      .on(t.createdAt, t.id)
       .where(sql`${t.status} = 'superseded' AND ${t.supersededAt} IS NULL`),
   ]
 );

--- a/lib/db/schema/tables/repository-index-generations.ts
+++ b/lib/db/schema/tables/repository-index-generations.ts
@@ -48,6 +48,7 @@ export const repositoryIndexGenerations = pgTable(
       .notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     publishedAt: timestamp("published_at", { withTimezone: true }),
+    supersededAt: timestamp("superseded_at", { withTimezone: true }),
   },
   (t) => [
     index("idx_repository_index_generations_history").on(
@@ -63,7 +64,7 @@ export const repositoryIndexGenerations = pgTable(
       )
       .where(sql`${t.status} IN ('building', 'active', 'failed')`),
     index("idx_repository_index_generations_superseded_retention")
-      .on(t.repositoryId, t.createdAt.desc(), t.id.desc())
+      .on(t.repositoryId, t.supersededAt.desc(), t.id.desc())
       .where(sql`${t.status} = 'superseded'`),
   ]
 );

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -11,6 +11,7 @@ export const GENERATION_GC_CHUNK_BATCH = 20_000;
 export const GENERATION_GC_REPOSITORY_BATCH = 200;
 export const GENERATION_GC_GENERATION_BATCH = 200;
 export const GENERATION_GC_PER_REPOSITORY_BATCH = 10;
+export const GENERATION_GC_TIMESTAMP_BATCH = 200;
 
 const GENERATION_GC_CURSOR_SETTING_KEY = "REPOSITORY_GENERATION_GC_CURSOR";
 
@@ -32,12 +33,13 @@ export interface CollectSupersededRepositoryGenerationsOptions {
 }
 
 export interface SupersededGenerationCollectionResult {
+  generationsTimestamped: number;
   chunksDeleted: number;
   generationsDeleted: number;
 }
 
-interface DeletedCountRow {
-  deleted_count: number;
+interface AffectedCountRow {
+  affected_count: number;
 }
 
 interface RepositoryProbeCursorRow {
@@ -55,9 +57,9 @@ function requirePositiveInteger(value: number, name: string): number {
   return value;
 }
 
-function deletedCount(result: unknown): number {
-  const [row] = toPgRows<DeletedCountRow>(result);
-  return row?.deleted_count ?? 0;
+function affectedCount(result: unknown): number {
+  const [row] = toPgRows<AffectedCountRow>(result);
+  return row?.affected_count ?? 0;
 }
 
 function integerArray(values: number[]): SQL {
@@ -140,6 +142,35 @@ async function advanceRepositoryProbeCursor(
         updated_at = statement_timestamp()
     WHERE key = ${GENERATION_GC_CURSOR_SETTING_KEY}
   `);
+}
+
+async function backfillMissingSupersessionTimes(
+  tx: DbTransaction,
+  generationBatchSize: number,
+): Promise<number> {
+  const result = await tx.execute(sql`
+    WITH selected_generations AS MATERIALIZED (
+      SELECT generation.id
+      FROM repository_index_generations generation
+      WHERE generation.status = 'superseded'
+        AND generation.superseded_at IS NULL
+      ORDER BY generation.id
+      FOR UPDATE OF generation SKIP LOCKED
+      LIMIT ${generationBatchSize}
+    ),
+    timestamped_generations AS (
+      UPDATE repository_index_generations generation
+      SET superseded_at = clock_timestamp()
+      FROM selected_generations selected
+      WHERE generation.id = selected.id
+        AND generation.status = 'superseded'
+        AND generation.superseded_at IS NULL
+      RETURNING 1
+    )
+    SELECT count(*)::integer AS affected_count
+    FROM timestamped_generations
+  `);
+  return affectedCount(result);
 }
 
 function eligibleGenerationCtes(params: {
@@ -302,6 +333,10 @@ export async function collectSupersededRepositoryGenerations(
         tx,
         repositoryBatchSize,
       );
+      const generationsTimestamped = await backfillMissingSupersessionTimes(
+        tx,
+        Math.min(generationBatchSize, GENERATION_GC_TIMESTAMP_BATCH),
+      );
 
       // Keep the phases as sequential statements: sibling data-modifying CTEs
       // share one snapshot, so a combined statement would not see chunk deletes
@@ -327,7 +362,7 @@ export async function collectSupersededRepositoryGenerations(
           WHERE chunk.ctid = selected.row_id
           RETURNING 1
         )
-        SELECT count(*)::integer AS deleted_count
+        SELECT count(*)::integer AS affected_count
         FROM deleted_chunks
       `);
 
@@ -360,15 +395,16 @@ export async function collectSupersededRepositoryGenerations(
             )
           RETURNING 1
         )
-        SELECT count(*)::integer AS deleted_count
+        SELECT count(*)::integer AS affected_count
         FROM deleted_generations
       `);
 
       await advanceRepositoryProbeCursor(tx, repositoryIds);
 
       return {
-        chunksDeleted: deletedCount(chunksResult),
-        generationsDeleted: deletedCount(generationsResult),
+        generationsTimestamped,
+        chunksDeleted: affectedCount(chunksResult),
+        generationsDeleted: affectedCount(generationsResult),
       };
     },
     "contentPlatform.collectSupersededRepositoryGenerations",

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -1,0 +1,184 @@
+import { sql } from "drizzle-orm";
+import { executeTransaction, toPgRows } from "@/lib/db/drizzle-client";
+
+export const SUPERSEDED_GENERATION_RETENTION_HOURS = 24;
+export const SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY = 3;
+export const GENERATION_GC_CHUNK_BATCH = 20_000;
+export const GENERATION_GC_GENERATION_BATCH = 200;
+
+export interface CollectSupersededRepositoryGenerationsOptions {
+  /** Testable clock; production always uses the current time. */
+  now?: Date;
+  /** Test override; production always uses the exported retention window. */
+  retentionHours?: number;
+  /** Test override; production always keeps the exported generation floor. */
+  keepPerRepository?: number;
+  /** Test override; production always uses the exported chunk batch size. */
+  chunkBatchSize?: number;
+  /** Test override; production always uses the exported generation batch size. */
+  generationBatchSize?: number;
+}
+
+export interface SupersededGenerationCollectionResult {
+  chunksDeleted: number;
+  generationsDeleted: number;
+}
+
+interface DeletedCountRow {
+  deleted_count: number;
+}
+
+function requirePositiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function deletedCount(result: unknown): number {
+  const [row] = toPgRows<DeletedCountRow>(result);
+  return row?.deleted_count ?? 0;
+}
+
+/**
+ * Delete one bounded batch from repository generations that are safely beyond
+ * the rollback window. Generation rows are locked with SKIP LOCKED so multiple
+ * scheduler invocations cannot work on the same parents. Chunks are removed
+ * first in a ctid-bounded batch; a parent is deleted only after it is childless.
+ */
+export async function collectSupersededRepositoryGenerations(
+  options: CollectSupersededRepositoryGenerationsOptions = {},
+): Promise<SupersededGenerationCollectionResult> {
+  const retentionHours = requirePositiveInteger(
+    options.retentionHours ?? SUPERSEDED_GENERATION_RETENTION_HOURS,
+    "retentionHours",
+  );
+  const keepPerRepository = requirePositiveInteger(
+    options.keepPerRepository ?? SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY,
+    "keepPerRepository",
+  );
+  const chunkBatchSize = requirePositiveInteger(
+    options.chunkBatchSize ?? GENERATION_GC_CHUNK_BATCH,
+    "chunkBatchSize",
+  );
+  const generationBatchSize = requirePositiveInteger(
+    options.generationBatchSize ?? GENERATION_GC_GENERATION_BATCH,
+    "generationBatchSize",
+  );
+  const eligibleBefore = new Date(
+    (options.now ?? new Date()).getTime() - retentionHours * 60 * 60_000,
+  ).toISOString();
+
+  return executeTransaction(
+    async (tx) => {
+      const chunksResult = await tx.execute(sql`
+        WITH ranked_superseded AS (
+          SELECT generation.id,
+                 row_number() OVER (
+                   PARTITION BY generation.repository_id
+                   ORDER BY generation.created_at DESC, generation.id DESC
+                 ) AS superseded_rank
+          FROM repository_index_generations generation
+          WHERE generation.status = 'superseded'
+        ),
+        eligible_generations AS (
+          SELECT generation.id
+          FROM repository_index_generations generation
+          INNER JOIN ranked_superseded ranked
+            ON ranked.id = generation.id
+          INNER JOIN knowledge_repositories repository
+            ON repository.id = generation.repository_id
+          WHERE generation.status = 'superseded'
+            AND generation.created_at < ${eligibleBefore}::timestamptz
+            AND ranked.superseded_rank > ${keepPerRepository}
+            AND generation.id IS DISTINCT FROM repository.active_index_generation_id
+            AND NOT EXISTS (
+              SELECT 1
+              FROM knowledge_repositories active_repository
+              WHERE active_repository.active_index_generation_id = generation.id
+            )
+          ORDER BY generation.created_at, generation.id
+          FOR UPDATE OF generation SKIP LOCKED
+          LIMIT ${generationBatchSize}
+        ),
+        selected_chunks AS (
+          SELECT chunk.ctid AS row_id
+          FROM repository_item_chunks chunk
+          INNER JOIN eligible_generations eligible
+            ON eligible.id = chunk.index_generation_id
+          ORDER BY chunk.id
+          LIMIT ${chunkBatchSize}
+        ),
+        deleted_chunks AS (
+          DELETE FROM repository_item_chunks chunk
+          USING selected_chunks selected
+          WHERE chunk.ctid = selected.row_id
+          RETURNING 1
+        )
+        SELECT count(*)::integer AS deleted_count
+        FROM deleted_chunks
+      `);
+
+      const generationsResult = await tx.execute(sql`
+        WITH ranked_superseded AS (
+          SELECT generation.id,
+                 row_number() OVER (
+                   PARTITION BY generation.repository_id
+                   ORDER BY generation.created_at DESC, generation.id DESC
+                 ) AS superseded_rank
+          FROM repository_index_generations generation
+          WHERE generation.status = 'superseded'
+        ),
+        eligible_generations AS (
+          SELECT generation.id
+          FROM repository_index_generations generation
+          INNER JOIN ranked_superseded ranked
+            ON ranked.id = generation.id
+          INNER JOIN knowledge_repositories repository
+            ON repository.id = generation.repository_id
+          WHERE generation.status = 'superseded'
+            AND generation.created_at < ${eligibleBefore}::timestamptz
+            AND ranked.superseded_rank > ${keepPerRepository}
+            AND generation.id IS DISTINCT FROM repository.active_index_generation_id
+            AND NOT EXISTS (
+              SELECT 1
+              FROM knowledge_repositories active_repository
+              WHERE active_repository.active_index_generation_id = generation.id
+            )
+          ORDER BY generation.created_at, generation.id
+          FOR UPDATE OF generation SKIP LOCKED
+          LIMIT ${generationBatchSize}
+        ),
+        deleted_generations AS (
+          DELETE FROM repository_index_generations generation
+          USING eligible_generations eligible,
+                knowledge_repositories repository
+          WHERE generation.id = eligible.id
+            AND repository.id = generation.repository_id
+            AND generation.status = 'superseded'
+            AND generation.created_at < ${eligibleBefore}::timestamptz
+            AND generation.id IS DISTINCT FROM repository.active_index_generation_id
+            AND NOT EXISTS (
+              SELECT 1
+              FROM knowledge_repositories active_repository
+              WHERE active_repository.active_index_generation_id = generation.id
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM repository_item_chunks remaining_chunk
+              WHERE remaining_chunk.index_generation_id = generation.id
+            )
+          RETURNING 1
+        )
+        SELECT count(*)::integer AS deleted_count
+        FROM deleted_generations
+      `);
+
+      return {
+        chunksDeleted: deletedCount(chunksResult),
+        generationsDeleted: deletedCount(generationsResult),
+      };
+    },
+    "contentPlatform.collectSupersededRepositoryGenerations",
+  );
+}

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -98,7 +98,8 @@ export async function collectSupersededRepositoryGenerations(
               WHERE active_repository.active_index_generation_id = generation.id
             )
           ORDER BY generation.superseded_at, generation.id
-          FOR UPDATE OF generation SKIP LOCKED
+          -- Keep the serving pointer stable until both deletion phases commit.
+          FOR UPDATE OF generation, repository SKIP LOCKED
           LIMIT ${generationBatchSize}
         ),
         selected_chunks AS (
@@ -106,7 +107,6 @@ export async function collectSupersededRepositoryGenerations(
           FROM repository_item_chunks chunk
           INNER JOIN eligible_generations eligible
             ON eligible.id = chunk.index_generation_id
-          ORDER BY chunk.id
           LIMIT ${chunkBatchSize}
         ),
         deleted_chunks AS (
@@ -146,7 +146,8 @@ export async function collectSupersededRepositoryGenerations(
               WHERE active_repository.active_index_generation_id = generation.id
             )
           ORDER BY generation.superseded_at, generation.id
-          FOR UPDATE OF generation SKIP LOCKED
+          -- Keep the serving pointer stable until both deletion phases commit.
+          FOR UPDATE OF generation, repository SKIP LOCKED
           LIMIT ${generationBatchSize}
         ),
         deleted_generations AS (

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -140,7 +140,9 @@ function eligibleGenerationCtes(params: {
       SELECT generation.id
       FROM eligible_repositories repository
       CROSS JOIN LATERAL (
-        SELECT candidate_generation.id
+        SELECT candidate_generation.id,
+               candidate_generation.superseded_at,
+               candidate_generation.created_at
         FROM repository_index_generations candidate_generation
         WHERE candidate_generation.repository_id = repository.id
           AND candidate_generation.status = 'superseded'
@@ -163,6 +165,10 @@ function eligibleGenerationCtes(params: {
         FOR UPDATE OF candidate_generation SKIP LOCKED
         LIMIT ${params.perRepositoryGenerationBatchSize}
       ) generation
+      ORDER BY generation.superseded_at,
+               generation.created_at,
+               generation.id,
+               repository.id
       LIMIT ${params.generationBatchSize}
     )
   `;
@@ -225,6 +231,9 @@ export async function collectSupersededRepositoryGenerations(
 
   return executeTransaction(
     async (tx) => {
+      // Keep the phases as sequential statements: sibling data-modifying CTEs
+      // share one snapshot, so a combined statement would not see chunk deletes
+      // when deciding whether a generation is childless.
       const chunksResult = await tx.execute(sql`
         WITH ${eligibleGenerationCtes({
           eligibleBefore,

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -8,6 +8,8 @@ export const GENERATION_GC_REPOSITORY_BATCH = 200;
 export const GENERATION_GC_GENERATION_BATCH = 200;
 export const GENERATION_GC_PER_REPOSITORY_BATCH = 10;
 
+const GENERATION_GC_CURSOR_SETTING_KEY = "REPOSITORY_GENERATION_GC_CURSOR";
+
 export interface CollectSupersededRepositoryGenerationsOptions {
   /** Testable clock; production always uses the current time. */
   now?: Date;
@@ -34,6 +36,14 @@ interface DeletedCountRow {
   deleted_count: number;
 }
 
+interface RepositoryProbeCursorRow {
+  repository_id: number;
+}
+
+interface RepositoryProbeRow {
+  id: number;
+}
+
 function requirePositiveInteger(value: number, name: string): number {
   if (!Number.isSafeInteger(value) || value <= 0) {
     throw new Error(`${name} must be a positive integer`);
@@ -46,43 +56,32 @@ function deletedCount(result: unknown): number {
   return row?.deleted_count ?? 0;
 }
 
+function integerArray(values: number[]): SQL {
+  if (values.length === 0) {
+    return sql`ARRAY[]::integer[]`;
+  }
+
+  return sql`ARRAY[${sql.join(
+    values.map((value) => sql`${value}`),
+    sql`, `,
+  )}]::integer[]`;
+}
+
 function eligibleGenerationCtes(params: {
   eligibleBefore: string;
   keepPerRepository: number;
-  repositoryProbeAnchor: string;
-  repositoryBatchSize: number;
+  repositoryIds: number[];
   generationBatchSize: number;
   perRepositoryGenerationBatchSize: number;
 }): SQL {
   const keepFloorOffset = params.keepPerRepository - 1;
 
   return sql`
-    repository_probe_start AS (
-      SELECT mod(
-               ${params.repositoryProbeAnchor}::bigint,
-               COALESCE(max(repository.id), 0)::bigint + 1
-             )::integer AS id
-      FROM knowledge_repositories repository
-    ),
     repository_probe_ids AS MATERIALIZED (
-      (
-        SELECT repository.id
-        FROM knowledge_repositories repository
-        CROSS JOIN repository_probe_start probe_start
-        WHERE repository.id >= probe_start.id
-        ORDER BY repository.id
-        LIMIT ${params.repositoryBatchSize}
-      )
-      UNION ALL
-      (
-        SELECT repository.id
-        FROM knowledge_repositories repository
-        CROSS JOIN repository_probe_start probe_start
-        WHERE repository.id < probe_start.id
-        ORDER BY repository.id
-        LIMIT ${params.repositoryBatchSize}
-      )
-      LIMIT ${params.repositoryBatchSize}
+      SELECT probe.id
+      FROM unnest(${integerArray(params.repositoryIds)})
+        WITH ORDINALITY AS probe(id, probe_order)
+      ORDER BY probe.probe_order
     ),
     eligible_repositories AS MATERIALIZED (
       SELECT repository.id,
@@ -134,7 +133,7 @@ function eligibleGenerationCtes(params: {
                oldest_candidate.id,
                repository.id
       FOR UPDATE OF repository SKIP LOCKED
-      LIMIT ${params.repositoryBatchSize}
+      LIMIT ${params.repositoryIds.length}
     ),
     eligible_generations AS MATERIALIZED (
       SELECT generation.id
@@ -182,12 +181,13 @@ function eligibleGenerationCtes(params: {
  * invocations cannot work on the same parents. Chunks are removed first in a
  * ctid-bounded batch; a parent is deleted only after it is childless.
  * Eligible repositories are ordered by their oldest candidate so sustained
- * work on low repository IDs cannot starve older garbage elsewhere. A rotating
- * keyset window bounds steady-state repository probes even when nothing is
- * eligible, while a per-repository generation cap prevents one backlog from
- * consuming the entire global batch. The owner row lock stabilizes every
- * supported pointer update; the global pointer guard additionally fails closed
- * on pre-existing cross-repository pointer skew.
+ * work on low repository IDs cannot starve older garbage elsewhere. A
+ * persisted existing-key cursor makes each rotating repository probe bounded
+ * by the live repository count even when IDs are sparse, while a
+ * per-repository generation cap prevents one backlog from consuming the
+ * entire global batch. The owner row lock stabilizes every supported pointer
+ * update; the global pointer guard additionally fails closed on pre-existing
+ * cross-repository pointer skew.
  */
 export async function collectSupersededRepositoryGenerations(
   options: CollectSupersededRepositoryGenerationsOptions = {},
@@ -221,16 +221,61 @@ export async function collectSupersededRepositoryGenerations(
   const eligibleBefore = new Date(
     collectionNow.getTime() - retentionHours * 60 * 60_000,
   ).toISOString();
-  // Advance by exactly one window per minute. For any modulus N, every common
-  // divisor of N and the step is no larger than the window, so the B-wide
-  // wraparound keyset windows cover every repository without a coprime guess.
-  const repositoryProbeAnchor = (
-    BigInt(Math.floor(collectionNow.getTime() / 60_000)) *
-    BigInt(repositoryBatchSize)
-  ).toString();
-
   return executeTransaction(
     async (tx) => {
+      await tx.execute(sql`
+        INSERT INTO settings (key, value, description, category, is_secret)
+        VALUES (
+          ${GENERATION_GC_CURSOR_SETTING_KEY},
+          '0',
+          'Internal checkpoint: last repository ID probed by generation retention',
+          'repositories',
+          false
+        )
+        ON CONFLICT (key) DO NOTHING
+      `);
+
+      const cursorResult = await tx.execute(sql`
+        SELECT CASE
+                 WHEN value ~ '^[0-9]{1,10}$'
+                   THEN LEAST(value::numeric, 2147483647)::integer
+                 ELSE 0
+               END AS repository_id
+        FROM settings
+        WHERE key = ${GENERATION_GC_CURSOR_SETTING_KEY}
+        FOR UPDATE
+      `);
+      const [cursorRow] = toPgRows<RepositoryProbeCursorRow>(cursorResult);
+      const repositoryProbeCursor = cursorRow?.repository_id ?? 0;
+
+      const probeResult = await tx.execute(sql`
+        WITH forward_probe AS MATERIALIZED (
+          SELECT repository.id, 0 AS probe_segment
+          FROM knowledge_repositories repository
+          WHERE repository.id > ${repositoryProbeCursor}
+          ORDER BY repository.id
+          LIMIT ${repositoryBatchSize}
+        ),
+        wrapped_probe AS MATERIALIZED (
+          SELECT repository.id, 1 AS probe_segment
+          FROM knowledge_repositories repository
+          WHERE repository.id <= ${repositoryProbeCursor}
+          ORDER BY repository.id
+          LIMIT ${repositoryBatchSize}
+        )
+        SELECT probe.id
+        FROM (
+          SELECT * FROM forward_probe
+          UNION ALL
+          SELECT * FROM wrapped_probe
+        ) probe
+        ORDER BY probe.probe_segment, probe.id
+        LIMIT ${repositoryBatchSize}
+      `);
+      const repositoryIds = toPgRows<RepositoryProbeRow>(probeResult).map(
+        (row) => row.id,
+      );
+
       // Keep the phases as sequential statements: sibling data-modifying CTEs
       // share one snapshot, so a combined statement would not see chunk deletes
       // when deciding whether a generation is childless.
@@ -238,8 +283,7 @@ export async function collectSupersededRepositoryGenerations(
         WITH ${eligibleGenerationCtes({
           eligibleBefore,
           keepPerRepository,
-          repositoryProbeAnchor,
-          repositoryBatchSize,
+          repositoryIds,
           generationBatchSize,
           perRepositoryGenerationBatchSize,
         })},
@@ -264,8 +308,7 @@ export async function collectSupersededRepositoryGenerations(
         WITH ${eligibleGenerationCtes({
           eligibleBefore,
           keepPerRepository,
-          repositoryProbeAnchor,
-          repositoryBatchSize,
+          repositoryIds,
           generationBatchSize,
           perRepositoryGenerationBatchSize,
         })},
@@ -293,6 +336,16 @@ export async function collectSupersededRepositoryGenerations(
         SELECT count(*)::integer AS deleted_count
         FROM deleted_generations
       `);
+
+      const lastRepositoryId = repositoryIds.at(-1);
+      if (lastRepositoryId !== undefined) {
+        await tx.execute(sql`
+          UPDATE settings
+          SET value = ${lastRepositoryId.toString()},
+              updated_at = statement_timestamp()
+          WHERE key = ${GENERATION_GC_CURSOR_SETTING_KEY}
+        `);
+      }
 
       return {
         chunksDeleted: deletedCount(chunksResult),

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -86,39 +86,49 @@ function eligibleGenerationCtes(params: {
       SELECT repository.id,
              repository.active_index_generation_id,
              keep_floor.superseded_at AS keep_floor_superseded_at,
+             keep_floor.created_at AS keep_floor_created_at,
              keep_floor.id AS keep_floor_id
       FROM repository_probe_ids probe
       INNER JOIN knowledge_repositories repository
         ON repository.id = probe.id
       CROSS JOIN LATERAL (
         SELECT kept_generation.superseded_at,
+               kept_generation.created_at,
                kept_generation.id
         FROM repository_index_generations kept_generation
         WHERE kept_generation.repository_id = repository.id
           AND kept_generation.status = 'superseded'
-        ORDER BY kept_generation.superseded_at DESC, kept_generation.id DESC
+        ORDER BY kept_generation.superseded_at DESC,
+                 kept_generation.created_at DESC,
+                 kept_generation.id DESC
         OFFSET ${keepFloorOffset}
         LIMIT 1
       ) keep_floor
       CROSS JOIN LATERAL (
         SELECT candidate_generation.superseded_at,
+               candidate_generation.created_at,
                candidate_generation.id
         FROM repository_index_generations candidate_generation
         WHERE candidate_generation.repository_id = repository.id
           AND candidate_generation.status = 'superseded'
           AND candidate_generation.superseded_at < ${params.eligibleBefore}::timestamptz
-          AND (candidate_generation.superseded_at, candidate_generation.id) <
-              (keep_floor.superseded_at, keep_floor.id)
+          AND (candidate_generation.superseded_at,
+               candidate_generation.created_at,
+               candidate_generation.id) <
+              (keep_floor.superseded_at, keep_floor.created_at, keep_floor.id)
           AND candidate_generation.id IS DISTINCT FROM repository.active_index_generation_id
           AND NOT EXISTS (
             SELECT 1
             FROM knowledge_repositories active_repository
             WHERE active_repository.active_index_generation_id = candidate_generation.id
           )
-        ORDER BY candidate_generation.superseded_at, candidate_generation.id
+        ORDER BY candidate_generation.superseded_at,
+                 candidate_generation.created_at,
+                 candidate_generation.id
         LIMIT 1
       ) oldest_candidate
       ORDER BY oldest_candidate.superseded_at,
+               oldest_candidate.created_at,
                oldest_candidate.id,
                repository.id
       FOR UPDATE OF repository SKIP LOCKED
@@ -133,15 +143,21 @@ function eligibleGenerationCtes(params: {
         WHERE candidate_generation.repository_id = repository.id
           AND candidate_generation.status = 'superseded'
           AND candidate_generation.superseded_at < ${params.eligibleBefore}::timestamptz
-          AND (candidate_generation.superseded_at, candidate_generation.id) <
-              (repository.keep_floor_superseded_at, repository.keep_floor_id)
+          AND (candidate_generation.superseded_at,
+               candidate_generation.created_at,
+               candidate_generation.id) <
+              (repository.keep_floor_superseded_at,
+               repository.keep_floor_created_at,
+               repository.keep_floor_id)
           AND candidate_generation.id IS DISTINCT FROM repository.active_index_generation_id
           AND NOT EXISTS (
             SELECT 1
             FROM knowledge_repositories active_repository
             WHERE active_repository.active_index_generation_id = candidate_generation.id
           )
-        ORDER BY candidate_generation.superseded_at, candidate_generation.id
+        ORDER BY candidate_generation.superseded_at,
+                 candidate_generation.created_at,
+                 candidate_generation.id
         FOR UPDATE OF candidate_generation SKIP LOCKED
         LIMIT ${params.generationBatchSize}
       ) generation

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -1,5 +1,9 @@
 import { sql, type SQL } from "drizzle-orm";
-import { executeTransaction, toPgRows } from "@/lib/db/drizzle-client";
+import {
+  executeTransaction,
+  toPgRows,
+  type DbTransaction,
+} from "@/lib/db/drizzle-client";
 
 export const SUPERSEDED_GENERATION_RETENTION_HOURS = 24;
 export const SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY = 3;
@@ -65,6 +69,77 @@ function integerArray(values: number[]): SQL {
     values.map((value) => sql`${value}`),
     sql`, `,
   )}]::integer[]`;
+}
+
+async function lockAndSelectRepositoryProbe(
+  tx: DbTransaction,
+  repositoryBatchSize: number,
+): Promise<number[]> {
+  await tx.execute(sql`
+    INSERT INTO settings (key, value, description, category, is_secret)
+    VALUES (
+      ${GENERATION_GC_CURSOR_SETTING_KEY},
+      '0',
+      'Internal checkpoint: last repository ID probed by generation retention',
+      'repositories',
+      false
+    )
+    ON CONFLICT (key) DO NOTHING
+  `);
+
+  const cursorResult = await tx.execute(sql`
+    SELECT CASE
+             WHEN value ~ '^[0-9]{1,10}$'
+               THEN LEAST(value::numeric, 2147483647)::integer
+             ELSE 0
+           END AS repository_id
+    FROM settings
+    WHERE key = ${GENERATION_GC_CURSOR_SETTING_KEY}
+    FOR UPDATE
+  `);
+  const [cursorRow] = toPgRows<RepositoryProbeCursorRow>(cursorResult);
+  const repositoryProbeCursor = cursorRow?.repository_id ?? 0;
+
+  const probeResult = await tx.execute(sql`
+    WITH forward_probe AS MATERIALIZED (
+      SELECT repository.id, 0 AS probe_segment
+      FROM knowledge_repositories repository
+      WHERE repository.id > ${repositoryProbeCursor}
+      ORDER BY repository.id
+      LIMIT ${repositoryBatchSize}
+    ),
+    wrapped_probe AS MATERIALIZED (
+      SELECT repository.id, 1 AS probe_segment
+      FROM knowledge_repositories repository
+      WHERE repository.id <= ${repositoryProbeCursor}
+      ORDER BY repository.id
+      LIMIT ${repositoryBatchSize}
+    )
+    SELECT probe.id
+    FROM (
+      SELECT * FROM forward_probe
+      UNION ALL
+      SELECT * FROM wrapped_probe
+    ) probe
+    ORDER BY probe.probe_segment, probe.id
+    LIMIT ${repositoryBatchSize}
+  `);
+  return toPgRows<RepositoryProbeRow>(probeResult).map((row) => row.id);
+}
+
+async function advanceRepositoryProbeCursor(
+  tx: DbTransaction,
+  repositoryIds: number[],
+): Promise<void> {
+  const lastRepositoryId = repositoryIds.at(-1);
+  if (lastRepositoryId === undefined) return;
+
+  await tx.execute(sql`
+    UPDATE settings
+    SET value = ${lastRepositoryId.toString()},
+        updated_at = statement_timestamp()
+    WHERE key = ${GENERATION_GC_CURSOR_SETTING_KEY}
+  `);
 }
 
 function eligibleGenerationCtes(params: {
@@ -223,57 +298,9 @@ export async function collectSupersededRepositoryGenerations(
   ).toISOString();
   return executeTransaction(
     async (tx) => {
-      await tx.execute(sql`
-        INSERT INTO settings (key, value, description, category, is_secret)
-        VALUES (
-          ${GENERATION_GC_CURSOR_SETTING_KEY},
-          '0',
-          'Internal checkpoint: last repository ID probed by generation retention',
-          'repositories',
-          false
-        )
-        ON CONFLICT (key) DO NOTHING
-      `);
-
-      const cursorResult = await tx.execute(sql`
-        SELECT CASE
-                 WHEN value ~ '^[0-9]{1,10}$'
-                   THEN LEAST(value::numeric, 2147483647)::integer
-                 ELSE 0
-               END AS repository_id
-        FROM settings
-        WHERE key = ${GENERATION_GC_CURSOR_SETTING_KEY}
-        FOR UPDATE
-      `);
-      const [cursorRow] = toPgRows<RepositoryProbeCursorRow>(cursorResult);
-      const repositoryProbeCursor = cursorRow?.repository_id ?? 0;
-
-      const probeResult = await tx.execute(sql`
-        WITH forward_probe AS MATERIALIZED (
-          SELECT repository.id, 0 AS probe_segment
-          FROM knowledge_repositories repository
-          WHERE repository.id > ${repositoryProbeCursor}
-          ORDER BY repository.id
-          LIMIT ${repositoryBatchSize}
-        ),
-        wrapped_probe AS MATERIALIZED (
-          SELECT repository.id, 1 AS probe_segment
-          FROM knowledge_repositories repository
-          WHERE repository.id <= ${repositoryProbeCursor}
-          ORDER BY repository.id
-          LIMIT ${repositoryBatchSize}
-        )
-        SELECT probe.id
-        FROM (
-          SELECT * FROM forward_probe
-          UNION ALL
-          SELECT * FROM wrapped_probe
-        ) probe
-        ORDER BY probe.probe_segment, probe.id
-        LIMIT ${repositoryBatchSize}
-      `);
-      const repositoryIds = toPgRows<RepositoryProbeRow>(probeResult).map(
-        (row) => row.id,
+      const repositoryIds = await lockAndSelectRepositoryProbe(
+        tx,
+        repositoryBatchSize,
       );
 
       // Keep the phases as sequential statements: sibling data-modifying CTEs
@@ -337,15 +364,7 @@ export async function collectSupersededRepositoryGenerations(
         FROM deleted_generations
       `);
 
-      const lastRepositoryId = repositoryIds.at(-1);
-      if (lastRepositoryId !== undefined) {
-        await tx.execute(sql`
-          UPDATE settings
-          SET value = ${lastRepositoryId.toString()},
-              updated_at = statement_timestamp()
-          WHERE key = ${GENERATION_GC_CURSOR_SETTING_KEY}
-        `);
-      }
+      await advanceRepositoryProbeCursor(tx, repositoryIds);
 
       return {
         chunksDeleted: deletedCount(chunksResult),

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -4,6 +4,7 @@ import { executeTransaction, toPgRows } from "@/lib/db/drizzle-client";
 export const SUPERSEDED_GENERATION_RETENTION_HOURS = 24;
 export const SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY = 3;
 export const GENERATION_GC_CHUNK_BATCH = 20_000;
+export const GENERATION_GC_REPOSITORY_BATCH = 200;
 export const GENERATION_GC_GENERATION_BATCH = 200;
 
 export interface CollectSupersededRepositoryGenerationsOptions {
@@ -15,6 +16,8 @@ export interface CollectSupersededRepositoryGenerationsOptions {
   keepPerRepository?: number;
   /** Test override; production always uses the exported chunk batch size. */
   chunkBatchSize?: number;
+  /** Test override; production always uses the exported repository batch size. */
+  repositoryBatchSize?: number;
   /** Test override; production always uses the exported generation batch size. */
   generationBatchSize?: number;
 }
@@ -43,6 +46,7 @@ function deletedCount(result: unknown): number {
 function eligibleGenerationCtes(params: {
   eligibleBefore: string;
   keepPerRepository: number;
+  repositoryBatchSize: number;
   generationBatchSize: number;
 }): SQL {
   const keepFloorOffset = params.keepPerRepository - 1;
@@ -64,8 +68,9 @@ function eligibleGenerationCtes(params: {
         OFFSET ${keepFloorOffset}
         LIMIT 1
       ) keep_floor
-      WHERE EXISTS (
-        SELECT 1
+      CROSS JOIN LATERAL (
+        SELECT candidate_generation.superseded_at,
+               candidate_generation.id
         FROM repository_index_generations candidate_generation
         WHERE candidate_generation.repository_id = repository.id
           AND candidate_generation.status = 'superseded'
@@ -78,10 +83,14 @@ function eligibleGenerationCtes(params: {
             FROM knowledge_repositories active_repository
             WHERE active_repository.active_index_generation_id = candidate_generation.id
           )
-      )
-      ORDER BY repository.id
+        ORDER BY candidate_generation.superseded_at, candidate_generation.id
+        LIMIT 1
+      ) oldest_candidate
+      ORDER BY oldest_candidate.superseded_at,
+               oldest_candidate.id,
+               repository.id
       FOR UPDATE OF repository SKIP LOCKED
-      LIMIT ${params.generationBatchSize}
+      LIMIT ${params.repositoryBatchSize}
     ),
     eligible_generations AS MATERIALIZED (
       SELECT generation.id
@@ -116,6 +125,10 @@ function eligibleGenerationCtes(params: {
  * and generation rows are locked with SKIP LOCKED so multiple scheduler
  * invocations cannot work on the same parents. Chunks are removed first in a
  * ctid-bounded batch; a parent is deleted only after it is childless.
+ * Eligible repositories are ordered by their oldest candidate so sustained
+ * work on low repository IDs cannot starve older garbage elsewhere. The owner
+ * row lock stabilizes every supported pointer update; the global pointer guard
+ * additionally fails closed on pre-existing cross-repository pointer skew.
  */
 export async function collectSupersededRepositoryGenerations(
   options: CollectSupersededRepositoryGenerationsOptions = {},
@@ -132,6 +145,10 @@ export async function collectSupersededRepositoryGenerations(
     options.chunkBatchSize ?? GENERATION_GC_CHUNK_BATCH,
     "chunkBatchSize",
   );
+  const repositoryBatchSize = requirePositiveInteger(
+    options.repositoryBatchSize ?? GENERATION_GC_REPOSITORY_BATCH,
+    "repositoryBatchSize",
+  );
   const generationBatchSize = requirePositiveInteger(
     options.generationBatchSize ?? GENERATION_GC_GENERATION_BATCH,
     "generationBatchSize",
@@ -146,6 +163,7 @@ export async function collectSupersededRepositoryGenerations(
         WITH ${eligibleGenerationCtes({
           eligibleBefore,
           keepPerRepository,
+          repositoryBatchSize,
           generationBatchSize,
         })},
         selected_chunks AS (
@@ -169,6 +187,7 @@ export async function collectSupersededRepositoryGenerations(
         WITH ${eligibleGenerationCtes({
           eligibleBefore,
           keepPerRepository,
+          repositoryBatchSize,
           generationBatchSize,
         })},
         deleted_generations AS (

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { sql, type SQL } from "drizzle-orm";
 import { executeTransaction, toPgRows } from "@/lib/db/drizzle-client";
 
 export const SUPERSEDED_GENERATION_RETENTION_HOURS = 24;
@@ -40,6 +40,45 @@ function deletedCount(result: unknown): number {
   return row?.deleted_count ?? 0;
 }
 
+function eligibleGenerationCtes(params: {
+  eligibleBefore: string;
+  keepPerRepository: number;
+  generationBatchSize: number;
+}): SQL {
+  return sql`
+    ranked_superseded AS (
+      SELECT generation.id,
+             row_number() OVER (
+               PARTITION BY generation.repository_id
+               ORDER BY generation.superseded_at DESC, generation.id DESC
+             ) AS superseded_rank
+      FROM repository_index_generations generation
+      WHERE generation.status = 'superseded'
+    ),
+    eligible_generations AS (
+      SELECT generation.id
+      FROM repository_index_generations generation
+      INNER JOIN ranked_superseded ranked
+        ON ranked.id = generation.id
+      INNER JOIN knowledge_repositories repository
+        ON repository.id = generation.repository_id
+      WHERE generation.status = 'superseded'
+        AND generation.superseded_at < ${params.eligibleBefore}::timestamptz
+        AND ranked.superseded_rank > ${params.keepPerRepository}
+        AND generation.id IS DISTINCT FROM repository.active_index_generation_id
+        AND NOT EXISTS (
+          SELECT 1
+          FROM knowledge_repositories active_repository
+          WHERE active_repository.active_index_generation_id = generation.id
+        )
+      ORDER BY generation.superseded_at, generation.id
+      -- Keep the serving pointer stable until both deletion phases commit.
+      FOR UPDATE OF generation, repository SKIP LOCKED
+      LIMIT ${params.generationBatchSize}
+    )
+  `;
+}
+
 /**
  * Delete one bounded batch from repository generations that are safely beyond
  * the rollback window. Generation rows are locked with SKIP LOCKED so multiple
@@ -72,36 +111,11 @@ export async function collectSupersededRepositoryGenerations(
   return executeTransaction(
     async (tx) => {
       const chunksResult = await tx.execute(sql`
-        WITH ranked_superseded AS (
-          SELECT generation.id,
-                 row_number() OVER (
-                   PARTITION BY generation.repository_id
-                   ORDER BY generation.superseded_at DESC, generation.id DESC
-                 ) AS superseded_rank
-          FROM repository_index_generations generation
-          WHERE generation.status = 'superseded'
-        ),
-        eligible_generations AS (
-          SELECT generation.id
-          FROM repository_index_generations generation
-          INNER JOIN ranked_superseded ranked
-            ON ranked.id = generation.id
-          INNER JOIN knowledge_repositories repository
-            ON repository.id = generation.repository_id
-          WHERE generation.status = 'superseded'
-            AND generation.superseded_at < ${eligibleBefore}::timestamptz
-            AND ranked.superseded_rank > ${keepPerRepository}
-            AND generation.id IS DISTINCT FROM repository.active_index_generation_id
-            AND NOT EXISTS (
-              SELECT 1
-              FROM knowledge_repositories active_repository
-              WHERE active_repository.active_index_generation_id = generation.id
-            )
-          ORDER BY generation.superseded_at, generation.id
-          -- Keep the serving pointer stable until both deletion phases commit.
-          FOR UPDATE OF generation, repository SKIP LOCKED
-          LIMIT ${generationBatchSize}
-        ),
+        WITH ${eligibleGenerationCtes({
+          eligibleBefore,
+          keepPerRepository,
+          generationBatchSize,
+        })},
         selected_chunks AS (
           SELECT chunk.ctid AS row_id
           FROM repository_item_chunks chunk
@@ -120,36 +134,11 @@ export async function collectSupersededRepositoryGenerations(
       `);
 
       const generationsResult = await tx.execute(sql`
-        WITH ranked_superseded AS (
-          SELECT generation.id,
-                 row_number() OVER (
-                   PARTITION BY generation.repository_id
-                   ORDER BY generation.superseded_at DESC, generation.id DESC
-                 ) AS superseded_rank
-          FROM repository_index_generations generation
-          WHERE generation.status = 'superseded'
-        ),
-        eligible_generations AS (
-          SELECT generation.id
-          FROM repository_index_generations generation
-          INNER JOIN ranked_superseded ranked
-            ON ranked.id = generation.id
-          INNER JOIN knowledge_repositories repository
-            ON repository.id = generation.repository_id
-          WHERE generation.status = 'superseded'
-            AND generation.superseded_at < ${eligibleBefore}::timestamptz
-            AND ranked.superseded_rank > ${keepPerRepository}
-            AND generation.id IS DISTINCT FROM repository.active_index_generation_id
-            AND NOT EXISTS (
-              SELECT 1
-              FROM knowledge_repositories active_repository
-              WHERE active_repository.active_index_generation_id = generation.id
-            )
-          ORDER BY generation.superseded_at, generation.id
-          -- Keep the serving pointer stable until both deletion phases commit.
-          FOR UPDATE OF generation, repository SKIP LOCKED
-          LIMIT ${generationBatchSize}
-        ),
+        WITH ${eligibleGenerationCtes({
+          eligibleBefore,
+          keepPerRepository,
+          generationBatchSize,
+        })},
         deleted_generations AS (
           DELETE FROM repository_index_generations generation
           USING eligible_generations eligible,

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -76,7 +76,7 @@ export async function collectSupersededRepositoryGenerations(
           SELECT generation.id,
                  row_number() OVER (
                    PARTITION BY generation.repository_id
-                   ORDER BY generation.created_at DESC, generation.id DESC
+                   ORDER BY generation.superseded_at DESC, generation.id DESC
                  ) AS superseded_rank
           FROM repository_index_generations generation
           WHERE generation.status = 'superseded'
@@ -89,7 +89,7 @@ export async function collectSupersededRepositoryGenerations(
           INNER JOIN knowledge_repositories repository
             ON repository.id = generation.repository_id
           WHERE generation.status = 'superseded'
-            AND generation.created_at < ${eligibleBefore}::timestamptz
+            AND generation.superseded_at < ${eligibleBefore}::timestamptz
             AND ranked.superseded_rank > ${keepPerRepository}
             AND generation.id IS DISTINCT FROM repository.active_index_generation_id
             AND NOT EXISTS (
@@ -97,7 +97,7 @@ export async function collectSupersededRepositoryGenerations(
               FROM knowledge_repositories active_repository
               WHERE active_repository.active_index_generation_id = generation.id
             )
-          ORDER BY generation.created_at, generation.id
+          ORDER BY generation.superseded_at, generation.id
           FOR UPDATE OF generation SKIP LOCKED
           LIMIT ${generationBatchSize}
         ),
@@ -124,7 +124,7 @@ export async function collectSupersededRepositoryGenerations(
           SELECT generation.id,
                  row_number() OVER (
                    PARTITION BY generation.repository_id
-                   ORDER BY generation.created_at DESC, generation.id DESC
+                   ORDER BY generation.superseded_at DESC, generation.id DESC
                  ) AS superseded_rank
           FROM repository_index_generations generation
           WHERE generation.status = 'superseded'
@@ -137,7 +137,7 @@ export async function collectSupersededRepositoryGenerations(
           INNER JOIN knowledge_repositories repository
             ON repository.id = generation.repository_id
           WHERE generation.status = 'superseded'
-            AND generation.created_at < ${eligibleBefore}::timestamptz
+            AND generation.superseded_at < ${eligibleBefore}::timestamptz
             AND ranked.superseded_rank > ${keepPerRepository}
             AND generation.id IS DISTINCT FROM repository.active_index_generation_id
             AND NOT EXISTS (
@@ -145,7 +145,7 @@ export async function collectSupersededRepositoryGenerations(
               FROM knowledge_repositories active_repository
               WHERE active_repository.active_index_generation_id = generation.id
             )
-          ORDER BY generation.created_at, generation.id
+          ORDER BY generation.superseded_at, generation.id
           FOR UPDATE OF generation SKIP LOCKED
           LIMIT ${generationBatchSize}
         ),
@@ -156,7 +156,7 @@ export async function collectSupersededRepositoryGenerations(
           WHERE generation.id = eligible.id
             AND repository.id = generation.repository_id
             AND generation.status = 'superseded'
-            AND generation.created_at < ${eligibleBefore}::timestamptz
+            AND generation.superseded_at < ${eligibleBefore}::timestamptz
             AND generation.id IS DISTINCT FROM repository.active_index_generation_id
             AND NOT EXISTS (
               SELECT 1

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -207,6 +207,7 @@ function eligibleGenerationCtes(params: {
         FROM repository_index_generations kept_generation
         WHERE kept_generation.repository_id = repository.id
           AND kept_generation.status = 'superseded'
+          AND kept_generation.superseded_at IS NOT NULL
         ORDER BY kept_generation.superseded_at DESC,
                  kept_generation.created_at DESC,
                  kept_generation.id DESC

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -6,6 +6,8 @@ export const SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY = 3;
 export const GENERATION_GC_CHUNK_BATCH = 20_000;
 export const GENERATION_GC_REPOSITORY_BATCH = 200;
 export const GENERATION_GC_GENERATION_BATCH = 200;
+/** Prime stride prevents the minute-based probe window from aligning to ID blocks. */
+const GENERATION_GC_REPOSITORY_PROBE_STRIDE = 104_729n;
 
 export interface CollectSupersededRepositoryGenerationsOptions {
   /** Testable clock; production always uses the current time. */
@@ -46,18 +48,48 @@ function deletedCount(result: unknown): number {
 function eligibleGenerationCtes(params: {
   eligibleBefore: string;
   keepPerRepository: number;
+  repositoryProbeAnchor: string;
   repositoryBatchSize: number;
   generationBatchSize: number;
 }): SQL {
   const keepFloorOffset = params.keepPerRepository - 1;
 
   return sql`
+    repository_probe_start AS (
+      SELECT mod(
+               ${params.repositoryProbeAnchor}::bigint,
+               COALESCE(max(repository.id), 0)::bigint + 1
+             )::integer AS id
+      FROM knowledge_repositories repository
+    ),
+    repository_probe_ids AS MATERIALIZED (
+      (
+        SELECT repository.id
+        FROM knowledge_repositories repository
+        CROSS JOIN repository_probe_start probe_start
+        WHERE repository.id >= probe_start.id
+        ORDER BY repository.id
+        LIMIT ${params.repositoryBatchSize}
+      )
+      UNION ALL
+      (
+        SELECT repository.id
+        FROM knowledge_repositories repository
+        CROSS JOIN repository_probe_start probe_start
+        WHERE repository.id < probe_start.id
+        ORDER BY repository.id
+        LIMIT ${params.repositoryBatchSize}
+      )
+      LIMIT ${params.repositoryBatchSize}
+    ),
     eligible_repositories AS MATERIALIZED (
       SELECT repository.id,
              repository.active_index_generation_id,
              keep_floor.superseded_at AS keep_floor_superseded_at,
              keep_floor.id AS keep_floor_id
-      FROM knowledge_repositories repository
+      FROM repository_probe_ids probe
+      INNER JOIN knowledge_repositories repository
+        ON repository.id = probe.id
       CROSS JOIN LATERAL (
         SELECT kept_generation.superseded_at,
                kept_generation.id
@@ -126,9 +158,11 @@ function eligibleGenerationCtes(params: {
  * invocations cannot work on the same parents. Chunks are removed first in a
  * ctid-bounded batch; a parent is deleted only after it is childless.
  * Eligible repositories are ordered by their oldest candidate so sustained
- * work on low repository IDs cannot starve older garbage elsewhere. The owner
- * row lock stabilizes every supported pointer update; the global pointer guard
- * additionally fails closed on pre-existing cross-repository pointer skew.
+ * work on low repository IDs cannot starve older garbage elsewhere. A rotating
+ * keyset window bounds steady-state repository probes even when nothing is
+ * eligible. The owner row lock stabilizes every supported pointer update; the
+ * global pointer guard additionally fails closed on pre-existing
+ * cross-repository pointer skew.
  */
 export async function collectSupersededRepositoryGenerations(
   options: CollectSupersededRepositoryGenerationsOptions = {},
@@ -153,9 +187,15 @@ export async function collectSupersededRepositoryGenerations(
     options.generationBatchSize ?? GENERATION_GC_GENERATION_BATCH,
     "generationBatchSize",
   );
+  const collectionNow = options.now ?? new Date();
   const eligibleBefore = new Date(
-    (options.now ?? new Date()).getTime() - retentionHours * 60 * 60_000,
+    collectionNow.getTime() - retentionHours * 60 * 60_000,
   ).toISOString();
+  const repositoryProbeAnchor = (
+    BigInt(Math.floor(collectionNow.getTime() / 60_000)) *
+    BigInt(repositoryBatchSize) *
+    GENERATION_GC_REPOSITORY_PROBE_STRIDE
+  ).toString();
 
   return executeTransaction(
     async (tx) => {
@@ -163,6 +203,7 @@ export async function collectSupersededRepositoryGenerations(
         WITH ${eligibleGenerationCtes({
           eligibleBefore,
           keepPerRepository,
+          repositoryProbeAnchor,
           repositoryBatchSize,
           generationBatchSize,
         })},
@@ -187,6 +228,7 @@ export async function collectSupersededRepositoryGenerations(
         WITH ${eligibleGenerationCtes({
           eligibleBefore,
           keepPerRepository,
+          repositoryProbeAnchor,
           repositoryBatchSize,
           generationBatchSize,
         })},

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -148,19 +148,21 @@ async function backfillMissingSupersessionTimes(
   tx: DbTransaction,
   generationBatchSize: number,
 ): Promise<number> {
+  // Oldest-first batches receive one timestamp per statement. Later batches
+  // therefore remain newer, while created_at breaks ties within each batch.
   const result = await tx.execute(sql`
     WITH selected_generations AS MATERIALIZED (
       SELECT generation.id
       FROM repository_index_generations generation
       WHERE generation.status = 'superseded'
         AND generation.superseded_at IS NULL
-      ORDER BY generation.id
+      ORDER BY generation.created_at, generation.id
       FOR UPDATE OF generation SKIP LOCKED
       LIMIT ${generationBatchSize}
     ),
     timestamped_generations AS (
       UPDATE repository_index_generations generation
-      SET superseded_at = clock_timestamp()
+      SET superseded_at = statement_timestamp()
       FROM selected_generations selected
       WHERE generation.id = selected.id
         AND generation.status = 'superseded'

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -239,7 +239,6 @@ function eligibleGenerationCtes(params: {
                oldest_candidate.id,
                repository.id
       FOR UPDATE OF repository SKIP LOCKED
-      LIMIT ${params.repositoryIds.length}
     ),
     eligible_generations AS MATERIALIZED (
       SELECT generation.id

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -45,35 +45,65 @@ function eligibleGenerationCtes(params: {
   keepPerRepository: number;
   generationBatchSize: number;
 }): SQL {
+  const keepFloorOffset = params.keepPerRepository - 1;
+
   return sql`
-    ranked_superseded AS (
-      SELECT generation.id,
-             row_number() OVER (
-               PARTITION BY generation.repository_id
-               ORDER BY generation.superseded_at DESC, generation.id DESC
-             ) AS superseded_rank
-      FROM repository_index_generations generation
-      WHERE generation.status = 'superseded'
+    eligible_repositories AS MATERIALIZED (
+      SELECT repository.id,
+             repository.active_index_generation_id,
+             keep_floor.superseded_at AS keep_floor_superseded_at,
+             keep_floor.id AS keep_floor_id
+      FROM knowledge_repositories repository
+      CROSS JOIN LATERAL (
+        SELECT kept_generation.superseded_at,
+               kept_generation.id
+        FROM repository_index_generations kept_generation
+        WHERE kept_generation.repository_id = repository.id
+          AND kept_generation.status = 'superseded'
+        ORDER BY kept_generation.superseded_at DESC, kept_generation.id DESC
+        OFFSET ${keepFloorOffset}
+        LIMIT 1
+      ) keep_floor
+      WHERE EXISTS (
+        SELECT 1
+        FROM repository_index_generations candidate_generation
+        WHERE candidate_generation.repository_id = repository.id
+          AND candidate_generation.status = 'superseded'
+          AND candidate_generation.superseded_at < ${params.eligibleBefore}::timestamptz
+          AND (candidate_generation.superseded_at, candidate_generation.id) <
+              (keep_floor.superseded_at, keep_floor.id)
+          AND candidate_generation.id IS DISTINCT FROM repository.active_index_generation_id
+          AND NOT EXISTS (
+            SELECT 1
+            FROM knowledge_repositories active_repository
+            WHERE active_repository.active_index_generation_id = candidate_generation.id
+          )
+      )
+      ORDER BY repository.id
+      FOR UPDATE OF repository SKIP LOCKED
+      LIMIT ${params.generationBatchSize}
     ),
-    eligible_generations AS (
+    eligible_generations AS MATERIALIZED (
       SELECT generation.id
-      FROM repository_index_generations generation
-      INNER JOIN ranked_superseded ranked
-        ON ranked.id = generation.id
-      INNER JOIN knowledge_repositories repository
-        ON repository.id = generation.repository_id
-      WHERE generation.status = 'superseded'
-        AND generation.superseded_at < ${params.eligibleBefore}::timestamptz
-        AND ranked.superseded_rank > ${params.keepPerRepository}
-        AND generation.id IS DISTINCT FROM repository.active_index_generation_id
-        AND NOT EXISTS (
-          SELECT 1
-          FROM knowledge_repositories active_repository
-          WHERE active_repository.active_index_generation_id = generation.id
-        )
-      ORDER BY generation.superseded_at, generation.id
-      -- Keep the serving pointer stable until both deletion phases commit.
-      FOR UPDATE OF generation, repository SKIP LOCKED
+      FROM eligible_repositories repository
+      CROSS JOIN LATERAL (
+        SELECT candidate_generation.id
+        FROM repository_index_generations candidate_generation
+        WHERE candidate_generation.repository_id = repository.id
+          AND candidate_generation.status = 'superseded'
+          AND candidate_generation.superseded_at < ${params.eligibleBefore}::timestamptz
+          AND (candidate_generation.superseded_at, candidate_generation.id) <
+              (repository.keep_floor_superseded_at, repository.keep_floor_id)
+          AND candidate_generation.id IS DISTINCT FROM repository.active_index_generation_id
+          AND NOT EXISTS (
+            SELECT 1
+            FROM knowledge_repositories active_repository
+            WHERE active_repository.active_index_generation_id = candidate_generation.id
+          )
+        ORDER BY candidate_generation.superseded_at, candidate_generation.id
+        FOR UPDATE OF candidate_generation SKIP LOCKED
+        LIMIT ${params.generationBatchSize}
+      ) generation
       LIMIT ${params.generationBatchSize}
     )
   `;
@@ -81,9 +111,11 @@ function eligibleGenerationCtes(params: {
 
 /**
  * Delete one bounded batch from repository generations that are safely beyond
- * the rollback window. Generation rows are locked with SKIP LOCKED so multiple
- * scheduler invocations cannot work on the same parents. Chunks are removed
- * first in a ctid-bounded batch; a parent is deleted only after it is childless.
+ * the rollback window. The keep floor is found with a bounded per-repository
+ * index probe instead of ranking the complete superseded history. Repository
+ * and generation rows are locked with SKIP LOCKED so multiple scheduler
+ * invocations cannot work on the same parents. Chunks are removed first in a
+ * ctid-bounded batch; a parent is deleted only after it is childless.
  */
 export async function collectSupersededRepositoryGenerations(
   options: CollectSupersededRepositoryGenerationsOptions = {},

--- a/lib/repositories/content-platform/generation-retention.ts
+++ b/lib/repositories/content-platform/generation-retention.ts
@@ -6,8 +6,7 @@ export const SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY = 3;
 export const GENERATION_GC_CHUNK_BATCH = 20_000;
 export const GENERATION_GC_REPOSITORY_BATCH = 200;
 export const GENERATION_GC_GENERATION_BATCH = 200;
-/** Prime stride prevents the minute-based probe window from aligning to ID blocks. */
-const GENERATION_GC_REPOSITORY_PROBE_STRIDE = 104_729n;
+export const GENERATION_GC_PER_REPOSITORY_BATCH = 10;
 
 export interface CollectSupersededRepositoryGenerationsOptions {
   /** Testable clock; production always uses the current time. */
@@ -22,6 +21,8 @@ export interface CollectSupersededRepositoryGenerationsOptions {
   repositoryBatchSize?: number;
   /** Test override; production always uses the exported generation batch size. */
   generationBatchSize?: number;
+  /** Test override; production always uses the per-repository generation cap. */
+  perRepositoryGenerationBatchSize?: number;
 }
 
 export interface SupersededGenerationCollectionResult {
@@ -51,6 +52,7 @@ function eligibleGenerationCtes(params: {
   repositoryProbeAnchor: string;
   repositoryBatchSize: number;
   generationBatchSize: number;
+  perRepositoryGenerationBatchSize: number;
 }): SQL {
   const keepFloorOffset = params.keepPerRepository - 1;
 
@@ -159,7 +161,7 @@ function eligibleGenerationCtes(params: {
                  candidate_generation.created_at,
                  candidate_generation.id
         FOR UPDATE OF candidate_generation SKIP LOCKED
-        LIMIT ${params.generationBatchSize}
+        LIMIT ${params.perRepositoryGenerationBatchSize}
       ) generation
       LIMIT ${params.generationBatchSize}
     )
@@ -176,9 +178,10 @@ function eligibleGenerationCtes(params: {
  * Eligible repositories are ordered by their oldest candidate so sustained
  * work on low repository IDs cannot starve older garbage elsewhere. A rotating
  * keyset window bounds steady-state repository probes even when nothing is
- * eligible. The owner row lock stabilizes every supported pointer update; the
- * global pointer guard additionally fails closed on pre-existing
- * cross-repository pointer skew.
+ * eligible, while a per-repository generation cap prevents one backlog from
+ * consuming the entire global batch. The owner row lock stabilizes every
+ * supported pointer update; the global pointer guard additionally fails closed
+ * on pre-existing cross-repository pointer skew.
  */
 export async function collectSupersededRepositoryGenerations(
   options: CollectSupersededRepositoryGenerationsOptions = {},
@@ -203,14 +206,21 @@ export async function collectSupersededRepositoryGenerations(
     options.generationBatchSize ?? GENERATION_GC_GENERATION_BATCH,
     "generationBatchSize",
   );
+  const perRepositoryGenerationBatchSize = requirePositiveInteger(
+    options.perRepositoryGenerationBatchSize ??
+      GENERATION_GC_PER_REPOSITORY_BATCH,
+    "perRepositoryGenerationBatchSize",
+  );
   const collectionNow = options.now ?? new Date();
   const eligibleBefore = new Date(
     collectionNow.getTime() - retentionHours * 60 * 60_000,
   ).toISOString();
+  // Advance by exactly one window per minute. For any modulus N, every common
+  // divisor of N and the step is no larger than the window, so the B-wide
+  // wraparound keyset windows cover every repository without a coprime guess.
   const repositoryProbeAnchor = (
     BigInt(Math.floor(collectionNow.getTime() / 60_000)) *
-    BigInt(repositoryBatchSize) *
-    GENERATION_GC_REPOSITORY_PROBE_STRIDE
+    BigInt(repositoryBatchSize)
   ).toString();
 
   return executeTransaction(
@@ -222,6 +232,7 @@ export async function collectSupersededRepositoryGenerations(
           repositoryProbeAnchor,
           repositoryBatchSize,
           generationBatchSize,
+          perRepositoryGenerationBatchSize,
         })},
         selected_chunks AS (
           SELECT chunk.ctid AS row_id
@@ -247,6 +258,7 @@ export async function collectSupersededRepositoryGenerations(
           repositoryProbeAnchor,
           repositoryBatchSize,
           generationBatchSize,
+          perRepositoryGenerationBatchSize,
         })},
         deleted_generations AS (
           DELETE FROM repository_index_generations generation

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:smoke:atrium-visibility": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/atrium-visibility-reference.smoke.ts",
     "test:smoke:resource-access": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/resource-access-grants.smoke.ts",
     "test:smoke:unified-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/unified-content-foundation.smoke.ts",
+    "test:smoke:generation-retention": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-generation-retention.smoke.ts",
     "test:smoke:nexus-ephemeral": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/nexus-ephemeral-repositories.smoke.ts",
     "test:smoke:repository-upload-quota": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-upload-quota.smoke.ts",
     "test:smoke:repository-pending-deletion": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-pending-deletion.smoke.ts",

--- a/tests/smoke/repository-generation-retention.smoke.ts
+++ b/tests/smoke/repository-generation-retention.smoke.ts
@@ -4,10 +4,11 @@
  */
 
 import assert from "node:assert/strict";
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import {
   closeDatabase,
   executeQuery,
+  executeTransaction,
 } from "@/lib/db/drizzle-client";
 import {
   knowledgeRepositories,
@@ -99,13 +100,36 @@ try {
         .where(eq(knowledgeRepositories.id, repository.id)),
     "smoke.generationRetention.setInitialServingPointer",
   );
-  await executeQuery(
-    (db) =>
-      db
+  const supersessionTransition = await executeTransaction(
+    async (tx) => {
+      const [transactionClock] = await tx.execute<{
+        transaction_started_at: Date | string;
+      }>(sql`SELECT transaction_timestamp() AS transaction_started_at`);
+      assert.ok(transactionClock);
+      await tx.execute(sql`SELECT pg_sleep(0.02)`);
+      await tx
         .update(repositoryIndexGenerations)
         .set({ status: "superseded" })
-        .where(eq(repositoryIndexGenerations.id, longLived.id)),
+        .where(eq(repositoryIndexGenerations.id, longLived.id));
+      const [transitioned] = await tx
+        .select({ supersededAt: repositoryIndexGenerations.supersededAt })
+        .from(repositoryIndexGenerations)
+        .where(eq(repositoryIndexGenerations.id, longLived.id));
+      assert.ok(transitioned?.supersededAt);
+      return {
+        supersededAt: transitioned.supersededAt,
+        transactionStartedAt:
+          transactionClock.transaction_started_at instanceof Date
+            ? transactionClock.transaction_started_at
+            : new Date(transactionClock.transaction_started_at),
+      };
+    },
     "smoke.generationRetention.supersedeLongLived",
+  );
+  assert.ok(
+    supersessionTransition.supersededAt.getTime() >
+      supersessionTransition.transactionStartedAt.getTime(),
+    "superseded_at must use the transition clock, not transaction start",
   );
   await executeQuery(
     (db) =>

--- a/tests/smoke/repository-generation-retention.smoke.ts
+++ b/tests/smoke/repository-generation-retention.smoke.ts
@@ -1,0 +1,220 @@
+/**
+ * Real-PostgreSQL safety contract for superseded generation retention (#1527).
+ * Runs after migrations and the local seed in CI's unified-content lifecycle job.
+ */
+
+import assert from "node:assert/strict";
+import { eq, inArray } from "drizzle-orm";
+import {
+  closeDatabase,
+  executeQuery,
+} from "@/lib/db/drizzle-client";
+import {
+  knowledgeRepositories,
+  repositoryIndexGenerations,
+  repositoryItemChunks,
+  repositoryItems,
+  users,
+} from "@/lib/db/schema";
+import { collectSupersededRepositoryGenerations } from "@/lib/repositories/content-platform/generation-retention";
+
+const HOUR_MS = 60 * 60_000;
+const now = new Date();
+const [owner] = await executeQuery(
+  (db) =>
+    db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.cognitoSub, "e2e-test-user"))
+      .limit(1),
+  "smoke.generationRetention.owner",
+);
+assert.ok(owner, "standard local seed is missing e2e-test-user");
+
+const [repository] = await executeQuery(
+  (db) =>
+    db
+      .insert(knowledgeRepositories)
+      .values({
+        name: `Generation retention smoke ${now.getTime()}`,
+        ownerId: owner.id,
+        repositoryKind: "durable",
+      })
+      .returning({ id: knowledgeRepositories.id }),
+  "smoke.generationRetention.createRepository",
+);
+assert.ok(repository);
+
+try {
+  const [item] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryItems)
+        .values({
+          repositoryId: repository.id,
+          type: "document",
+          name: "Generation retention fixture",
+          source: "smoke",
+        })
+        .returning({ id: repositoryItems.id }),
+    "smoke.generationRetention.createItem",
+  );
+  assert.ok(item);
+
+  const [longLived, serving, ...oldGenerations] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryIndexGenerations)
+        .values([
+          {
+            repositoryId: repository.id,
+            status: "active" as const,
+            processorVersion: "generation-retention-long-lived",
+            createdAt: new Date(now.getTime() - 90 * 24 * HOUR_MS),
+          },
+          {
+            repositoryId: repository.id,
+            status: "building" as const,
+            processorVersion: "generation-retention-serving",
+          },
+          ...[1, 2, 3, 4].map((daysOld) => ({
+            repositoryId: repository.id,
+            status: "superseded" as const,
+            processorVersion: `generation-retention-old-${daysOld}`,
+            createdAt: new Date(now.getTime() - 10 * 24 * HOUR_MS),
+          })),
+        ])
+        .returning({ id: repositoryIndexGenerations.id }),
+    "smoke.generationRetention.createGenerations",
+  );
+  assert.ok(longLived);
+  assert.ok(serving);
+  assert.equal(oldGenerations.length, 4);
+
+  await executeQuery(
+    (db) =>
+      db
+        .update(knowledgeRepositories)
+        .set({ activeIndexGenerationId: longLived.id })
+        .where(eq(knowledgeRepositories.id, repository.id)),
+    "smoke.generationRetention.setInitialServingPointer",
+  );
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryIndexGenerations)
+        .set({ status: "superseded" })
+        .where(eq(repositoryIndexGenerations.id, longLived.id)),
+    "smoke.generationRetention.supersedeLongLived",
+  );
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryIndexGenerations)
+        .set({ status: "active" })
+        .where(eq(repositoryIndexGenerations.id, serving.id)),
+    "smoke.generationRetention.activateServing",
+  );
+  await executeQuery(
+    (db) =>
+      db
+        .update(knowledgeRepositories)
+        .set({ activeIndexGenerationId: serving.id })
+        .where(eq(knowledgeRepositories.id, repository.id)),
+    "smoke.generationRetention.setServingPointer",
+  );
+
+  for (const [index, generation] of oldGenerations.entries()) {
+    assert.ok(generation);
+    await executeQuery(
+      (db) =>
+        db
+          .update(repositoryIndexGenerations)
+          .set({
+            supersededAt: new Date(
+              now.getTime() - (index + 1) * 24 * HOUR_MS,
+            ),
+          })
+          .where(eq(repositoryIndexGenerations.id, generation.id)),
+      `smoke.generationRetention.ageGeneration.${index}`,
+    );
+    await executeQuery(
+      (db) =>
+        db.insert(repositoryItemChunks).values({
+          itemId: item.id,
+          indexGenerationId: generation.id,
+          content: `generation retention chunk ${index}`,
+          chunkIndex: index,
+        }),
+      `smoke.generationRetention.createChunk.${index}`,
+    );
+  }
+
+  const [freshlySuperseded] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          createdAt: repositoryIndexGenerations.createdAt,
+          supersededAt: repositoryIndexGenerations.supersededAt,
+        })
+        .from(repositoryIndexGenerations)
+        .where(eq(repositoryIndexGenerations.id, longLived.id)),
+    "smoke.generationRetention.readSupersessionTime",
+  );
+  assert.ok(freshlySuperseded?.createdAt);
+  assert.ok(freshlySuperseded?.supersededAt);
+  assert.ok(freshlySuperseded.createdAt < new Date(now.getTime() - 89 * 24 * HOUR_MS));
+  assert.ok(freshlySuperseded.supersededAt >= new Date(now.getTime() - HOUR_MS));
+
+  await assert.doesNotReject(async () =>
+    assert.deepEqual(
+      await collectSupersededRepositoryGenerations({ now }),
+      { chunksDeleted: 2, generationsDeleted: 2 },
+    ),
+  );
+
+  const remaining = await executeQuery(
+    (db) =>
+      db
+        .select({ id: repositoryIndexGenerations.id })
+        .from(repositoryIndexGenerations)
+        .where(
+          inArray(repositoryIndexGenerations.id, [
+            longLived.id,
+            serving.id,
+            ...oldGenerations.map((generation) => generation.id),
+          ]),
+        ),
+    "smoke.generationRetention.readRemaining",
+  );
+  const remainingIds = new Set(remaining.map((generation) => generation.id));
+  assert.ok(remainingIds.has(longLived.id));
+  assert.ok(remainingIds.has(serving.id));
+  assert.ok(remainingIds.has(oldGenerations[0]!.id));
+  assert.ok(remainingIds.has(oldGenerations[1]!.id));
+  assert.equal(remainingIds.has(oldGenerations[2]!.id), false);
+  assert.equal(remainingIds.has(oldGenerations[3]!.id), false);
+
+  const remainingChunks = await executeQuery(
+    (db) =>
+      db
+        .select({ id: repositoryItemChunks.id })
+        .from(repositoryItemChunks)
+        .where(eq(repositoryItemChunks.itemId, item.id)),
+    "smoke.generationRetention.readRemainingChunks",
+  );
+  assert.equal(remainingChunks.length, 2);
+
+  process.stdout.write(
+    "repository-generation-retention smoke: transition window, keep floor, and bounded deletion passed\n",
+  );
+} finally {
+  await executeQuery(
+    (db) =>
+      db
+        .delete(knowledgeRepositories)
+        .where(eq(knowledgeRepositories.id, repository.id)),
+    "smoke.generationRetention.cleanup",
+  );
+  await closeDatabase();
+}

--- a/tests/smoke/repository-generation-retention.smoke.ts
+++ b/tests/smoke/repository-generation-retention.smoke.ts
@@ -32,19 +32,40 @@ const [owner] = await executeQuery(
 );
 assert.ok(owner, "standard local seed is missing e2e-test-user");
 
-const [repository] = await executeQuery(
+const primaryRepositoryName = `Generation retention smoke ${now.getTime()}`;
+const mixedRepositoryName = `Generation retention mixed floor ${now.getTime()}`;
+const decoyRepositoryName = `Generation retention backfill decoy ${now.getTime()}`;
+const createdRepositories = await executeQuery(
   (db) =>
     db
       .insert(knowledgeRepositories)
-      .values({
-        name: `Generation retention smoke ${now.getTime()}`,
-        ownerId: owner.id,
-        repositoryKind: "durable",
-      })
-      .returning({ id: knowledgeRepositories.id }),
-  "smoke.generationRetention.createRepository",
+      .values(
+        [primaryRepositoryName, mixedRepositoryName, decoyRepositoryName].map(
+          (name) => ({
+            name,
+            ownerId: owner.id,
+            repositoryKind: "durable" as const,
+          }),
+        ),
+      )
+      .returning({
+        id: knowledgeRepositories.id,
+        name: knowledgeRepositories.name,
+      }),
+  "smoke.generationRetention.createRepositories",
+);
+const repository = createdRepositories.find(
+  (candidate) => candidate.name === primaryRepositoryName,
+);
+const mixedRepository = createdRepositories.find(
+  (candidate) => candidate.name === mixedRepositoryName,
+);
+const decoyRepository = createdRepositories.find(
+  (candidate) => candidate.name === decoyRepositoryName,
 );
 assert.ok(repository);
+assert.ok(mixedRepository);
+assert.ok(decoyRepository);
 
 try {
   const [item] = await executeQuery(
@@ -244,6 +265,118 @@ try {
   );
   assert.equal(remainingChunks.length, 2);
 
+  const mixedFloorFixture = [
+    { id: "10000000-0000-4000-8000-000000000001", supersededHoursAgo: 1 },
+    { id: "10000000-0000-4000-8000-000000000002", supersededHoursAgo: 2 },
+    { id: "10000000-0000-4000-8000-000000000003", supersededHoursAgo: 48 },
+    { id: "10000000-0000-4000-8000-000000000004", supersededHoursAgo: 72 },
+    { id: "10000000-0000-4000-8000-000000000005", supersededHoursAgo: null },
+  ] as const;
+  await executeQuery(
+    (db) =>
+      db.insert(repositoryIndexGenerations).values(
+        mixedFloorFixture.map((fixture, index) => ({
+          id: fixture.id,
+          repositoryId: mixedRepository.id,
+          status: "superseded" as const,
+          processorVersion: `generation-retention-mixed-floor-${index}`,
+          createdAt: new Date(now.getTime() - (10 - index) * HOUR_MS),
+        })),
+      ),
+    "smoke.generationRetention.createMixedFloorGenerations",
+  );
+  for (const fixture of mixedFloorFixture) {
+    await executeQuery(
+      (db) =>
+        db
+          .update(repositoryIndexGenerations)
+          .set({
+            supersededAt:
+              fixture.supersededHoursAgo === null
+                ? null
+                : new Date(
+                    now.getTime() - fixture.supersededHoursAgo * HOUR_MS,
+                  ),
+          })
+          .where(eq(repositoryIndexGenerations.id, fixture.id)),
+      `smoke.generationRetention.ageMixedFloor.${fixture.id}`,
+    );
+  }
+
+  const decoyGenerationIds = [1, 2, 3, 4].map(
+    (sequence) =>
+      `20000000-0000-4000-8000-${sequence.toString().padStart(12, "0")}`,
+  );
+  await executeQuery(
+    (db) =>
+      db.insert(repositoryIndexGenerations).values(
+        decoyGenerationIds.map((id, index) => ({
+          id,
+          repositoryId: decoyRepository.id,
+          status: "superseded" as const,
+          processorVersion: `generation-retention-backfill-decoy-${index}`,
+          createdAt: new Date(now.getTime() - (500 - index) * HOUR_MS),
+        })),
+      ),
+    "smoke.generationRetention.createBackfillDecoys",
+  );
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryIndexGenerations)
+        .set({ supersededAt: null })
+        .where(inArray(repositoryIndexGenerations.id, decoyGenerationIds)),
+    "smoke.generationRetention.clearBackfillDecoyTimestamps",
+  );
+
+  assert.deepEqual(
+    await collectSupersededRepositoryGenerations({
+      now,
+      generationBatchSize: 4,
+      perRepositoryGenerationBatchSize: 4,
+    }),
+    {
+      generationsTimestamped: 4,
+      chunksDeleted: 0,
+      generationsDeleted: 1,
+    },
+  );
+  const mixedFloorRemaining = await executeQuery(
+    (db) =>
+      db
+        .select({
+          id: repositoryIndexGenerations.id,
+          supersededAt: repositoryIndexGenerations.supersededAt,
+        })
+        .from(repositoryIndexGenerations)
+        .where(
+          inArray(
+            repositoryIndexGenerations.id,
+            mixedFloorFixture.map((fixture) => fixture.id),
+          ),
+        ),
+    "smoke.generationRetention.readMixedFloorRemaining",
+  );
+  const mixedFloorRemainingIds = new Set(
+    mixedFloorRemaining.map((generation) => generation.id),
+  );
+  assert.ok(mixedFloorRemainingIds.has(mixedFloorFixture[2].id));
+  assert.equal(mixedFloorRemainingIds.has(mixedFloorFixture[3].id), false);
+  assert.equal(
+    mixedFloorRemaining.find(
+      (generation) => generation.id === mixedFloorFixture[4].id,
+    )?.supersededAt,
+    null,
+  );
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryIndexGenerations)
+        .set({ supersededAt: now })
+        .where(eq(repositoryIndexGenerations.id, mixedFloorFixture[4].id)),
+    "smoke.generationRetention.finishMixedFloorBackfill",
+  );
+
   const backlogGenerations = await executeQuery(
     (db) =>
       db
@@ -388,7 +521,13 @@ try {
     (db) =>
       db
         .delete(knowledgeRepositories)
-        .where(eq(knowledgeRepositories.id, repository.id)),
+        .where(
+          inArray(knowledgeRepositories.id, [
+            repository.id,
+            mixedRepository.id,
+            decoyRepository.id,
+          ]),
+        ),
     "smoke.generationRetention.cleanup",
   );
   await closeDatabase();

--- a/tests/smoke/repository-generation-retention.smoke.ts
+++ b/tests/smoke/repository-generation-retention.smoke.ts
@@ -192,10 +192,23 @@ try {
   assert.ok(freshlySuperseded.createdAt < new Date(now.getTime() - 89 * 24 * HOUR_MS));
   assert.ok(freshlySuperseded.supersededAt >= new Date(now.getTime() - HOUR_MS));
 
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryIndexGenerations)
+        .set({ supersededAt: null })
+        .where(eq(repositoryIndexGenerations.id, longLived.id)),
+    "smoke.generationRetention.simulateLegacyMissingTimestamp",
+  );
+
   await assert.doesNotReject(async () =>
     assert.deepEqual(
       await collectSupersededRepositoryGenerations({ now }),
-      { chunksDeleted: 2, generationsDeleted: 2 },
+      {
+        generationsTimestamped: 1,
+        chunksDeleted: 2,
+        generationsDeleted: 2,
+      },
     ),
   );
 

--- a/tests/smoke/repository-generation-retention.smoke.ts
+++ b/tests/smoke/repository-generation-retention.smoke.ts
@@ -82,7 +82,9 @@ try {
             repositoryId: repository.id,
             status: "superseded" as const,
             processorVersion: `generation-retention-old-${daysOld}`,
-            createdAt: new Date(now.getTime() - 10 * 24 * HOUR_MS),
+            createdAt: new Date(
+              now.getTime() - (10 + daysOld) * 24 * HOUR_MS,
+            ),
           })),
         ])
         .returning({ id: repositoryIndexGenerations.id }),
@@ -155,9 +157,9 @@ try {
         db
           .update(repositoryIndexGenerations)
           .set({
-            supersededAt: new Date(
-              now.getTime() - (index + 1) * 24 * HOUR_MS,
-            ),
+            // Migration 173 gives the historical backlog one shared timestamp.
+            // created_at must deterministically break that deployment-time tie.
+            supersededAt: new Date(now.getTime() - 4 * 24 * HOUR_MS),
           })
           .where(eq(repositoryIndexGenerations.id, generation.id)),
       `smoke.generationRetention.ageGeneration.${index}`,

--- a/tests/smoke/repository-generation-retention.smoke.ts
+++ b/tests/smoke/repository-generation-retention.smoke.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "node:assert/strict";
-import { eq, inArray, sql } from "drizzle-orm";
+import { asc, eq, inArray, sql } from "drizzle-orm";
 import {
   closeDatabase,
   executeQuery,
@@ -250,15 +250,79 @@ try {
         .insert(repositoryIndexGenerations)
         .values(
           [1, 2, 3, 4, 5].map((sequence) => ({
+            id: `00000000-0000-4000-8000-${(6 - sequence)
+              .toString()
+              .padStart(12, "0")}`,
             repositoryId: repository.id,
             status: "superseded" as const,
             processorVersion: `generation-retention-backlog-${sequence}`,
+            createdAt: new Date(now.getTime() - (10 - sequence) * HOUR_MS),
           })),
         )
         .returning({ id: repositoryIndexGenerations.id }),
     "smoke.generationRetention.createBacklogGenerations",
   );
   assert.equal(backlogGenerations.length, 5);
+
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryIndexGenerations)
+        .set({ supersededAt: null })
+        .where(
+          inArray(
+            repositoryIndexGenerations.id,
+            backlogGenerations.map((generation) => generation.id),
+          ),
+        ),
+    "smoke.generationRetention.simulateLegacyBackfill",
+  );
+
+  const backfillOptions = {
+    now,
+    retentionHours: 365 * 24,
+    generationBatchSize: 2,
+    perRepositoryGenerationBatchSize: 2,
+  };
+  for (const expectedTimestampCount of [2, 2, 1]) {
+    assert.deepEqual(
+      await collectSupersededRepositoryGenerations(backfillOptions),
+      {
+        generationsTimestamped: expectedTimestampCount,
+        chunksDeleted: 0,
+        generationsDeleted: 0,
+      },
+    );
+  }
+
+  const backfilledGenerations = await executeQuery(
+    (db) =>
+      db
+        .select({
+          createdAt: repositoryIndexGenerations.createdAt,
+          supersededAt: repositoryIndexGenerations.supersededAt,
+        })
+        .from(repositoryIndexGenerations)
+        .where(
+          inArray(
+            repositoryIndexGenerations.id,
+            backlogGenerations.map((generation) => generation.id),
+          ),
+        )
+        .orderBy(asc(repositoryIndexGenerations.createdAt)),
+    "smoke.generationRetention.readLegacyBackfillOrder",
+  );
+  for (const [index, generation] of backfilledGenerations.entries()) {
+    assert.ok(generation.supersededAt);
+    if (index > 0) {
+      assert.ok(backfilledGenerations[index - 1]!.supersededAt);
+      assert.ok(
+        backfilledGenerations[index - 1]!.supersededAt!.getTime() <=
+          generation.supersededAt.getTime(),
+        "legacy backfill timestamps must preserve created_at order across batches",
+      );
+    }
+  }
 
   for (const [index, generation] of backlogGenerations.entries()) {
     await executeQuery(

--- a/tests/smoke/repository-generation-retention.smoke.ts
+++ b/tests/smoke/repository-generation-retention.smoke.ts
@@ -244,8 +244,80 @@ try {
   );
   assert.equal(remainingChunks.length, 2);
 
+  const backlogGenerations = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryIndexGenerations)
+        .values(
+          [1, 2, 3, 4, 5].map((sequence) => ({
+            repositoryId: repository.id,
+            status: "superseded" as const,
+            processorVersion: `generation-retention-backlog-${sequence}`,
+          })),
+        )
+        .returning({ id: repositoryIndexGenerations.id }),
+    "smoke.generationRetention.createBacklogGenerations",
+  );
+  assert.equal(backlogGenerations.length, 5);
+
+  for (const [index, generation] of backlogGenerations.entries()) {
+    await executeQuery(
+      (db) =>
+        db
+          .update(repositoryIndexGenerations)
+          .set({
+            supersededAt: new Date(now.getTime() - (200 - index) * HOUR_MS),
+          })
+          .where(eq(repositoryIndexGenerations.id, generation.id)),
+      `smoke.generationRetention.ageBacklogGeneration.${index}`,
+    );
+    await executeQuery(
+      (db) =>
+        db.insert(repositoryItemChunks).values({
+          itemId: item.id,
+          indexGenerationId: generation.id,
+          content: `generation retention backlog chunk ${index}`,
+          chunkIndex: 100 + index,
+        }),
+      `smoke.generationRetention.createBacklogChunk.${index}`,
+    );
+  }
+
+  const boundedOptions = {
+    now,
+    generationBatchSize: 2,
+    perRepositoryGenerationBatchSize: 2,
+  };
+  assert.deepEqual(await collectSupersededRepositoryGenerations(boundedOptions), {
+    generationsTimestamped: 0,
+    chunksDeleted: 2,
+    generationsDeleted: 2,
+  });
+  assert.deepEqual(await collectSupersededRepositoryGenerations(boundedOptions), {
+    generationsTimestamped: 0,
+    chunksDeleted: 2,
+    generationsDeleted: 2,
+  });
+
+  const remainingBacklog = await executeQuery(
+    (db) =>
+      db
+        .select({ id: repositoryIndexGenerations.id })
+        .from(repositoryIndexGenerations)
+        .where(
+          inArray(
+            repositoryIndexGenerations.id,
+            backlogGenerations.map((generation) => generation.id),
+          ),
+    ),
+    "smoke.generationRetention.readRemainingBacklog",
+  );
+  assert.deepEqual(remainingBacklog, [
+    { id: backlogGenerations.at(-1)!.id },
+  ]);
+
   process.stdout.write(
-    "repository-generation-retention smoke: transition window, keep floor, and bounded deletion passed\n",
+    "repository-generation-retention smoke: transition window, keep floor, and repeated bounded deletion passed\n",
   );
 } finally {
   await executeQuery(

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -101,6 +101,7 @@ describe("superseded repository generation retention", () => {
       expect(compiled.sql).toContain(
         "ORDER BY oldest_candidate.superseded_at",
       );
+      expect(compiled.sql).toContain("ORDER BY generation.superseded_at");
       expect(compiled.sql).toContain("candidate_generation.superseded_at <");
       expect(compiled.sql).not.toContain("generation.created_at <");
       expect(compiled.sql).toContain(

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -69,8 +69,10 @@ describe("superseded repository generation retention", () => {
       expect(compiled.sql).toContain("row_number() OVER");
       expect(compiled.sql).toContain("PARTITION BY generation.repository_id");
       expect(compiled.sql).toContain(
-        "ORDER BY generation.created_at DESC, generation.id DESC",
+        "ORDER BY generation.superseded_at DESC, generation.id DESC",
       );
+      expect(compiled.sql).toContain("generation.superseded_at <");
+      expect(compiled.sql).not.toContain("generation.created_at <");
       expect(compiled.sql).toContain(
         "generation.id IS DISTINCT FROM repository.active_index_generation_id",
       );

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -14,6 +14,7 @@ import {
   collectSupersededRepositoryGenerations,
   GENERATION_GC_CHUNK_BATCH,
   GENERATION_GC_GENERATION_BATCH,
+  GENERATION_GC_REPOSITORY_BATCH,
   SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY,
   SUPERSEDED_GENERATION_RETENTION_HOURS,
 } from "@/lib/repositories/content-platform/generation-retention";
@@ -50,8 +51,9 @@ describe("superseded repository generation retention", () => {
     );
 
     const now = new Date("2026-08-01T12:00:00.000Z");
+    const repositoryBatchSize = 37;
     await expect(
-      collectSupersededRepositoryGenerations({ now }),
+      collectSupersededRepositoryGenerations({ now, repositoryBatchSize }),
     ).resolves.toEqual({
       chunksDeleted: 20_000,
       generationsDeleted: 17,
@@ -81,6 +83,9 @@ describe("superseded repository generation retention", () => {
       expect(compiled.sql).toContain(
         "(candidate_generation.superseded_at, candidate_generation.id) <",
       );
+      expect(compiled.sql).toContain(
+        "ORDER BY oldest_candidate.superseded_at",
+      );
       expect(compiled.sql).toContain("candidate_generation.superseded_at <");
       expect(compiled.sql).not.toContain("generation.created_at <");
       expect(compiled.sql).toContain(
@@ -99,6 +104,7 @@ describe("superseded repository generation retention", () => {
       expect(compiled.params).toContain(
         SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY - 1,
       );
+      expect(compiled.params).toContain(repositoryBatchSize);
       expect(compiled.params).toContain(GENERATION_GC_GENERATION_BATCH);
       expect(compiled.sql).not.toMatch(
         /generation\.status\s+(?:=|IN)\s*\(?\s*'(?:active|building)'/i,
@@ -115,6 +121,7 @@ describe("superseded repository generation retention", () => {
     expect(SUPERSEDED_GENERATION_RETENTION_HOURS).toBe(24);
     expect(SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY).toBe(3);
     expect(GENERATION_GC_CHUNK_BATCH).toBe(20_000);
+    expect(GENERATION_GC_REPOSITORY_BATCH).toBe(200);
     expect(GENERATION_GC_GENERATION_BATCH).toBe(200);
   });
 
@@ -122,6 +129,7 @@ describe("superseded repository generation retention", () => {
     ["retentionHours", { retentionHours: 0 }],
     ["keepPerRepository", { keepPerRepository: 0 }],
     ["chunkBatchSize", { chunkBatchSize: 0 }],
+    ["repositoryBatchSize", { repositoryBatchSize: 0 }],
     ["generationBatchSize", { generationBatchSize: 0 }],
   ])("rejects an unsafe %s override", async (name, options) => {
     await expect(

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -87,9 +87,8 @@ describe("superseded repository generation retention", () => {
     expect(timestampBackfill!.sql).toContain(
       "FOR UPDATE OF generation SKIP LOCKED",
     );
-    expect(timestampBackfill!.sql).toContain(
-      "SET superseded_at = clock_timestamp()",
-    );
+    expect(timestampBackfill!.sql).toContain("ORDER BY generation.created_at, generation.id");
+    expect(timestampBackfill!.sql).toContain("SET superseded_at = statement_timestamp()");
     expect(timestampBackfill!.params).toContain(GENERATION_GC_TIMESTAMP_BATCH);
     expect(cursorUpdate!.sql).toContain("UPDATE settings");
     expect(cursorUpdate!.params).toContain("1300");

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -80,7 +80,7 @@ describe("superseded repository generation retention", () => {
         "active_repository.active_index_generation_id = generation.id",
       );
       expect(compiled.sql).toContain(
-        "FOR UPDATE OF generation SKIP LOCKED",
+        "FOR UPDATE OF generation, repository SKIP LOCKED",
       );
       expect(compiled.params).toContain("2026-07-31T12:00:00.000Z");
       expect(compiled.params).toContain(
@@ -94,6 +94,7 @@ describe("superseded repository generation retention", () => {
 
     expect(chunkDeletion!.sql).toContain("chunk.ctid AS row_id");
     expect(chunkDeletion!.sql).toContain("chunk.ctid = selected.row_id");
+    expect(chunkDeletion!.sql).not.toContain("ORDER BY chunk.id");
     expect(chunkDeletion!.params).toContain(GENERATION_GC_CHUNK_BATCH);
     expect(generationDeletion!.sql).toContain(
       "remaining_chunk.index_generation_id = generation.id",

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -31,21 +31,18 @@ describe("superseded repository generation retention", () => {
 
   it("compiles bounded deletion with every active-generation safety guard", async () => {
     const queries: SQL[] = [];
-    const execute = jest
-      .fn<(query: SQL) => Promise<Array<{ deleted_count: number }>>>(
-        async (query) => {
-          queries.push(query);
-          return [];
-        },
-      )
-      .mockImplementationOnce(async (query) => {
-        queries.push(query);
-        return [{ deleted_count: 20_000 }];
-      })
-      .mockImplementationOnce(async (query) => {
-        queries.push(query);
-        return [{ deleted_count: 17 }];
-      });
+    const responses: unknown[] = [
+      [],
+      [{ repository_id: 950 }],
+      [{ id: 1_001 }, { id: 1_300 }],
+      [{ deleted_count: 20_000 }],
+      [{ deleted_count: 17 }],
+      [],
+    ];
+    const execute = jest.fn<(query: SQL) => Promise<unknown>>(async (query) => {
+      queries.push(query);
+      return responses[queries.length - 1];
+    });
 
     mockExecuteTransaction.mockImplementationOnce(async (callback) =>
       callback({ execute } as never),
@@ -53,10 +50,6 @@ describe("superseded repository generation retention", () => {
 
     const now = new Date("2026-08-01T12:00:00.000Z");
     const repositoryBatchSize = 37;
-    const repositoryProbeAnchor = (
-      BigInt(Math.floor(now.getTime() / 60_000)) *
-      BigInt(repositoryBatchSize)
-    ).toString();
     await expect(
       collectSupersededRepositoryGenerations({ now, repositoryBatchSize }),
     ).resolves.toEqual({
@@ -64,10 +57,22 @@ describe("superseded repository generation retention", () => {
       generationsDeleted: 17,
     });
 
-    expect(queries).toHaveLength(2);
-    const [chunkDeletion, generationDeletion] = queries.map((query) =>
+    expect(queries).toHaveLength(6);
+    const compiledQueries = queries.map((query) =>
       new PgDialect().sqlToQuery(query),
     );
+    const [cursorInsert, cursorRead, repositoryProbe, chunkDeletion, generationDeletion, cursorUpdate] =
+      compiledQueries;
+    expect(cursorInsert?.sql).toContain("ON CONFLICT (key) DO NOTHING");
+    expect(cursorRead?.sql).toContain("FOR UPDATE");
+    expect(cursorRead?.params).toContain("REPOSITORY_GENERATION_GC_CURSOR");
+    expect(repositoryProbe?.sql).toContain("repository.id >");
+    expect(repositoryProbe?.sql).toContain("repository.id <=");
+    expect(repositoryProbe?.sql).toContain("ORDER BY probe.probe_segment, probe.id");
+    expect(repositoryProbe?.params).toContain(950);
+    expect(repositoryProbe?.params).toContain(repositoryBatchSize);
+    expect(cursorUpdate?.sql).toContain("UPDATE settings");
+    expect(cursorUpdate?.params).toContain("1300");
     expect(chunkDeletion).toBeDefined();
     expect(generationDeletion).toBeDefined();
 
@@ -78,12 +83,7 @@ describe("superseded repository generation retention", () => {
       );
       expect(compiled.sql).not.toContain("row_number() OVER");
       expect(compiled.sql).toContain("repository_probe_ids AS MATERIALIZED");
-      expect(compiled.sql).toContain(
-        "WHERE repository.id >= probe_start.id",
-      );
-      expect(compiled.sql).toContain(
-        "WHERE repository.id < probe_start.id",
-      );
+      expect(compiled.sql).toContain("WITH ORDINALITY AS probe");
       expect(compiled.sql).toContain("FROM repository_probe_ids probe");
       expect(compiled.sql).toContain("CROSS JOIN LATERAL");
       expect(compiled.sql).toContain(
@@ -120,8 +120,8 @@ describe("superseded repository generation retention", () => {
       expect(compiled.params).toContain(
         SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY - 1,
       );
-      expect(compiled.params).toContain(repositoryProbeAnchor);
-      expect(compiled.params).toContain(repositoryBatchSize);
+      expect(compiled.params).toContain(1_001);
+      expect(compiled.params).toContain(1_300);
       expect(compiled.params).toContain(GENERATION_GC_GENERATION_BATCH);
       expect(compiled.params).toContain(GENERATION_GC_PER_REPOSITORY_BATCH);
       expect(compiled.sql).not.toMatch(

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -14,6 +14,7 @@ import {
   collectSupersededRepositoryGenerations,
   GENERATION_GC_CHUNK_BATCH,
   GENERATION_GC_GENERATION_BATCH,
+  GENERATION_GC_PER_REPOSITORY_BATCH,
   GENERATION_GC_REPOSITORY_BATCH,
   SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY,
   SUPERSEDED_GENERATION_RETENTION_HOURS,
@@ -54,8 +55,7 @@ describe("superseded repository generation retention", () => {
     const repositoryBatchSize = 37;
     const repositoryProbeAnchor = (
       BigInt(Math.floor(now.getTime() / 60_000)) *
-      BigInt(repositoryBatchSize) *
-      104_729n
+      BigInt(repositoryBatchSize)
     ).toString();
     await expect(
       collectSupersededRepositoryGenerations({ now, repositoryBatchSize }),
@@ -122,6 +122,7 @@ describe("superseded repository generation retention", () => {
       expect(compiled.params).toContain(repositoryProbeAnchor);
       expect(compiled.params).toContain(repositoryBatchSize);
       expect(compiled.params).toContain(GENERATION_GC_GENERATION_BATCH);
+      expect(compiled.params).toContain(GENERATION_GC_PER_REPOSITORY_BATCH);
       expect(compiled.sql).not.toMatch(
         /generation\.status\s+(?:=|IN)\s*\(?\s*'(?:active|building)'/i,
       );
@@ -139,6 +140,7 @@ describe("superseded repository generation retention", () => {
     expect(GENERATION_GC_CHUNK_BATCH).toBe(20_000);
     expect(GENERATION_GC_REPOSITORY_BATCH).toBe(200);
     expect(GENERATION_GC_GENERATION_BATCH).toBe(200);
+    expect(GENERATION_GC_PER_REPOSITORY_BATCH).toBe(10);
   });
 
   it.each([
@@ -147,6 +149,10 @@ describe("superseded repository generation retention", () => {
     ["chunkBatchSize", { chunkBatchSize: 0 }],
     ["repositoryBatchSize", { repositoryBatchSize: 0 }],
     ["generationBatchSize", { generationBatchSize: 0 }],
+    [
+      "perRepositoryGenerationBatchSize",
+      { perRepositoryGenerationBatchSize: 0 },
+    ],
   ])("rejects an unsafe %s override", async (name, options) => {
     await expect(
       collectSupersededRepositoryGenerations(options),

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -73,26 +73,26 @@ describe("superseded repository generation retention", () => {
       generationDeletion,
       cursorUpdate,
     ] = compiledQueries;
-    expect(cursorInsert?.sql).toContain("ON CONFLICT (key) DO NOTHING");
-    expect(cursorRead?.sql).toContain("FOR UPDATE");
-    expect(cursorRead?.params).toContain("REPOSITORY_GENERATION_GC_CURSOR");
-    expect(repositoryProbe?.sql).toContain("repository.id >");
-    expect(repositoryProbe?.sql).toContain("repository.id <=");
-    expect(repositoryProbe?.sql).toContain("ORDER BY probe.probe_segment, probe.id");
-    expect(repositoryProbe?.params).toContain(950);
-    expect(repositoryProbe?.params).toContain(repositoryBatchSize);
-    expect(timestampBackfill?.sql).toContain(
+    expect(cursorInsert!.sql).toContain("ON CONFLICT (key) DO NOTHING");
+    expect(cursorRead!.sql).toContain("FOR UPDATE");
+    expect(cursorRead!.params).toContain("REPOSITORY_GENERATION_GC_CURSOR");
+    expect(repositoryProbe!.sql).toContain("repository.id >");
+    expect(repositoryProbe!.sql).toContain("repository.id <=");
+    expect(repositoryProbe!.sql).toContain("ORDER BY probe.probe_segment, probe.id");
+    expect(repositoryProbe!.params).toContain(950);
+    expect(repositoryProbe!.params).toContain(repositoryBatchSize);
+    expect(timestampBackfill!.sql).toContain(
       "generation.superseded_at IS NULL",
     );
-    expect(timestampBackfill?.sql).toContain(
+    expect(timestampBackfill!.sql).toContain(
       "FOR UPDATE OF generation SKIP LOCKED",
     );
-    expect(timestampBackfill?.sql).toContain(
+    expect(timestampBackfill!.sql).toContain(
       "SET superseded_at = clock_timestamp()",
     );
-    expect(timestampBackfill?.params).toContain(GENERATION_GC_TIMESTAMP_BATCH);
-    expect(cursorUpdate?.sql).toContain("UPDATE settings");
-    expect(cursorUpdate?.params).toContain("1300");
+    expect(timestampBackfill!.params).toContain(GENERATION_GC_TIMESTAMP_BATCH);
+    expect(cursorUpdate!.sql).toContain("UPDATE settings");
+    expect(cursorUpdate!.params).toContain("1300");
     expect(chunkDeletion).toBeDefined();
     expect(generationDeletion).toBeDefined();
 

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -65,26 +65,39 @@ describe("superseded repository generation retention", () => {
     expect(generationDeletion).toBeDefined();
 
     for (const compiled of [chunkDeletion!, generationDeletion!]) {
-      expect(compiled.sql).toContain("generation.status = 'superseded'");
-      expect(compiled.sql).toContain("row_number() OVER");
-      expect(compiled.sql).toContain("PARTITION BY generation.repository_id");
+      expect(compiled.sql).toContain("kept_generation.status = 'superseded'");
       expect(compiled.sql).toContain(
-        "ORDER BY generation.superseded_at DESC, generation.id DESC",
+        "candidate_generation.status = 'superseded'",
       );
-      expect(compiled.sql).toContain("generation.superseded_at <");
+      expect(compiled.sql).not.toContain("row_number() OVER");
+      expect(compiled.sql).toContain("CROSS JOIN LATERAL");
+      expect(compiled.sql).toContain(
+        "kept_generation.repository_id = repository.id",
+      );
+      expect(compiled.sql).toContain(
+        "ORDER BY kept_generation.superseded_at DESC, kept_generation.id DESC",
+      );
+      expect(compiled.sql).toContain("OFFSET");
+      expect(compiled.sql).toContain(
+        "(candidate_generation.superseded_at, candidate_generation.id) <",
+      );
+      expect(compiled.sql).toContain("candidate_generation.superseded_at <");
       expect(compiled.sql).not.toContain("generation.created_at <");
       expect(compiled.sql).toContain(
-        "generation.id IS DISTINCT FROM repository.active_index_generation_id",
+        "candidate_generation.id IS DISTINCT FROM repository.active_index_generation_id",
       );
       expect(compiled.sql).toContain(
-        "active_repository.active_index_generation_id = generation.id",
+        "active_repository.active_index_generation_id = candidate_generation.id",
       );
       expect(compiled.sql).toContain(
-        "FOR UPDATE OF generation, repository SKIP LOCKED",
+        "FOR UPDATE OF repository SKIP LOCKED",
+      );
+      expect(compiled.sql).toContain(
+        "FOR UPDATE OF candidate_generation SKIP LOCKED",
       );
       expect(compiled.params).toContain("2026-07-31T12:00:00.000Z");
       expect(compiled.params).toContain(
-        SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY,
+        SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY - 1,
       );
       expect(compiled.params).toContain(GENERATION_GC_GENERATION_BATCH);
       expect(compiled.sql).not.toMatch(

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -16,6 +16,7 @@ import {
   GENERATION_GC_GENERATION_BATCH,
   GENERATION_GC_PER_REPOSITORY_BATCH,
   GENERATION_GC_REPOSITORY_BATCH,
+  GENERATION_GC_TIMESTAMP_BATCH,
   SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY,
   SUPERSEDED_GENERATION_RETENTION_HOURS,
 } from "@/lib/repositories/content-platform/generation-retention";
@@ -35,8 +36,9 @@ describe("superseded repository generation retention", () => {
       [],
       [{ repository_id: 950 }],
       [{ id: 1_001 }, { id: 1_300 }],
-      [{ deleted_count: 20_000 }],
-      [{ deleted_count: 17 }],
+      [{ affected_count: 12 }],
+      [{ affected_count: 20_000 }],
+      [{ affected_count: 17 }],
       [],
     ];
     const execute = jest.fn<(query: SQL) => Promise<unknown>>(async (query) => {
@@ -53,16 +55,24 @@ describe("superseded repository generation retention", () => {
     await expect(
       collectSupersededRepositoryGenerations({ now, repositoryBatchSize }),
     ).resolves.toEqual({
+      generationsTimestamped: 12,
       chunksDeleted: 20_000,
       generationsDeleted: 17,
     });
 
-    expect(queries).toHaveLength(6);
+    expect(queries).toHaveLength(7);
     const compiledQueries = queries.map((query) =>
       new PgDialect().sqlToQuery(query),
     );
-    const [cursorInsert, cursorRead, repositoryProbe, chunkDeletion, generationDeletion, cursorUpdate] =
-      compiledQueries;
+    const [
+      cursorInsert,
+      cursorRead,
+      repositoryProbe,
+      timestampBackfill,
+      chunkDeletion,
+      generationDeletion,
+      cursorUpdate,
+    ] = compiledQueries;
     expect(cursorInsert?.sql).toContain("ON CONFLICT (key) DO NOTHING");
     expect(cursorRead?.sql).toContain("FOR UPDATE");
     expect(cursorRead?.params).toContain("REPOSITORY_GENERATION_GC_CURSOR");
@@ -71,6 +81,16 @@ describe("superseded repository generation retention", () => {
     expect(repositoryProbe?.sql).toContain("ORDER BY probe.probe_segment, probe.id");
     expect(repositoryProbe?.params).toContain(950);
     expect(repositoryProbe?.params).toContain(repositoryBatchSize);
+    expect(timestampBackfill?.sql).toContain(
+      "generation.superseded_at IS NULL",
+    );
+    expect(timestampBackfill?.sql).toContain(
+      "FOR UPDATE OF generation SKIP LOCKED",
+    );
+    expect(timestampBackfill?.sql).toContain(
+      "SET superseded_at = clock_timestamp()",
+    );
+    expect(timestampBackfill?.params).toContain(GENERATION_GC_TIMESTAMP_BATCH);
     expect(cursorUpdate?.sql).toContain("UPDATE settings");
     expect(cursorUpdate?.params).toContain("1300");
     expect(chunkDeletion).toBeDefined();
@@ -142,6 +162,7 @@ describe("superseded repository generation retention", () => {
     expect(GENERATION_GC_REPOSITORY_BATCH).toBe(200);
     expect(GENERATION_GC_GENERATION_BATCH).toBe(200);
     expect(GENERATION_GC_PER_REPOSITORY_BATCH).toBe(10);
+    expect(GENERATION_GC_TIMESTAMP_BATCH).toBe(200);
   });
 
   it.each([

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -52,6 +52,11 @@ describe("superseded repository generation retention", () => {
 
     const now = new Date("2026-08-01T12:00:00.000Z");
     const repositoryBatchSize = 37;
+    const repositoryProbeAnchor = (
+      BigInt(Math.floor(now.getTime() / 60_000)) *
+      BigInt(repositoryBatchSize) *
+      104_729n
+    ).toString();
     await expect(
       collectSupersededRepositoryGenerations({ now, repositoryBatchSize }),
     ).resolves.toEqual({
@@ -72,6 +77,14 @@ describe("superseded repository generation retention", () => {
         "candidate_generation.status = 'superseded'",
       );
       expect(compiled.sql).not.toContain("row_number() OVER");
+      expect(compiled.sql).toContain("repository_probe_ids AS MATERIALIZED");
+      expect(compiled.sql).toContain(
+        "WHERE repository.id >= probe_start.id",
+      );
+      expect(compiled.sql).toContain(
+        "WHERE repository.id < probe_start.id",
+      );
+      expect(compiled.sql).toContain("FROM repository_probe_ids probe");
       expect(compiled.sql).toContain("CROSS JOIN LATERAL");
       expect(compiled.sql).toContain(
         "kept_generation.repository_id = repository.id",
@@ -104,6 +117,7 @@ describe("superseded repository generation retention", () => {
       expect(compiled.params).toContain(
         SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY - 1,
       );
+      expect(compiled.params).toContain(repositoryProbeAnchor);
       expect(compiled.params).toContain(repositoryBatchSize);
       expect(compiled.params).toContain(GENERATION_GC_GENERATION_BATCH);
       expect(compiled.sql).not.toMatch(

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -97,6 +97,7 @@ describe("superseded repository generation retention", () => {
 
     for (const compiled of [chunkDeletion!, generationDeletion!]) {
       expect(compiled.sql).toContain("kept_generation.status = 'superseded'");
+      expect(compiled.sql).toContain("kept_generation.superseded_at IS NOT NULL");
       expect(compiled.sql).toContain(
         "candidate_generation.status = 'superseded'",
       );

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -1,0 +1,116 @@
+/** @jest-environment node */
+
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeTransaction: jest.fn(),
+  toPgRows: (rows: unknown) => rows,
+}));
+
+import { executeTransaction } from "@/lib/db/drizzle-client";
+import {
+  collectSupersededRepositoryGenerations,
+  GENERATION_GC_CHUNK_BATCH,
+  GENERATION_GC_GENERATION_BATCH,
+  SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY,
+  SUPERSEDED_GENERATION_RETENTION_HOURS,
+} from "@/lib/repositories/content-platform/generation-retention";
+
+const mockExecuteTransaction = executeTransaction as jest.MockedFunction<
+  typeof executeTransaction
+>;
+
+describe("superseded repository generation retention", () => {
+  beforeEach(() => {
+    mockExecuteTransaction.mockReset();
+  });
+
+  it("compiles bounded deletion with every active-generation safety guard", async () => {
+    const queries: SQL[] = [];
+    const execute = jest
+      .fn<(query: SQL) => Promise<Array<{ deleted_count: number }>>>(
+        async (query) => {
+          queries.push(query);
+          return [];
+        },
+      )
+      .mockImplementationOnce(async (query) => {
+        queries.push(query);
+        return [{ deleted_count: 20_000 }];
+      })
+      .mockImplementationOnce(async (query) => {
+        queries.push(query);
+        return [{ deleted_count: 17 }];
+      });
+
+    mockExecuteTransaction.mockImplementationOnce(async (callback) =>
+      callback({ execute } as never),
+    );
+
+    const now = new Date("2026-08-01T12:00:00.000Z");
+    await expect(
+      collectSupersededRepositoryGenerations({ now }),
+    ).resolves.toEqual({
+      chunksDeleted: 20_000,
+      generationsDeleted: 17,
+    });
+
+    expect(queries).toHaveLength(2);
+    const [chunkDeletion, generationDeletion] = queries.map((query) =>
+      new PgDialect().sqlToQuery(query),
+    );
+    expect(chunkDeletion).toBeDefined();
+    expect(generationDeletion).toBeDefined();
+
+    for (const compiled of [chunkDeletion!, generationDeletion!]) {
+      expect(compiled.sql).toContain("generation.status = 'superseded'");
+      expect(compiled.sql).toContain("row_number() OVER");
+      expect(compiled.sql).toContain("PARTITION BY generation.repository_id");
+      expect(compiled.sql).toContain(
+        "ORDER BY generation.created_at DESC, generation.id DESC",
+      );
+      expect(compiled.sql).toContain(
+        "generation.id IS DISTINCT FROM repository.active_index_generation_id",
+      );
+      expect(compiled.sql).toContain(
+        "active_repository.active_index_generation_id = generation.id",
+      );
+      expect(compiled.sql).toContain(
+        "FOR UPDATE OF generation SKIP LOCKED",
+      );
+      expect(compiled.params).toContain("2026-07-31T12:00:00.000Z");
+      expect(compiled.params).toContain(
+        SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY,
+      );
+      expect(compiled.params).toContain(GENERATION_GC_GENERATION_BATCH);
+      expect(compiled.sql).not.toMatch(
+        /generation\.status\s+(?:=|IN)\s*\(?\s*'(?:active|building)'/i,
+      );
+    }
+
+    expect(chunkDeletion!.sql).toContain("chunk.ctid AS row_id");
+    expect(chunkDeletion!.sql).toContain("chunk.ctid = selected.row_id");
+    expect(chunkDeletion!.params).toContain(GENERATION_GC_CHUNK_BATCH);
+    expect(generationDeletion!.sql).toContain(
+      "remaining_chunk.index_generation_id = generation.id",
+    );
+    expect(SUPERSEDED_GENERATION_RETENTION_HOURS).toBe(24);
+    expect(SUPERSEDED_GENERATION_KEEP_PER_REPOSITORY).toBe(3);
+    expect(GENERATION_GC_CHUNK_BATCH).toBe(20_000);
+    expect(GENERATION_GC_GENERATION_BATCH).toBe(200);
+  });
+
+  it.each([
+    ["retentionHours", { retentionHours: 0 }],
+    ["keepPerRepository", { keepPerRepository: 0 }],
+    ["chunkBatchSize", { chunkBatchSize: 0 }],
+    ["generationBatchSize", { generationBatchSize: 0 }],
+  ])("rejects an unsafe %s override", async (name, options) => {
+    await expect(
+      collectSupersededRepositoryGenerations(options),
+    ).rejects.toThrow(`${name} must be a positive integer`);
+    expect(mockExecuteTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-generation-retention.test.ts
@@ -90,12 +90,14 @@ describe("superseded repository generation retention", () => {
         "kept_generation.repository_id = repository.id",
       );
       expect(compiled.sql).toContain(
-        "ORDER BY kept_generation.superseded_at DESC, kept_generation.id DESC",
+        "ORDER BY kept_generation.superseded_at DESC,",
       );
+      expect(compiled.sql).toContain("kept_generation.created_at DESC");
       expect(compiled.sql).toContain("OFFSET");
       expect(compiled.sql).toContain(
-        "(candidate_generation.superseded_at, candidate_generation.id) <",
+        "candidate_generation.created_at,",
       );
+      expect(compiled.sql).toContain("keep_floor.created_at, keep_floor.id");
       expect(compiled.sql).toContain(
         "ORDER BY oldest_candidate.superseded_at",
       );

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -29,8 +29,8 @@ describe("migration 173 repository generation retention", () => {
     expect(migration).toContain(
       "ADD COLUMN IF NOT EXISTS superseded_at timestamptz",
     );
-    expect(migration).toContain("DEFAULT statement_timestamp()");
-    expect(migration).toContain("ALTER COLUMN superseded_at DROP DEFAULT");
+    expect(migration).not.toContain("DEFAULT statement_timestamp()");
+    expect(migration).not.toContain("ALTER COLUMN superseded_at DROP DEFAULT");
     expect(migration).toContain(
       "CREATE OR REPLACE TRIGGER trg_repository_index_generation_superseded_at",
     );
@@ -39,6 +39,9 @@ describe("migration 173 repository generation retention", () => {
     expect(migration).not.toContain("TG_OP = 'INSERT' OR OLD.status");
     expect(migration).toMatch(
       /CREATE INDEX IF NOT EXISTS\s+idx_repository_index_generations_superseded_retention/i,
+    );
+    expect(migration).toMatch(
+      /CREATE INDEX IF NOT EXISTS\s+idx_repository_index_generations_superseded_backfill/i,
     );
     expect(migration).toContain(
       "ON repository_index_generations (repository_id, superseded_at DESC, created_at DESC, id DESC)",
@@ -58,17 +61,12 @@ describe("migration 173 repository generation retention", () => {
     const triggerIndex = migration.indexOf(
       "CREATE OR REPLACE TRIGGER trg_repository_index_generation_superseded_at",
     );
-    const dropDefaultIndex = migration.indexOf(
-      "ALTER COLUMN superseded_at DROP DEFAULT",
-    );
-    const historicalBackfillIndex = migration.indexOf(
-      "SET superseded_at = clock_timestamp()",
-    );
     expect(addColumnIndex).toBeGreaterThanOrEqual(0);
     expect(triggerIndex).toBeGreaterThanOrEqual(0);
     expect(triggerIndex).toBeGreaterThan(addColumnIndex);
-    expect(dropDefaultIndex).toBeGreaterThan(triggerIndex);
-    expect(historicalBackfillIndex).toBeGreaterThan(triggerIndex);
+    expect(migration).not.toMatch(
+      /\nUPDATE repository_index_generations\s+SET superseded_at/,
+    );
     expect(migration).not.toMatch(
       /\nDROP TRIGGER IF EXISTS trg_repository_index_generation_superseded_at/,
     );

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -34,8 +34,8 @@ describe("migration 173 repository generation retention", () => {
     expect(migration).toContain(
       "CREATE TRIGGER trg_repository_index_generation_superseded_at",
     );
-    expect(migration).toContain("NEW.superseded_at = clock_timestamp()");
-    expect(migration).toContain("ELSIF TG_OP = 'INSERT' THEN");
+    expect(migration).toContain("NEW.superseded_at := clock_timestamp()");
+    expect(migration).toContain("ELSIF TG_OP = ''INSERT'' THEN");
     expect(migration).not.toContain("TG_OP = 'INSERT' OR OLD.status");
     expect(migration).toMatch(
       /CREATE INDEX IF NOT EXISTS\s+idx_repository_index_generations_superseded_retention/i,
@@ -43,6 +43,28 @@ describe("migration 173 repository generation retention", () => {
     expect(migration).toContain(
       "ON repository_index_generations (repository_id, superseded_at DESC, id DESC)",
     );
+    expect(migration).toMatch(
+      /CREATE INDEX IF NOT EXISTS\s+idx_knowledge_repositories_active_index_generation/i,
+    );
+    expect(migration).toContain(
+      "ON knowledge_repositories (active_index_generation_id)",
+    );
     expect(migration).toContain("WHERE status = 'superseded'");
+  });
+
+  it("encodes the trigger function for the production line-based SQL splitter", () => {
+    const functionLines = migration
+      .split("\n")
+      .filter((line) =>
+        line.startsWith(
+          "CREATE OR REPLACE FUNCTION set_repository_index_generation_superseded_at()",
+        ),
+      );
+
+    expect(functionLines).toHaveLength(1);
+    expect(functionLines[0]).toMatch(
+      /^CREATE OR REPLACE FUNCTION .+ RETURNS trigger AS '.+' LANGUAGE plpgsql;$/,
+    );
+    expect(migration).not.toContain("AS $$");
   });
 });

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -1,0 +1,37 @@
+/** @jest-environment node */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationName = "173-repository-index-generation-retention.sql";
+const migration = fs.readFileSync(
+  path.join(process.cwd(), "infra/database/schema", migrationName),
+  "utf8",
+);
+const manifest = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), "infra/database/migrations.json"),
+    "utf8",
+  ),
+) as { migrationFiles: string[] };
+
+describe("migration 173 repository generation retention", () => {
+  it("runs immediately after the previous migration head", () => {
+    const previousIndex = manifest.migrationFiles.indexOf(
+      "172-content-data-records.sql",
+    );
+
+    expect(previousIndex).toBeGreaterThanOrEqual(0);
+    expect(manifest.migrationFiles[previousIndex + 1]).toBe(migrationName);
+  });
+
+  it("adds the partial ordering index used by the bounded collector", () => {
+    expect(migration).toMatch(
+      /CREATE INDEX IF NOT EXISTS\s+idx_repository_index_generations_superseded_retention/i,
+    );
+    expect(migration).toContain(
+      "ON repository_index_generations (repository_id, created_at DESC, id DESC)",
+    );
+    expect(migration).toContain("WHERE status = 'superseded'");
+  });
+});

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -44,6 +44,9 @@ describe("migration 173 repository generation retention", () => {
       /CREATE INDEX IF NOT EXISTS\s+idx_repository_index_generations_superseded_backfill/i,
     );
     expect(migration).toContain(
+      "ON repository_index_generations (created_at, id)",
+    );
+    expect(migration).toContain(
       "ON repository_index_generations (repository_id, superseded_at DESC, created_at DESC, id DESC)",
     );
     expect(migration).toMatch(

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -50,6 +50,18 @@ describe("migration 173 repository generation retention", () => {
       "ON knowledge_repositories (active_index_generation_id)",
     );
     expect(migration).toContain("WHERE status = 'superseded'");
+
+    const triggerIndex = migration.indexOf(
+      "CREATE TRIGGER trg_repository_index_generation_superseded_at",
+    );
+    const finalBackfillIndex = migration.lastIndexOf(
+      "SET superseded_at = statement_timestamp()",
+    );
+    expect(triggerIndex).toBeGreaterThanOrEqual(0);
+    expect(finalBackfillIndex).toBeGreaterThan(triggerIndex);
+    expect(
+      migration.match(/SET superseded_at = statement_timestamp\(\)/g),
+    ).toHaveLength(2);
   });
 
   it("encodes the trigger function for the production line-based SQL splitter", () => {

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -5,12 +5,12 @@ import path from "node:path";
 
 const migrationName = "173-repository-index-generation-retention.sql";
 const migration = fs.readFileSync(
-  path.join(process.cwd(), "infra/database/schema", migrationName),
+  path.join(__dirname, "../../infra/database/schema", migrationName),
   "utf8",
 );
 const manifest = JSON.parse(
   fs.readFileSync(
-    path.join(process.cwd(), "infra/database/migrations.json"),
+    path.join(__dirname, "../../infra/database/migrations.json"),
     "utf8",
   ),
 ) as { migrationFiles: string[] };
@@ -25,12 +25,19 @@ describe("migration 173 repository generation retention", () => {
     expect(manifest.migrationFiles[previousIndex + 1]).toBe(migrationName);
   });
 
-  it("adds the partial ordering index used by the bounded collector", () => {
+  it("tracks supersession time and adds the collector ordering index", () => {
+    expect(migration).toContain(
+      "ADD COLUMN IF NOT EXISTS superseded_at timestamptz",
+    );
+    expect(migration).toContain(
+      "CREATE TRIGGER trg_repository_index_generation_superseded_at",
+    );
+    expect(migration).toContain("NEW.superseded_at = now()");
     expect(migration).toMatch(
       /CREATE INDEX IF NOT EXISTS\s+idx_repository_index_generations_superseded_retention/i,
     );
     expect(migration).toContain(
-      "ON repository_index_generations (repository_id, created_at DESC, id DESC)",
+      "ON repository_index_generations (repository_id, superseded_at DESC, id DESC)",
     );
     expect(migration).toContain("WHERE status = 'superseded'");
   });

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -32,7 +32,7 @@ describe("migration 173 repository generation retention", () => {
     expect(migration).toContain("DEFAULT statement_timestamp()");
     expect(migration).toContain("ALTER COLUMN superseded_at DROP DEFAULT");
     expect(migration).toContain(
-      "CREATE TRIGGER trg_repository_index_generation_superseded_at",
+      "CREATE OR REPLACE TRIGGER trg_repository_index_generation_superseded_at",
     );
     expect(migration).toContain("NEW.superseded_at := clock_timestamp()");
     expect(migration).toContain("ELSIF TG_OP = ''INSERT'' THEN");
@@ -50,18 +50,28 @@ describe("migration 173 repository generation retention", () => {
       "ON knowledge_repositories (active_index_generation_id)",
     );
     expect(migration).toContain("WHERE status = 'superseded'");
+    expect(migration).toContain("REPOSITORY_GENERATION_GC_CURSOR");
 
+    const addColumnIndex = migration.indexOf(
+      "ADD COLUMN IF NOT EXISTS superseded_at timestamptz",
+    );
     const triggerIndex = migration.indexOf(
-      "CREATE TRIGGER trg_repository_index_generation_superseded_at",
+      "CREATE OR REPLACE TRIGGER trg_repository_index_generation_superseded_at",
     );
-    const finalBackfillIndex = migration.lastIndexOf(
-      "SET superseded_at = statement_timestamp()",
+    const dropDefaultIndex = migration.indexOf(
+      "ALTER COLUMN superseded_at DROP DEFAULT",
     );
+    const historicalBackfillIndex = migration.indexOf(
+      "SET superseded_at = clock_timestamp()",
+    );
+    expect(addColumnIndex).toBeGreaterThanOrEqual(0);
     expect(triggerIndex).toBeGreaterThanOrEqual(0);
-    expect(finalBackfillIndex).toBeGreaterThan(triggerIndex);
-    expect(
-      migration.match(/SET superseded_at = statement_timestamp\(\)/g),
-    ).toHaveLength(2);
+    expect(triggerIndex).toBeGreaterThan(addColumnIndex);
+    expect(dropDefaultIndex).toBeGreaterThan(triggerIndex);
+    expect(historicalBackfillIndex).toBeGreaterThan(triggerIndex);
+    expect(migration).not.toMatch(
+      /\nDROP TRIGGER IF EXISTS trg_repository_index_generation_superseded_at/,
+    );
   });
 
   it("encodes the trigger function for the production line-based SQL splitter", () => {

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -41,7 +41,7 @@ describe("migration 173 repository generation retention", () => {
       /CREATE INDEX IF NOT EXISTS\s+idx_repository_index_generations_superseded_retention/i,
     );
     expect(migration).toContain(
-      "ON repository_index_generations (repository_id, superseded_at DESC, id DESC)",
+      "ON repository_index_generations (repository_id, superseded_at DESC, created_at DESC, id DESC)",
     );
     expect(migration).toMatch(
       /CREATE INDEX IF NOT EXISTS\s+idx_knowledge_repositories_active_index_generation/i,

--- a/tests/unit/repository-index-generation-retention-migration.test.ts
+++ b/tests/unit/repository-index-generation-retention-migration.test.ts
@@ -29,10 +29,14 @@ describe("migration 173 repository generation retention", () => {
     expect(migration).toContain(
       "ADD COLUMN IF NOT EXISTS superseded_at timestamptz",
     );
+    expect(migration).toContain("DEFAULT statement_timestamp()");
+    expect(migration).toContain("ALTER COLUMN superseded_at DROP DEFAULT");
     expect(migration).toContain(
       "CREATE TRIGGER trg_repository_index_generation_superseded_at",
     );
-    expect(migration).toContain("NEW.superseded_at = now()");
+    expect(migration).toContain("NEW.superseded_at = clock_timestamp()");
+    expect(migration).toContain("ELSIF TG_OP = 'INSERT' THEN");
+    expect(migration).not.toContain("TG_OP = 'INSERT' OR OLD.status");
     expect(migration).toMatch(
       /CREATE INDEX IF NOT EXISTS\s+idx_repository_index_generations_superseded_retention/i,
     );

--- a/tests/unit/repository-reliability-source-contracts.test.ts
+++ b/tests/unit/repository-reliability-source-contracts.test.ts
@@ -74,5 +74,11 @@ describe("repository reliability source contracts", () => {
     expect(embeddingWorker).toContain(
       "Acknowledging stale visual embedding work before provider call"
     );
+    expect(embeddingWorker).toContain(
+      "Skipping collected embedding generation"
+    );
+    expect(embeddingWorker).not.toContain(
+      "Index generation ${message.generationId} was not found"
+    );
   });
 });

--- a/tests/unit/unified-content-generation-retention-scheduling.test.ts
+++ b/tests/unit/unified-content-generation-retention-scheduling.test.ts
@@ -1,0 +1,30 @@
+/** @jest-environment node */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const runtimeSource = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    "infra/lambdas/unified-content-processor/index.ts",
+  ),
+  "utf8",
+);
+
+describe("unified-content generation retention scheduling", () => {
+  it("registers superseded-generation retention as the final maintenance task", () => {
+    const priorTask = runtimeSource.indexOf(
+      'name: "embedding-dlq-reconciliation"',
+    );
+    const retentionTask = runtimeSource.indexOf(
+      'name: "superseded-generation-retention"',
+    );
+    const taskListEnd = runtimeSource.indexOf("\n      ],", retentionTask);
+    const laterTask = runtimeSource.indexOf("name:", retentionTask + 1);
+
+    expect(priorTask).toBeGreaterThanOrEqual(0);
+    expect(retentionTask).toBeGreaterThan(priorTask);
+    expect(taskListEnd).toBeGreaterThan(retentionTask);
+    expect(laterTask === -1 || laterTask > taskListEnd).toBe(true);
+  });
+});

--- a/tests/unit/unified-content-generation-retention-scheduling.test.ts
+++ b/tests/unit/unified-content-generation-retention-scheduling.test.ts
@@ -5,8 +5,8 @@ import path from "node:path";
 
 const runtimeSource = fs.readFileSync(
   path.join(
-    process.cwd(),
-    "infra/lambdas/unified-content-processor/index.ts",
+    __dirname,
+    "../../infra/lambdas/unified-content-processor/index.ts",
   ),
   "utf8",
 );


### PR DESCRIPTION
## Summary

- add a bounded two-phase collector for superseded repository index generations
- retain the newest 3 superseded generations per repository and every generation superseded within the last 24 hours, using `created_at` before UUID as the deterministic legacy-backlog tie-break
- delete at most 20,000 chunks and 200 childless generations per invocation with `FOR UPDATE ... SKIP LOCKED`
- persist and lock an existing-repository keyset cursor, probing at most 200 live IDs per run with wraparound so sparse sequence gaps cannot starve later repositories
- backfill at most 200 legacy missing supersession timestamps per run oldest-first, with one statement timestamp per batch and a dedicated partial index; migration 173 performs no table-wide timestamp rewrite
- cap generation candidates at 10 per repository before the global 200-generation limit so one backlog cannot monopolize a run
- protect active pointers independently through status, owner-pointer, and indexed cross-repository pointer guards held stable for supported pointer updates
- treat embedding messages whose generation was already collected as stale completed work instead of retrying them into the DLQ
- run retention as the final isolated unified-content scheduled-maintenance task
- add migration 173, matching Drizzle schema, a repeatable PostgreSQL lifecycle smoke, and CI-run embedding handler coverage

## Safety and operational notes

The collector only targets `superseded` generations older than the retention window. Each invocation locks an internal cursor setting, selects the next bounded batch of existing repository IDs after that key, wraps at the end, and advances the cursor to the actual last selected ID in the same transaction. Sweep latency therefore depends on live repository count instead of numeric sequence gaps, and a caught-up run never scans the full repository table. Inside that bounded window the collector finds each repository keep-3 boundary with an indexed `OFFSET`/`LIMIT 1` probe, orders repositories by their oldest eligible generation, and takes at most 10 generations from any one repository. Because the per-repository lateral is materialized before the global trim, it may lock up to 2,000 generation rows (10 across each of 200 repositories), while both generation selection and deletion remain capped at 200. `created_at` breaks a tied `superseded_at`.

Existing superseded rows and any transition in the short add-column-to-trigger interval begin with a null timestamp. Before deletion, each scheduled run uses the partial null-timestamp index to lock and timestamp at most 200 such rows. Until a row is timestamped, it is excluded from both deletion candidates and keep-floor ranking, so mixed legacy/current state cannot displace one of the newest three timestamped generations. This starts a conservative full rollback window without a migration-wide update. Chunk rows are then deleted by a bounded `ctid` selection without a global backlog sort, and a generation is removed only after it is childless. Active, building, and failed generations are never deletion candidates. A well-formed embedding message for a missing generation is intentionally acknowledged with an info log: retention-collected work and a bogus missing ID are indistinguishable at that point, trading a DLQ signal for GC-safe stale-work handling.

Deleting these rows returns space to PostgreSQL heap free space for reuse. Autovacuum can reclaim it internally, but the Aurora volume will not shrink. `VACUUM FULL` remains an operator action outside this change.

## Migration

- adds nullable `repository_index_generations.superseded_at` without a default or data rewrite
- prepares the trigger function before adding the column, then installs the transition trigger as the next statement after `ADD COLUMN`, before any maintenance can run
- leaves historical missing timestamps for the bounded scheduled backfill, including any transition that raced trigger installation
- adds a partial `(created_at, id)` index for missing superseded timestamps, the retention index on `(repository_id, superseded_at DESC, created_at DESC, id DESC)`, and the active-pointer lookup index; all are mirrored in Drizzle
- seeds the internal repository-GC cursor setting without overwriting an existing checkpoint
- encodes the trigger function in the one-line, single-quoted form required by the production Data API SQL splitter
- registers migration 173 immediately after migration 172 in `infra/database/migrations.json`
- no destructive schema change

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test:ci -- --runInBand` — 560 suites passed, 1 skipped; 5,217 tests passed, 15 skipped
- `bun test infra/lambdas/embedding-generator/__tests__` — 20 passed, including full missing-generation handler acknowledgement
- focused retention, migration, scheduling, and embedding lifecycle tests
- `bun run build`
- `cd infra && bun run build` — embedding Lambda suite plus 17 agent-skill-builder tests passed
- `cd infra && bunx cdk synth --all --no-lookups --context baseDomain=example.com`
- unified-content and embedding Lambda artifact smokes
- `bun run migration:list` — migration 173 registered; next migration 174
- real PostgreSQL 16/pgvector validation after applying the complete migration chain — bounded legacy timestamp backfill, exact delete counts, retention floor, timestamp tie-breaking, active-pointer protection, trigger behavior, stale-work behavior, transaction-time supersession semantics, persisted sparse-safe repository probes, and per-repository generation caps, deterministic three-batch legacy ordering, mixed null/non-null keep-floor protection while decoys consume the backfill batch, and two consecutive bounded backlog batches passed
- GitHub CI repeats the real PostgreSQL lifecycle smoke in the `Unified Content PostgreSQL Lifecycle` job

Authenticated Playwright E2E was not applicable because this is scheduled backend maintenance with no UI or API behavior. The isolated worktree has no `.env.local` `AUTH_SECRET`, so the repository-supported one-push `SKIP_E2E=1` hook bypass was used after the full Jest, build, infrastructure, artifact, and PostgreSQL gates passed.

## Risk

The main risk is database maintenance load on large histories. Legacy timestamp backfill, repository discovery, keep-floor selection, per-repository generation contribution, and both deletion phases are bounded; candidate parents and their owning repository pointer rows are locked with `SKIP LOCKED`; the two eligibility queries share one SQL fragment; the checkpoint serializes concurrent collectors; and the task runs last so recovery and dispatch work completes first.

Closes #1527
Part of #1523

