### PR TITLE
feat(atrium): add authenticated artifact data bridge

### DIFF
--- a/app/(protected)/c/[slug]/page.tsx
+++ b/app/(protected)/c/[slug]/page.tsx
@@ -289,6 +289,8 @@ export default async function ReaderPage({
         <ArtifactSandbox
           code={code}
           src={getArtifactSandboxRenderUrl()}
+          dataBridgeEnabled={true}
+          contentId={published.id}
           className="atrium-artifact-reader-frame"
         />
       </ReaderFrame>

--- a/components/atrium/ArtifactSandbox.tsx
+++ b/components/atrium/ArtifactSandbox.tsx
@@ -87,8 +87,12 @@ const RENDER_RETRY_MS = 300;
 const RENDER_MAX_ATTEMPTS = 40;
 /** Keep a hostile artifact from queueing unbounded server-action work. */
 const MAX_IN_FLIGHT_DATA_REQUESTS = 8;
+const MAX_DATA_PAYLOAD_BYTES = 8 * 1024;
+const MAX_DATA_PAYLOAD_VALUES = 8_192;
+const MAX_DATA_PAYLOAD_STRING_CODE_UNITS = MAX_DATA_PAYLOAD_BYTES;
 /** One response for every bridge failure; never expose action or database detail. */
 const DATA_BRIDGE_ERROR_MESSAGE = "Artifact data request failed";
+const DATA_NAMESPACE_RE = /^[a-z0-9_-]{1,64}$/;
 const REQUEST_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -176,6 +180,96 @@ function isSubmitPayload(payload: unknown): payload is ArtifactDataPayload {
   return typeof payload === "object" && payload !== null && !Array.isArray(payload);
 }
 
+function isPlainJsonObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Bound parent-side work before Next serializes a payload for the Server Action.
+ * The action remains the authority and repeats its full validation; this mirror
+ * prevents an artifact from using the action transport itself as an oversized
+ * allocation/traffic amplifier.
+ */
+function hasBoundedJsonStructure(value: unknown): boolean {
+  type ValidationFrame =
+    | { kind: "value"; value: unknown }
+    | { kind: "leave"; value: object };
+
+  const pending: ValidationFrame[] = [{ kind: "value", value }];
+  const activePath = new WeakSet<object>();
+  let discoveredValues = 1;
+  let discoveredStringCodeUnits = 0;
+
+  const countString = (next: string): void => {
+    discoveredStringCodeUnits += next.length;
+    if (discoveredStringCodeUnits > MAX_DATA_PAYLOAD_STRING_CODE_UNITS) {
+      throw new Error("payload string bound exceeded");
+    }
+  };
+  const enqueue = (next: unknown): void => {
+    discoveredValues += 1;
+    if (discoveredValues > MAX_DATA_PAYLOAD_VALUES) {
+      throw new Error("payload value bound exceeded");
+    }
+    pending.push({ kind: "value", value: next });
+  };
+  const enterContainer = (next: object): void => {
+    if (activePath.has(next)) throw new Error("payload cycle");
+    activePath.add(next);
+    pending.push({ kind: "leave", value: next });
+  };
+
+  try {
+    while (pending.length > 0) {
+      const frame = pending.pop()!;
+      if (frame.kind === "leave") {
+        activePath.delete(frame.value);
+        continue;
+      }
+
+      const current = frame.value;
+      if (current === null || typeof current === "boolean") continue;
+      if (typeof current === "string") {
+        countString(current);
+        continue;
+      }
+      if (typeof current === "number" && Number.isFinite(current)) continue;
+      if (typeof current !== "object") return false;
+
+      if (Array.isArray(current)) {
+        enterContainer(current);
+        for (const item of current) enqueue(item);
+        continue;
+      }
+
+      if (!isPlainJsonObject(current)) return false;
+      enterContainer(current);
+      const record = current as Record<string, unknown>;
+      for (const key in record) {
+        if (Object.prototype.hasOwnProperty.call(record, key)) {
+          countString(key);
+          enqueue(record[key]);
+        }
+      }
+    }
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function isPayloadWithinBridgeBounds(payload: ArtifactDataPayload): boolean {
+  if (!hasBoundedJsonStructure(payload)) return false;
+  try {
+    const serialized = JSON.stringify(payload);
+    if (!serialized || serialized.length > MAX_DATA_PAYLOAD_BYTES) return false;
+    return new TextEncoder().encode(serialized).byteLength <= MAX_DATA_PAYLOAD_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 function hasValidListOptions(candidate: Record<string, unknown>): boolean {
   const validLimit =
     candidate.limit === undefined ||
@@ -249,6 +343,9 @@ function useArtifactDataBridge({
       if (
         !dataBridgeEnabled ||
         !contentId ||
+        !DATA_NAMESPACE_RE.test(request.namespace) ||
+        (request.op === "submit" &&
+          !isPayloadWithinBridgeBounds(request.payload)) ||
         inFlightDataRequestsRef.current >= MAX_IN_FLIGHT_DATA_REQUESTS
       ) {
         frameWindow.postMessage(dataBridgeFailure(request.requestId), "*");

--- a/components/atrium/ArtifactSandbox.tsx
+++ b/components/atrium/ArtifactSandbox.tsx
@@ -34,6 +34,14 @@
  *   message would be silently dropped). Authentication is inverted: the host page
  *   accepts the message only from an allowlisted `event.origin`. The payload is
  *   the untrusted code itself, so `"*"` leaks no app secret. See `postCode` below.
+ * - The reverse-direction artifact data bridge accepts requests only when
+ *   `event.source === iframeRef.current?.contentWindow`. Opaque-origin frames
+ *   report `event.origin === "null"`, so origin is deliberately NOT the bridge
+ *   authenticator. The trusted `contentId` comes only from this component's
+ *   props; any similarly named request field is ignored. Only authenticated
+ *   callers explicitly enable the bridge, work is bounded per frame, and every
+ *   failure returned to artifact code uses the same generic message. Responses
+ *   also require `targetOrigin: "*"` because the receiving frame is opaque-origin.
  *
  * When the sandbox origin is not configured (or, defensively, resolves to the
  * app origin) the component fails CLOSED — it renders an "unavailable" notice
@@ -47,6 +55,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { normalizeOrigin } from "@/lib/content/artifact-sandbox-config";
+import type { ArtifactDataPayload } from "@/lib/db/types/jsonb";
 
 type FrameLoadStatus = "loading" | "loaded" | "error";
 /**
@@ -76,8 +85,14 @@ const RENDER_RETRY_MS = 300;
  * failure notice rather than a perpetual "Waiting for artifact…".
  */
 const RENDER_MAX_ATTEMPTS = 40;
+/** Keep a hostile artifact from queueing unbounded server-action work. */
+const MAX_IN_FLIGHT_DATA_REQUESTS = 8;
+/** One response for every bridge failure; never expose action or database detail. */
+const DATA_BRIDGE_ERROR_MESSAGE = "Artifact data request failed";
+const REQUEST_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export interface ArtifactSandboxProps {
+interface ArtifactSandboxBaseProps {
   /**
    * The untrusted artifact code (HTML/JS). It is sent to the cross-origin host
    * via postMessage and never touches the app-origin DOM.
@@ -98,11 +113,55 @@ export interface ArtifactSandboxProps {
   className?: string;
 }
 
+/**
+ * The bridge is absent unless a trusted caller deliberately enables it and
+ * supplies the content identity. The disabled variant cannot carry a contentId,
+ * which keeps anonymous/public-reader wiring fail-closed at the type boundary.
+ */
+export type ArtifactSandboxProps = ArtifactSandboxBaseProps &
+  (
+    | { dataBridgeEnabled: true; contentId: string }
+    | { dataBridgeEnabled?: false; contentId?: never }
+  );
+
 interface RenderAck {
   type: "atrium-artifact-rendered";
   ok: boolean;
   error?: string;
 }
+
+interface SubmitDataRequest {
+  type: "atrium-artifact-data-request";
+  requestId: string;
+  op: "submit";
+  namespace: string;
+  payload: ArtifactDataPayload;
+}
+
+interface ListDataRequest {
+  type: "atrium-artifact-data-request";
+  requestId: string;
+  op: "list";
+  namespace: string;
+  limit?: number;
+  scope?: "all" | "mine";
+}
+
+type ArtifactDataRequest = SubmitDataRequest | ListDataRequest;
+
+type ArtifactDataResponse =
+  | {
+      type: "atrium-artifact-data-response";
+      requestId: string;
+      ok: true;
+      data: unknown;
+    }
+  | {
+      type: "atrium-artifact-data-response";
+      requestId: string;
+      ok: false;
+      error: string;
+    };
 
 /** Narrow an unknown postMessage payload to the host's render acknowledgement. */
 function isRenderAck(data: unknown): data is RenderAck {
@@ -111,6 +170,157 @@ function isRenderAck(data: unknown): data is RenderAck {
     data !== null &&
     (data as { type?: unknown }).type === "atrium-artifact-rendered"
   );
+}
+
+function isSubmitPayload(payload: unknown): payload is ArtifactDataPayload {
+  return typeof payload === "object" && payload !== null && !Array.isArray(payload);
+}
+
+function hasValidListOptions(candidate: Record<string, unknown>): boolean {
+  const validLimit =
+    candidate.limit === undefined ||
+    (typeof candidate.limit === "number" && Number.isFinite(candidate.limit));
+  const validScope =
+    candidate.scope === undefined ||
+    candidate.scope === "all" ||
+    candidate.scope === "mine";
+  return validLimit && validScope;
+}
+
+/** Narrow an unknown payload to the two artifact data request operations. */
+function isArtifactDataRequest(data: unknown): data is ArtifactDataRequest {
+  if (typeof data !== "object" || data === null) return false;
+
+  const candidate = data as Record<string, unknown>;
+  if (
+    candidate.type !== "atrium-artifact-data-request" ||
+    typeof candidate.requestId !== "string" ||
+    !REQUEST_ID_RE.test(candidate.requestId) ||
+    typeof candidate.namespace !== "string"
+  ) {
+    return false;
+  }
+
+  if (candidate.op === "submit") {
+    return isSubmitPayload(candidate.payload);
+  }
+
+  if (candidate.op === "list") {
+    return hasValidListOptions(candidate);
+  }
+
+  return false;
+}
+
+function dataBridgeFailure(requestId: string): ArtifactDataResponse {
+  return {
+    type: "atrium-artifact-data-response",
+    requestId,
+    ok: false,
+    error: DATA_BRIDGE_ERROR_MESSAGE,
+  };
+}
+
+interface ArtifactDataBridgeOptions {
+  iframeRef: React.RefObject<HTMLIFrameElement | null>;
+  origin: string | null;
+  dataBridgeEnabled: boolean;
+  contentId?: string;
+}
+
+/** Install the source-authenticated, bounded artifact data request listener. */
+function useArtifactDataBridge({
+  iframeRef,
+  origin,
+  dataBridgeEnabled,
+  contentId,
+}: ArtifactDataBridgeOptions): void {
+  const inFlightDataRequestsRef = useRef(0);
+
+  /**
+   * Execute one source-authenticated bridge request. `contentId` is constructed
+   * exclusively from trusted props; request fields are copied individually, so
+   * an artifact-supplied `contentId` (or any other extra field) cannot override
+   * the authority boundary. Action failures and thrown errors collapse to the
+   * same generic response.
+   */
+  const handleDataRequest = useCallback(
+    async (request: ArtifactDataRequest, frameWindow: Window): Promise<void> => {
+      if (
+        !dataBridgeEnabled ||
+        !contentId ||
+        inFlightDataRequestsRef.current >= MAX_IN_FLIGHT_DATA_REQUESTS
+      ) {
+        frameWindow.postMessage(dataBridgeFailure(request.requestId), "*");
+        return;
+      }
+
+      inFlightDataRequestsRef.current += 1;
+      let response: ArtifactDataResponse;
+      try {
+        // Keep the server-only action graph out of fail-closed/preview-only
+        // clients. Next resolves this `use server` module to action references
+        // when an enabled bridge request reaches the authenticated parent.
+        const { listArtifactRecords, submitArtifactRecord } = await import(
+          "@/actions/db/atrium/artifact-data"
+        );
+        if (request.op === "submit") {
+          const result = await submitArtifactRecord({
+            contentId,
+            namespace: request.namespace,
+            payload: request.payload,
+          });
+          response = result.isSuccess
+            ? {
+                type: "atrium-artifact-data-response",
+                requestId: request.requestId,
+                ok: true,
+                data: result.data,
+              }
+            : dataBridgeFailure(request.requestId);
+        } else {
+          const result = await listArtifactRecords({
+            contentId,
+            namespace: request.namespace,
+            limit: request.limit,
+            scope: request.scope,
+          });
+          response = result.isSuccess
+            ? {
+                type: "atrium-artifact-data-response",
+                requestId: request.requestId,
+                ok: true,
+                data: result.data,
+              }
+            : dataBridgeFailure(request.requestId);
+        }
+      } catch {
+        response = dataBridgeFailure(request.requestId);
+      } finally {
+        inFlightDataRequestsRef.current -= 1;
+      }
+
+      // The authenticated receiver is an opaque-origin WindowProxy. As with
+      // postCode, a concrete targetOrigin would silently discard the response.
+      frameWindow.postMessage(response, "*");
+    },
+    [contentId, dataBridgeEnabled]
+  );
+
+  useEffect(() => {
+    if (!origin) return;
+    const onDataMessage = (event: MessageEvent) => {
+      const frameWindow = iframeRef.current?.contentWindow;
+      // This browser-assigned WindowProxy identity is the bridge's sender
+      // authentication. event.origin is intentionally not consulted: a real
+      // `sandbox="allow-scripts"` frame has the opaque serialized origin "null".
+      if (!frameWindow || event.source !== frameWindow) return;
+      if (!isArtifactDataRequest(event.data)) return;
+      void handleDataRequest(event.data, frameWindow);
+    };
+    window.addEventListener("message", onDataMessage);
+    return () => window.removeEventListener("message", onDataMessage);
+  }, [handleDataRequest, iframeRef, origin]);
 }
 
 /** Shared look for the two non-executable notices (unavailable / frame error). */
@@ -132,6 +342,8 @@ export function ArtifactSandbox({
   src = null,
   title = "Artifact preview",
   className,
+  dataBridgeEnabled = false,
+  contentId,
 }: ArtifactSandboxProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   // The render URL is resolved server-side and arrives via `src`. Derive the
@@ -155,6 +367,12 @@ export function ArtifactSandbox({
   // being re-created on every render (the setInterval closure would otherwise see
   // a stale `renderStatus`).
   const renderedRef = useRef(false);
+  useArtifactDataBridge({
+    iframeRef,
+    origin,
+    dataBridgeEnabled,
+    contentId,
+  });
 
   /**
    * Post the current code to the framed host. Reads `code` and `origin` via

--- a/tests/unit/atrium-artifact-data-bridge.test.tsx
+++ b/tests/unit/atrium-artifact-data-bridge.test.tsx
@@ -207,6 +207,29 @@ describe("ArtifactSandbox artifact data bridge", () => {
 });
 
 describe("ArtifactSandbox artifact data bridge failure controls", () => {
+  it("rejects an oversized payload before invoking or serializing a Server Action", async () => {
+    const { frameWindow, postMessage } = mountSandbox(true);
+    const request = {
+      ...submitRequest(REQUEST_IDS[0]),
+      payload: { value: "x".repeat(8 * 1024 + 1) },
+    };
+
+    await sendMessage(request, frameWindow);
+
+    expect(submitArtifactRecordMock).not.toHaveBeenCalled();
+    expect(dataResponses(postMessage)).toEqual([
+      {
+        message: {
+          type: "atrium-artifact-data-response",
+          requestId: REQUEST_IDS[0],
+          ok: false,
+          error: "Artifact data request failed",
+        },
+        targetOrigin: "*",
+      },
+    ]);
+  });
+
   it("refuses every request when disabled and never invokes either action", async () => {
     const { frameWindow, postMessage } = mountSandbox(false);
 

--- a/tests/unit/atrium-artifact-data-bridge.test.tsx
+++ b/tests/unit/atrium-artifact-data-bridge.test.tsx
@@ -1,0 +1,328 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+const submitArtifactRecordMock = jest.fn();
+const listArtifactRecordsMock = jest.fn();
+
+jest.mock("@/actions/db/atrium/artifact-data", () => ({
+  submitArtifactRecord: (...args: unknown[]) =>
+    submitArtifactRecordMock(...args),
+  listArtifactRecords: (...args: unknown[]) => listArtifactRecordsMock(...args),
+}));
+
+import { ArtifactSandbox } from "@/components/atrium/ArtifactSandbox";
+
+const SANDBOX_SRC = "https://sandbox.example.test/render";
+const TRUSTED_CONTENT_ID = "trusted-content-id";
+const REQUEST_IDS = [
+  "00000000-0000-4000-8000-000000000001",
+  "00000000-0000-4000-8000-000000000002",
+  "00000000-0000-4000-8000-000000000003",
+  "00000000-0000-4000-8000-000000000004",
+  "00000000-0000-4000-8000-000000000005",
+  "00000000-0000-4000-8000-000000000006",
+  "00000000-0000-4000-8000-000000000007",
+  "00000000-0000-4000-8000-000000000008",
+  "00000000-0000-4000-8000-000000000009",
+] as const;
+
+interface PostedDataResponse {
+  message: Record<string, unknown>;
+  targetOrigin: unknown;
+}
+
+function isDataResponse(message: unknown): message is Record<string, unknown> {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    (message as { type?: unknown }).type ===
+      "atrium-artifact-data-response"
+  );
+}
+
+function dataResponses(postMessage: jest.Mock): PostedDataResponse[] {
+  const calls = postMessage.mock.calls as Array<
+    [message: unknown, targetOrigin: unknown]
+  >;
+  return calls.flatMap(([message, targetOrigin]) =>
+    isDataResponse(message) ? [{ message, targetOrigin }] : []
+  );
+}
+
+function mountSandbox(enabled: boolean): {
+  frameWindow: Window;
+  postMessage: jest.Mock;
+} {
+  if (enabled) {
+    render(
+      <ArtifactSandbox
+        code="<p>artifact</p>"
+        src={SANDBOX_SRC}
+        dataBridgeEnabled={true}
+        contentId={TRUSTED_CONTENT_ID}
+      />
+    );
+  } else {
+    // This is the public-reader shape: the enabling prop and contentId are both
+    // structurally absent.
+    render(<ArtifactSandbox code="<p>artifact</p>" src={SANDBOX_SRC} />);
+  }
+
+  const frame = screen.getByTestId(
+    "artifact-sandbox-frame"
+  ) as HTMLIFrameElement;
+  const frameWindow = frame.contentWindow;
+  if (!frameWindow) throw new Error("test iframe has no contentWindow");
+
+  const postMessage = jest.fn();
+  Object.defineProperty(frameWindow, "postMessage", {
+    configurable: true,
+    value: postMessage,
+  });
+  return { frameWindow, postMessage };
+}
+
+async function sendMessage(
+  data: unknown,
+  source: MessageEventSource | null,
+  origin = "null"
+): Promise<void> {
+  await act(async () => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data,
+        origin,
+        source,
+      })
+    );
+    await Promise.resolve();
+  });
+}
+
+function submitRequest(requestId: string): Record<string, unknown> {
+  return {
+    type: "atrium-artifact-data-request",
+    requestId,
+    op: "submit",
+    namespace: "leaderboard",
+    payload: { score: 42 },
+  };
+}
+
+beforeEach(() => {
+  submitArtifactRecordMock.mockReset().mockResolvedValue({
+    isSuccess: true,
+    message: "Artifact record submitted",
+    data: { id: "record-1", createdAt: "2026-08-02T00:00:00.000Z" },
+  });
+  listArtifactRecordsMock.mockReset().mockResolvedValue({
+    isSuccess: true,
+    message: "Artifact records listed",
+    data: { records: [] },
+  });
+});
+
+describe("ArtifactSandbox artifact data bridge", () => {
+  it("ignores a data request whose event.source is not this frame", async () => {
+    const { postMessage } = mountSandbox(true);
+
+    await sendMessage(submitRequest(REQUEST_IDS[0]), window);
+
+    expect(submitArtifactRecordMock).not.toHaveBeenCalled();
+    expect(dataResponses(postMessage)).toEqual([]);
+  });
+
+  it("uses the trusted prop contentId, correlates requestId, and responds to the opaque frame with '*'", async () => {
+    const { frameWindow, postMessage } = mountSandbox(true);
+    const request = {
+      ...submitRequest(REQUEST_IDS[0]),
+      contentId: "attacker-controlled-content-id",
+    };
+
+    await sendMessage(request, frameWindow);
+
+    expect(submitArtifactRecordMock).toHaveBeenCalledWith({
+      contentId: TRUSTED_CONTENT_ID,
+      namespace: "leaderboard",
+      payload: { score: 42 },
+    });
+    expect(dataResponses(postMessage)).toEqual([
+      {
+        message: {
+          type: "atrium-artifact-data-response",
+          requestId: REQUEST_IDS[0],
+          ok: true,
+          data: {
+            id: "record-1",
+            createdAt: "2026-08-02T00:00:00.000Z",
+          },
+        },
+        targetOrigin: "*",
+      },
+    ]);
+  });
+
+  it("drops a request with no requestId without invoking an action or responding", async () => {
+    const { frameWindow, postMessage } = mountSandbox(true);
+    const request = submitRequest(REQUEST_IDS[0]);
+    delete request.requestId;
+
+    await sendMessage(request, frameWindow);
+
+    expect(submitArtifactRecordMock).not.toHaveBeenCalled();
+    expect(dataResponses(postMessage)).toEqual([]);
+  });
+
+  it("maps list requests and does not use event.origin as sender authentication", async () => {
+    const { frameWindow, postMessage } = mountSandbox(true);
+
+    await sendMessage(
+      {
+        type: "atrium-artifact-data-request",
+        requestId: REQUEST_IDS[1],
+        op: "list",
+        namespace: "leaderboard",
+        limit: 25,
+        scope: "mine",
+      },
+      frameWindow,
+      "https://origin-is-not-the-authenticator.example"
+    );
+
+    expect(listArtifactRecordsMock).toHaveBeenCalledWith({
+      contentId: TRUSTED_CONTENT_ID,
+      namespace: "leaderboard",
+      limit: 25,
+      scope: "mine",
+    });
+    expect(dataResponses(postMessage)[0]).toEqual({
+      message: {
+        type: "atrium-artifact-data-response",
+        requestId: REQUEST_IDS[1],
+        ok: true,
+        data: { records: [] },
+      },
+      targetOrigin: "*",
+    });
+  });
+});
+
+describe("ArtifactSandbox artifact data bridge failure controls", () => {
+  it("refuses every request when disabled and never invokes either action", async () => {
+    const { frameWindow, postMessage } = mountSandbox(false);
+
+    await sendMessage(submitRequest(REQUEST_IDS[0]), frameWindow);
+    await sendMessage(
+      {
+        type: "atrium-artifact-data-request",
+        requestId: REQUEST_IDS[1],
+        op: "list",
+        namespace: "leaderboard",
+      },
+      frameWindow
+    );
+
+    expect(submitArtifactRecordMock).not.toHaveBeenCalled();
+    expect(listArtifactRecordsMock).not.toHaveBeenCalled();
+    expect(dataResponses(postMessage)).toEqual([
+      {
+        message: {
+          type: "atrium-artifact-data-response",
+          requestId: REQUEST_IDS[0],
+          ok: false,
+          error: "Artifact data request failed",
+        },
+        targetOrigin: "*",
+      },
+      {
+        message: {
+          type: "atrium-artifact-data-response",
+          requestId: REQUEST_IDS[1],
+          ok: false,
+          error: "Artifact data request failed",
+        },
+        targetOrigin: "*",
+      },
+    ]);
+  });
+
+  it("returns a generic failure without leaking the underlying action message", async () => {
+    const { frameWindow, postMessage } = mountSandbox(true);
+    submitArtifactRecordMock.mockResolvedValueOnce({
+      isSuccess: false,
+      message: "relation content_data_records missing for private-content-id",
+      error: new Error("database host db.internal.example refused connection"),
+    });
+
+    await sendMessage(submitRequest(REQUEST_IDS[0]), frameWindow);
+
+    const [response] = dataResponses(postMessage);
+    expect(response).toEqual({
+      message: {
+        type: "atrium-artifact-data-response",
+        requestId: REQUEST_IDS[0],
+        ok: false,
+        error: "Artifact data request failed",
+      },
+      targetOrigin: "*",
+    });
+    expect(JSON.stringify(response)).not.toMatch(
+      /content_data_records|private-content-id|db\.internal/i
+    );
+  });
+
+  it("bounds in-flight action work per frame", async () => {
+    const { frameWindow, postMessage } = mountSandbox(true);
+    type SubmitSuccess = {
+      isSuccess: true;
+      message: string;
+      data: { id: string; createdAt: string };
+    };
+    const resolvers: Array<(result: SubmitSuccess) => void> = [];
+    submitArtifactRecordMock.mockImplementation(
+      () =>
+        new Promise<SubmitSuccess>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    await act(async () => {
+      for (const requestId of REQUEST_IDS) {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: submitRequest(requestId),
+            origin: "null",
+            source: frameWindow,
+          })
+        );
+      }
+    });
+
+    expect(submitArtifactRecordMock).toHaveBeenCalledTimes(8);
+    expect(dataResponses(postMessage)).toContainEqual({
+      message: {
+        type: "atrium-artifact-data-response",
+        requestId: REQUEST_IDS[8],
+        ok: false,
+        error: "Artifact data request failed",
+      },
+      targetOrigin: "*",
+    });
+
+    await act(async () => {
+      let index = 0;
+      for (const resolve of resolvers) {
+        resolve({
+          isSuccess: true,
+          message: "ok",
+          data: {
+            id: `record-${index}`,
+            createdAt: "2026-08-02T00:00:00.000Z",
+          },
+        });
+        index += 1;
+      }
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(dataResponses(postMessage)).toHaveLength(9));
+  });
+});

--- a/tests/unit/atrium-public-reader-page.test.tsx
+++ b/tests/unit/atrium-public-reader-page.test.tsx
@@ -78,6 +78,7 @@ jest.mock("@/lib/content/version-service", () => ({
   versionService: {
     getById: (...a: unknown[]) => getByIdMock(...a),
     loadArtifactCode: (...a: unknown[]) => loadArtifactCodeMock(...a),
+    loadArtifactCodeSafe: (...a: unknown[]) => loadArtifactCodeMock(...a),
   },
 }));
 
@@ -205,6 +206,22 @@ describe("Atrium public reader page — anonymous 404 masking", () => {
     expect(mockNotFound).not.toHaveBeenCalled();
     expect(getByIdMock).toHaveBeenCalledWith("obj-1", "ver-1");
     expect(result).toBeTruthy();
+  });
+
+  it("omits the data bridge capability from the anonymous artifact reader wiring", async () => {
+    executeQueryMock.mockResolvedValueOnce([
+      { ...PUBLIC_OBJ, kind: "artifact" },
+    ]);
+    executeQueryMock.mockResolvedValueOnce([PUBLICATION_ROW]);
+    getByIdMock.mockResolvedValue({ objectId: "obj-1", versionNumber: 3 });
+    loadArtifactCodeMock.mockResolvedValue("<p>public artifact</p>");
+
+    const result = await render("public-artifact-slug");
+    const child = (result as { props: { children: React.ReactElement } }).props
+      .children;
+
+    expect(child.props).not.toHaveProperty("dataBridgeEnabled");
+    expect(child.props).not.toHaveProperty("contentId");
   });
 
   it("404s when the published version no longer exists (dangling publication)", async () => {

--- a/tests/unit/atrium-reader-page-masking.test.tsx
+++ b/tests/unit/atrium-reader-page-masking.test.tsx
@@ -74,6 +74,7 @@ jest.mock("@/lib/content/version-service", () => ({
   versionService: {
     getById: (...a: unknown[]) => getByIdMock(...a),
     loadArtifactCode: (...a: unknown[]) => loadArtifactCodeMock(...a),
+    loadArtifactCodeSafe: (...a: unknown[]) => loadArtifactCodeMock(...a),
   },
 }));
 
@@ -206,6 +207,27 @@ describe("Atrium reader page — 404 existence masking", () => {
     expect(mockNotFound).not.toHaveBeenCalled();
     expect(getByIdMock).toHaveBeenCalledWith("obj-1", "ver-1");
     expect(result).toBeTruthy();
+  });
+
+  it("enables the data bridge with the trusted object id for an authenticated artifact reader", async () => {
+    withLookups({ ...OBJ_ROW, kind: "artifact" }, PUBLICATION_ROW);
+    canViewMock.mockResolvedValue(true);
+    getByIdMock.mockResolvedValue({
+      objectId: "obj-1",
+      versionNumber: 3,
+    });
+    loadArtifactCodeMock.mockResolvedValue("<p>artifact</p>");
+
+    const result = await render("artifact-slug");
+    const child = (result as { props: { children: React.ReactElement } }).props
+      .children;
+
+    expect(child.props).toEqual(
+      expect.objectContaining({
+        dataBridgeEnabled: true,
+        contentId: "obj-1",
+      })
+    );
   });
 
   it("404s when the published version no longer exists (dangling publication)", async () => {


### PR DESCRIPTION
## Summary

Implements the security-critical parent-side Atrium artifact data bridge from #1518 on top of the merged server actions in #1537.

- Authenticates every request with exact `event.source === iframe.contentWindow` identity and deliberately does not use opaque `event.origin` as authentication.
- Constructs action inputs field-by-field with `contentId` only from trusted component props, requires UUID-shaped `requestId` correlation, and caps each frame at eight in-flight actions.
- Sends opaque-origin responses with `targetOrigin: "*"` and collapses disabled, bounded, thrown, and returned action failures to one generic error.
- Enables the capability only from authenticated `/c/[slug]` artifact reader wiring. Anonymous `/p/[slug]` omits both enabling props, and the component refuses requests without invoking either action.
- Leaves the existing render-ack listener and retry protocol unchanged.

## Verification

- `bunx jest tests/unit/atrium-artifact-data-bridge.test.tsx tests/unit/atrium-reader-page-masking.test.tsx tests/unit/atrium-public-reader-page.test.tsx --runInBand` — PASS on final head, 3 suites / 30 tests.
- `bun run tests/smoke/atrium-artifact-sandbox-component.smoke.ts` — PASS, 4 checks, including unchanged per-frame opaque-origin render-ack behavior.
- `bun run lint` — PASS on final head, zero warnings.
- `bun run typecheck` — the local root install is blocked by unchanged nested agent-router dependency skew (`@aws-sdk/client-ecs`, `@googleapis/chat`, and duplicated Smithy types). GitHub Actions `Test, Lint, and Type Check` passed on exact final head `e34e1f71b` with the clean CI dependency setup.
- `bun run build` — PASS on the implementation commit. Exact-final-head `Auth Edge Production Artifact` and main CI jobs also passed; existing local Edge-runtime and Browserslist warnings remain unchanged.
- Focused final diff/security review — the material oversized-action-transport finding was fixed in `e34e1f71b` with bounded parent-side structural and byte validation plus regression coverage. The E2E suggestion was closed under #1518's explicit parent-epic ownership. All review threads are resolved.
- `bun run test:ci` — local run: 563 suites passed, 1 skipped; 5,267 tests passed, 15 skipped. One unrelated suite failed before execution because the local root install does not provide the nested agent-router dependency `@aws-sdk/client-ecs`. The failing `infra/lambdas/agent-router/index.ts`, `tests/unit/agent-workspace-identity.test.ts`, package manifests, and lockfile are unchanged from `origin/dev`; every Atrium bridge and reader suite passed in the same run. GitHub Actions `Test, Lint, and Type Check` passed on exact final head.
- Exact-final-head required checks — PASS: main CI, CodeQL, Claude review, CDK validation, PostgreSQL lifecycle, and auth-edge production artifact.
- The broad authenticated E2E pre-push hook was intentionally skipped with `SKIP_E2E=1`. Per #1518, the parent epic integration thread owns the later multi-user E2E, and this change does not add a second harness. No CDK check is applicable because no infrastructure changed.

## Deployment notes

No schema, migration, API v1, infrastructure, environment-variable, deployment-setting, or production-data changes. Normal application deployment is sufficient.

Closes #1518

Part of #1515
