### PR TITLE
feat(atrium): add sandbox AtriumData helper

### DIFF
--- a/infra/sandbox-host/render.html
+++ b/infra/sandbox-host/render.html
@@ -29,6 +29,10 @@
   script-src 'unsafe-inline'). We render only ONE message (the first valid one
   is replaced on each subsequent valid message) and never eval arbitrary strings
   ourselves beyond reconstructing the author's own script nodes.
+
+  Before any artifact code runs, this host installs window.AtriumData. The helper
+  uses postMessage to ask the authenticated parent for scoped data operations;
+  it does not weaken the frame CSP or give artifact code direct network access.
 -->
 <html lang="en">
   <head>
@@ -73,6 +77,133 @@
           }
           return false;
         }
+
+        var DATA_REQUEST_TYPE = "atrium-artifact-data-request";
+        var DATA_RESPONSE_TYPE = "atrium-artifact-data-response";
+        var DATA_REQUEST_TIMEOUT_MS = 10000;
+        var MAX_PENDING_DATA_REQUESTS = 32;
+        var pendingDataRequests = new Map();
+        // Capture the primitives before artifact scripts can replace globals.
+        var parentWindow = window.parent;
+        var postToParent = parentWindow.postMessage.bind(parentWindow);
+        var createRequestId =
+          window.crypto && typeof window.crypto.randomUUID === "function"
+            ? window.crypto.randomUUID.bind(window.crypto)
+            : null;
+        var scheduleTimeout = window.setTimeout.bind(window);
+        var cancelTimeout = window.clearTimeout.bind(window);
+
+        function handleDataResponse(event) {
+          // Match the exact parent WindowProxy rather than trusting any window
+          // that happens to share the parent's origin. The parent bridge applies
+          // the reciprocal check against this frame's contentWindow.
+          if (event.source !== parentWindow) return;
+          var data = event.data;
+          if (
+            !data ||
+            data.type !== DATA_RESPONSE_TYPE ||
+            typeof data.requestId !== "string" ||
+            typeof data.ok !== "boolean"
+          ) {
+            return;
+          }
+
+          var pending = pendingDataRequests.get(data.requestId);
+          if (!pending) return;
+
+          pendingDataRequests.delete(data.requestId);
+          cancelTimeout(pending.timeoutId);
+          if (data.ok) {
+            pending.resolve(data.data);
+          } else {
+            pending.reject(
+              new Error(
+                typeof data.error === "string" && data.error
+                  ? data.error
+                  : "Atrium data bridge is unavailable"
+              )
+            );
+          }
+        }
+
+        // Install exactly one response listener. Unknown, late, spoofed-source,
+        // and non-data messages are ignored without disturbing pending calls.
+        window.addEventListener("message", handleDataResponse);
+
+        function requestData(op, namespace, fields) {
+          if (!createRequestId) {
+            return Promise.reject(
+              new Error("Atrium data bridge is unavailable")
+            );
+          }
+          if (pendingDataRequests.size >= MAX_PENDING_DATA_REQUESTS) {
+            return Promise.reject(
+              new Error("Atrium data bridge has too many pending requests")
+            );
+          }
+
+          return new Promise(function (resolve, reject) {
+            var requestId;
+            try {
+              requestId = createRequestId();
+            } catch (_err) {
+              reject(new Error("Atrium data bridge is unavailable"));
+              return;
+            }
+            if (pendingDataRequests.has(requestId)) {
+              reject(new Error("Atrium data request ID collision"));
+              return;
+            }
+            var timeoutId = scheduleTimeout(function () {
+              pendingDataRequests.delete(requestId);
+              reject(new Error("Atrium data request timed out"));
+            }, DATA_REQUEST_TIMEOUT_MS);
+
+            pendingDataRequests.set(requestId, {
+              resolve: resolve,
+              reject: reject,
+              timeoutId: timeoutId,
+            });
+
+            var message = {
+              type: DATA_REQUEST_TYPE,
+              requestId: requestId,
+              op: op,
+              namespace: namespace,
+            };
+            if (op === "submit") {
+              message.payload = fields.payload;
+            } else {
+              if (fields.limit !== undefined) message.limit = fields.limit;
+              if (fields.scope !== undefined) message.scope = fields.scope;
+            }
+
+            try {
+              // The parent is a concrete app origin, but this document is opaque
+              // because the iframe intentionally omits allow-same-origin. `*` is
+              // therefore required for delivery; the receiver authenticates the
+              // sender by WindowProxy identity.
+              postToParent(message, "*");
+            } catch (_err) {
+              pendingDataRequests.delete(requestId);
+              cancelTimeout(timeoutId);
+              reject(new Error("Atrium data bridge is unavailable"));
+            }
+          });
+        }
+
+        window.AtriumData = {
+          submit: function (namespace, payload) {
+            return requestData("submit", namespace, { payload: payload });
+          },
+          list: function (namespace, options) {
+            options = options || {};
+            return requestData("list", namespace, {
+              limit: options.limit,
+              scope: options.scope,
+            });
+          },
+        };
 
         // Recreate <script> nodes so the browser executes them (innerHTML does
         // not run injected scripts). We recreate the artifact's OWN <script> nodes

--- a/infra/test/atrium-sandbox-csp.test.ts
+++ b/infra/test/atrium-sandbox-csp.test.ts
@@ -53,8 +53,9 @@ describe('AtriumSandboxStack CSP media-src', () => {
     expect(csp).not.toContain('s3.us-east-1.amazonaws.com');
   });
 
-  it('keeps connect-src none (media-src does not open an exfil channel)', () => {
+  it('keeps the default and network sources closed', () => {
     const csp = cspOf({ allowedMediaOrigins: [BUCKET_ORIGIN] });
+    expect(csp).toContain("default-src 'none'");
     expect(csp).toContain("connect-src 'none'");
   });
 

--- a/tests/smoke/atrium-artifact-sandbox-host.smoke.ts
+++ b/tests/smoke/atrium-artifact-sandbox-host.smoke.ts
@@ -43,6 +43,29 @@ function check(name: string, fn: () => void | Promise<void>): Promise<void> | vo
 
 const APP_ORIGIN = "https://app.example.com";
 const EVIL_ORIGIN = "https://evil.example.com";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface AtriumDataApi {
+  submit(
+    namespace: string,
+    payload: unknown
+  ): Promise<{ id: string; createdAt: string }>;
+  list(
+    namespace: string,
+    options?: { limit?: number; scope?: "all" | "mine" }
+  ): Promise<{ records: unknown[] }>;
+}
+
+interface ParentMessage {
+  type?: unknown;
+  requestId?: unknown;
+  op?: unknown;
+  namespace?: unknown;
+  payload?: unknown;
+  limit?: unknown;
+  scope?: unknown;
+}
 
 /** Build the deployed host HTML the way the CDK stack does (token substitution). */
 function renderHostHtml(allowedParentOrigins: string[]): string {
@@ -68,17 +91,57 @@ function renderHostHtml(allowedParentOrigins: string[]): string {
 }
 
 /** Spin up a jsdom window running the host page script, with a capture for acks. */
-function makeHost(allowedParentOrigins: string[]): {
+function makeHost(
+  allowedParentOrigins: string[],
+  options: {
+    timeoutDelayMs?: number;
+    disableRandomUuid?: boolean;
+    postMessageFailures?: number;
+  } = {}
+): {
   window: Window & typeof globalThis;
   acks: Array<{ origin: string; data: unknown }>;
+  parentMessages: Array<{ origin: string; data: ParentMessage }>;
 } {
   const html = renderHostHtml(allowedParentOrigins);
-  const dom = new JSDOM(html, { runScripts: "dangerously", pretendToBeVisual: true });
-  const window = dom.window as unknown as Window & typeof globalThis;
   const acks: Array<{ origin: string; data: unknown }> = [];
+  const parentMessages: Array<{ origin: string; data: ParentMessage }> = [];
+  const dom = new JSDOM(html, {
+    runScripts: "dangerously",
+    pretendToBeVisual: true,
+    beforeParse(jsdomWindow) {
+      const hostWindow = jsdomWindow as unknown as Window & typeof globalThis;
+      let remainingPostMessageFailures = options.postMessageFailures ?? 0;
+      hostWindow.parent.postMessage = ((
+        data: ParentMessage,
+        targetOrigin: string
+      ) => {
+        if (remainingPostMessageFailures > 0) {
+          remainingPostMessageFailures -= 1;
+          throw new Error("postMessage failed");
+        }
+        parentMessages.push({ origin: targetOrigin, data });
+      }) as Window["postMessage"];
+      if (options.timeoutDelayMs !== undefined) {
+        const nativeSetTimeout = hostWindow.setTimeout.bind(hostWindow);
+        Object.defineProperty(hostWindow, "setTimeout", {
+          configurable: true,
+          value: (handler: TimerHandler) =>
+            nativeSetTimeout(handler, options.timeoutDelayMs),
+        });
+      }
+      if (options.disableRandomUuid) {
+        Object.defineProperty(hostWindow.crypto, "randomUUID", {
+          configurable: true,
+          value: undefined,
+        });
+      }
+    },
+  });
+  const window = dom.window as unknown as Window & typeof globalThis;
   // The host calls event.source.postMessage(ack, event.origin); our synthetic
   // `source` records what the host tried to send back.
-  return { window, acks };
+  return { window, acks, parentMessages };
 }
 
 /** Dispatch a synthetic MessageEvent with a controlled origin into the host. */
@@ -104,6 +167,230 @@ function postToHost(
 
 function rootHtml(window: Window & typeof globalThis): string {
   return window.document.getElementById("atrium-artifact-root")?.innerHTML ?? "";
+}
+
+function atriumData(window: Window & typeof globalThis): AtriumDataApi {
+  const api = (window as unknown as { AtriumData?: AtriumDataApi }).AtriumData;
+  assert.ok(api, "window.AtriumData was not installed");
+  return api;
+}
+
+function postDataResponse(
+  window: Window & typeof globalThis,
+  data: unknown,
+  source: Window = window.parent
+): void {
+  window.dispatchEvent(
+    new window.MessageEvent("message", {
+      data,
+      origin: APP_ORIGIN,
+      source,
+    })
+  );
+}
+
+function testAtriumDataReadyBeforeArtifact(): void {
+  const { window, acks } = makeHost([APP_ORIGIN]);
+  const code =
+    "<script>window.__ATRIUM_DATA_READY__ = " +
+    "typeof window.AtriumData?.submit === 'function' && " +
+    "typeof window.AtriumData?.list === 'function';</" +
+    "script>";
+  postToHost(window, APP_ORIGIN, { type: "atrium-render", code }, acks);
+  assert.equal(
+    (window as unknown as { __ATRIUM_DATA_READY__?: boolean })
+      .__ATRIUM_DATA_READY__,
+    true
+  );
+}
+
+async function testBridgeEnvelopes(): Promise<void> {
+  const { window, parentMessages } = makeHost([APP_ORIGIN]);
+  const api = atriumData(window);
+  const payload = { score: 42 };
+
+  const submitPromise = api.submit("leaderboard", payload);
+  assert.equal(parentMessages.length, 1);
+  assert.equal(parentMessages[0]?.origin, "*");
+  const submitRequest = parentMessages[0]?.data;
+  assert.deepEqual(submitRequest, {
+    type: "atrium-artifact-data-request",
+    requestId: submitRequest?.requestId,
+    op: "submit",
+    namespace: "leaderboard",
+    payload,
+  });
+  assert.match(String(submitRequest?.requestId), UUID_PATTERN);
+  const submitted = {
+    id: "record-1",
+    createdAt: "2026-08-01T12:00:00.000Z",
+  };
+  postDataResponse(window, {
+    type: "atrium-artifact-data-response",
+    requestId: submitRequest?.requestId,
+    ok: true,
+    data: submitted,
+  });
+  assert.deepEqual(await submitPromise, submitted);
+
+  const listPromise = api.list("leaderboard", { limit: 50, scope: "mine" });
+  assert.equal(parentMessages.length, 2);
+  assert.equal(parentMessages[1]?.origin, "*");
+  const listRequest = parentMessages[1]?.data;
+  assert.deepEqual(listRequest, {
+    type: "atrium-artifact-data-request",
+    requestId: listRequest?.requestId,
+    op: "list",
+    namespace: "leaderboard",
+    limit: 50,
+    scope: "mine",
+  });
+  assert.match(String(listRequest?.requestId), UUID_PATTERN);
+  assert.notEqual(listRequest?.requestId, submitRequest?.requestId);
+  const listed = { records: [submitted] };
+  postDataResponse(window, {
+    type: "atrium-artifact-data-response",
+    requestId: listRequest?.requestId,
+    ok: true,
+    data: listed,
+  });
+  assert.deepEqual(await listPromise, listed);
+}
+
+async function testParentSourceFilter(): Promise<void> {
+  const { window, parentMessages } = makeHost([APP_ORIGIN]);
+  const listPromise = atriumData(window).list("leaderboard");
+  const requestId = parentMessages[0]?.data.requestId;
+  let settled = false;
+  void listPromise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    }
+  );
+
+  postDataResponse(
+    window,
+    {
+      type: "atrium-artifact-data-response",
+      requestId,
+      ok: true,
+      data: { records: ["spoofed"] },
+    },
+    {} as Window
+  );
+  await Promise.resolve();
+  assert.equal(settled, false, "a non-parent source settled the pending call");
+
+  postDataResponse(window, {
+    type: "atrium-artifact-data-response",
+    requestId,
+    ok: true,
+    data: { records: [] },
+  });
+  assert.deepEqual(await listPromise, { records: [] });
+}
+
+async function testDisabledBridgeResponse(): Promise<void> {
+  const { window, parentMessages } = makeHost([APP_ORIGIN]);
+  const listPromise = atriumData(window).list("leaderboard");
+  postDataResponse(window, {
+    type: "atrium-artifact-data-response",
+    requestId: parentMessages[0]?.data.requestId,
+    ok: false,
+    error: "Atrium data bridge is disabled",
+  });
+  await assert.rejects(listPromise, /Atrium data bridge is disabled/);
+}
+
+async function testDataRequestTimeout(): Promise<void> {
+  const { window } = makeHost([APP_ORIGIN], { timeoutDelayMs: 0 });
+  await assert.rejects(
+    atriumData(window).list("leaderboard"),
+    /Atrium data request timed out/
+  );
+}
+
+async function testMissingRandomUuidDoesNotBreakRendering(): Promise<void> {
+  const { window, acks, parentMessages } = makeHost([APP_ORIGIN], {
+    disableRandomUuid: true,
+  });
+
+  await assert.rejects(
+    atriumData(window).list("leaderboard"),
+    /Atrium data bridge is unavailable/
+  );
+  assert.equal(parentMessages.length, 0);
+
+  postToHost(
+    window,
+    APP_ORIGIN,
+    { type: "atrium-render", code: "<p id='still-renders'>ready</p>" },
+    acks
+  );
+  assert.match(rootHtml(window), /id="still-renders"/);
+  assert.deepEqual(acks[0]?.data, {
+    type: "atrium-artifact-rendered",
+    ok: true,
+  });
+}
+
+async function testPostMessageFailureCleanup(): Promise<void> {
+  const { window, parentMessages } = makeHost([APP_ORIGIN], {
+    postMessageFailures: 1,
+  });
+  const api = atriumData(window);
+
+  await assert.rejects(
+    api.list("leaderboard"),
+    /Atrium data bridge is unavailable/
+  );
+  assert.equal(parentMessages.length, 0);
+
+  const retry = api.list("leaderboard");
+  const requestId = parentMessages[0]?.data.requestId;
+  postDataResponse(window, {
+    type: "atrium-artifact-data-response",
+    requestId,
+    ok: true,
+    data: { records: [] },
+  });
+  assert.deepEqual(await retry, { records: [] });
+}
+
+async function testPendingRequestBound(): Promise<void> {
+  const { window, parentMessages } = makeHost([APP_ORIGIN]);
+  const api = atriumData(window);
+  const pending: Array<Promise<{ records: unknown[] }>> = [];
+  for (let i = 0; i < 32; i += 1) {
+    pending.push(api.list("leaderboard"));
+  }
+  await assert.rejects(
+    api.list("leaderboard"),
+    /Atrium data bridge has too many pending requests/
+  );
+
+  for (const request of parentMessages) {
+    postDataResponse(window, {
+      type: "atrium-artifact-data-response",
+      requestId: request.data.requestId,
+      ok: true,
+      data: { records: [] },
+    });
+  }
+  await Promise.all(pending);
+
+  const afterCleanup = api.list("leaderboard");
+  const afterCleanupRequest = parentMessages[32]?.data;
+  postDataResponse(window, {
+    type: "atrium-artifact-data-response",
+    requestId: afterCleanupRequest?.requestId,
+    ok: true,
+    data: { records: [] },
+  });
+  assert.deepEqual(await afterCleanup, { records: [] });
 }
 
 async function main(): Promise<void> {
@@ -150,6 +437,39 @@ async function main(): Promise<void> {
       "inline artifact script did not execute"
     );
   });
+
+  await check(
+    "installs AtriumData before artifact scripts execute",
+    testAtriumDataReadyBeforeArtifact
+  );
+  await check(
+    "submit and list use UUID-correlated bridge envelopes",
+    testBridgeEnvelopes
+  );
+  await check(
+    "ignores data responses not sent by window.parent",
+    testParentSourceFilter
+  );
+  await check(
+    "rejects a disabled-bridge response with a catchable error",
+    testDisabledBridgeResponse
+  );
+  await check(
+    "rejects and cleans up when no response arrives before timeout",
+    testDataRequestTimeout
+  );
+  await check(
+    "keeps rendering when UUID generation is unavailable",
+    testMissingRandomUuidDoesNotBreakRendering
+  );
+  await check(
+    "cleans up after a synchronous parent post failure",
+    testPostMessageFailureCleanup
+  );
+  await check(
+    "bounds pending calls and releases capacity after cleanup",
+    testPendingRequestBound
+  );
 
   await check("the deployed host page hard-codes no allow-same-origin and embeds the allowlist", () => {
     const html = renderHostHtml([APP_ORIGIN]);


### PR DESCRIPTION
## Summary

Implements the sandbox-host `window.AtriumData` helper from #1519 against the locked #1518 protocol.

- Installs `AtriumData.submit(namespace, payload)` and `AtriumData.list(namespace, options?)` before artifact scripts execute.
- Uses `crypto.randomUUID()` request correlation, one exact-parent-source-filtered response listener, a 10-second per-call timeout, and a 32-call pending bound.
- Cleans pending state and timers on success, parent rejection, timeout, and synchronous post failures; rejects disabled bridge responses with a catchable `Error`.
- Captures the parent, UUID, postMessage, and timer primitives before artifact code can replace globals.
- Preserves the sandbox network boundary: `default-src 'none'` and `connect-src 'none'` are unchanged and asserted by the CDK test.

## Merge dependency

Satisfied: #1540 closed #1518 before this PR. This branch was rebased after that merge, the integrated parent/host gates were rerun, and the final head was rebased onto corrected current `dev` after #1545.

## Verification

- `bun run test:smoke:atrium-sandbox-host` — PASS, 14 checks, including graceful UUID-unavailable degradation without breaking artifact rendering and cleanup/retry after synchronous parent-post failure.
- `bun run tests/smoke/atrium-artifact-sandbox-component.smoke.ts` — PASS, 4 checks.
- `bun run test -- --runInBand tests/unit/atrium-artifact-data-bridge.test.tsx tests/unit/atrium-reader-page-masking.test.tsx tests/unit/atrium-public-reader-page.test.tsx` — PASS, 3 suites / 30 tests.
- `cd infra && bunx jest --runInBand test/atrium-sandbox-csp.test.ts` — PASS, 1 suite / 5 tests.
- `bun run lint` — PASS, zero warnings.
- `bun run typecheck` — PASS.
- `cd infra && bunx cdk synth` — PASS; existing stack-policy/configuration warnings only.
- Full authenticated Playwright E2E after #1518 — PASS, 309 passed / 40 intentionally skipped / 0 failed (349 total, 10.4 minutes).
- After the final unrelated #1545 baseline correction, the sandbox host/component/CSP suites were rerun and passed; `tests/unit/lib/repositories/content-platform-orphaned-item-sweep.test.ts` also passed (2 tests), confirming the corrected repository baseline.
- After review feedback, `bun run lint` and `bun run typecheck` were rerun on the final diff — PASS.
- Focused diff/security review — PASS, no material finding. Exact parent authentication, UUID correlation, terminal-path cleanup, pending bounds, and unchanged CSP were reviewed.

## Deployment notes

Requires a sandbox stack / CloudFront host redeploy to publish the changed `render.html`. Use the canonical full dev deployment with `AIStudio-AtriumSandboxStack-Dev` included; do not partial-deploy the sandbox stack. No deployment, production setting, or production data operation was performed by this PR.

Closes #1519

Part of #1515
