### PR TITLE
feat(agent): add Atrium artifact data reads

### DIFF
--- a/app/api/agent/atrium/route.ts
+++ b/app/api/agent/atrium/route.ts
@@ -12,6 +12,8 @@ const ALLOWED_QUERY_KEYS = new Set([
   "tag",
   "query",
   "since",
+  "namespace",
+  "limit",
 ])
 const IDENTIFIER = "[A-Za-z0-9%._~-]{1,384}"
 
@@ -30,6 +32,7 @@ const ALLOWED_PATHS: Record<AtriumBody["method"], readonly RegExp[]> = {
     // Committed markdown source — the ONLY way an agent can read a document's
     // body text (`GET /<id>` returns bodyLocation "proof" with no text).
     new RegExp(`^/${IDENTIFIER}/source$`),
+    new RegExp(`^/${IDENTIFIER}/data$`),
     // Authored image assets (#1284): metadata list, plus a bounded
     // base64 byte read so an agent can copy an image between objects.
     new RegExp(`^/${IDENTIFIER}/assets$`),

--- a/lib/agent-workspace/atrium-owner-operation.ts
+++ b/lib/agent-workspace/atrium-owner-operation.ts
@@ -1,3 +1,4 @@
+import { and, desc, eq } from "drizzle-orm"
 import { z } from "zod"
 import {
   ApprovalRequiredError,
@@ -29,6 +30,36 @@ import {
   updateCollectionBodySchema,
 } from "@/lib/content/rest"
 import { getUserByEmail } from "@/lib/db/drizzle/users"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { contentDataRecords, users } from "@/lib/db/schema"
+import type { ArtifactDataPayload } from "@/lib/db/types/jsonb"
+
+const ARTIFACT_DATA_NAMESPACE_RE = /^[a-z0-9_-]{1,64}$/
+const DEFAULT_ARTIFACT_DATA_LIMIT = 50
+const MAX_ARTIFACT_DATA_LIMIT = 200
+
+const artifactDataQuerySchema = z
+  .object({
+    namespace: z.string().regex(ARTIFACT_DATA_NAMESPACE_RE, {
+      message:
+        "namespace must be 1-64 lowercase letters, numbers, underscores, or hyphens",
+    }),
+    limit: z
+      .string()
+      .regex(/^[1-9][0-9]*$/, {
+        message: "limit must be a positive base-10 integer",
+      })
+      .optional(),
+  })
+  .strict()
+
+type ArtifactDataRecordRow = {
+  id: string
+  payload: ArtifactDataPayload
+  createdAt: Date
+  userFirstName: string | null
+  userLastName: string | null
+}
 
 const visibilitySchema = z
   .object({
@@ -219,6 +250,23 @@ function parsePath(path: string): string[] {
   })
 }
 
+function artifactDataLimit(value: string | undefined): number {
+  if (value === undefined) return DEFAULT_ARTIFACT_DATA_LIMIT
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed)
+    ? Math.min(parsed, MAX_ARTIFACT_DATA_LIMIT)
+    : MAX_ARTIFACT_DATA_LIMIT
+}
+
+function artifactDataDisplayName(row: ArtifactDataRecordRow): string {
+  const fullName = [row.userFirstName, row.userLastName]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+    .join(" ")
+    .trim()
+  return fullName || "Unknown user"
+}
+
 async function ownerRequester(ownerEmail: string): Promise<{
   req: Requester
   cognitoSub: string
@@ -286,6 +334,80 @@ async function executeSingleSegmentRead(
   return success({ ...object, url: contentDeepLink(object.slug) }, requestId)
 }
 
+async function executeTwoSegmentRead(
+  req: Requester,
+  input: AgentAtriumOperationInput,
+  contentId: string,
+  operation: string
+): Promise<AgentAtriumOperationResult | null> {
+  // Committed markdown source. `GET /<id>` deliberately omits a DOCUMENT's
+  // text (it lives in the collaborative store, `bodyLocation: "proof"`), so
+  // this is the only read that returns a document body — without it an agent
+  // cannot use an existing Atrium document as an input.
+  if (operation === "source") {
+    const source = await contentSourceService.read(req, contentId)
+    return success(source, input.requestId)
+  }
+
+  if (operation === "assets") {
+    const assets = await contentAssetService.list(req, contentId)
+    return success(assets, input.requestId)
+  }
+
+  if (operation !== "data") return null
+
+  const query = artifactDataQuerySchema.parse(input.query ?? {})
+  const limit = artifactDataLimit(query.limit)
+
+  // Resolve the object before touching its records. `contentService.get`
+  // preserves the shared 404 mask for missing and non-viewable content, and
+  // this read branch returns before the authoring-capability gate below.
+  const content = await contentService.get(req, contentId)
+  if (content.kind !== "artifact") {
+    throw new ValidationError("Content is not an artifact", {
+      field: "contentId",
+    })
+  }
+
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .select({
+          id: contentDataRecords.id,
+          payload: contentDataRecords.payload,
+          createdAt: contentDataRecords.createdAt,
+          userFirstName: users.firstName,
+          userLastName: users.lastName,
+        })
+        .from(contentDataRecords)
+        .leftJoin(users, eq(contentDataRecords.userId, users.id))
+        .where(
+          and(
+            eq(contentDataRecords.contentId, content.id),
+            eq(contentDataRecords.namespace, query.namespace)
+          )
+        )
+        .orderBy(
+          desc(contentDataRecords.createdAt),
+          desc(contentDataRecords.id)
+        )
+        .limit(limit),
+    "agentAtrium.listArtifactRecords"
+  )
+
+  return success(
+    {
+      records: (rows as ArtifactDataRecordRow[]).map((row) => ({
+        id: row.id,
+        displayName: artifactDataDisplayName(row),
+        payload: row.payload,
+        createdAt: row.createdAt.toISOString(),
+      })),
+    },
+    input.requestId
+  )
+}
+
 /**
  * The READ half of the fixed surface.
  *
@@ -332,18 +454,8 @@ async function executeAtriumRead(
     return executeSingleSegmentRead(req, segments[0], input.requestId)
   }
 
-  // Committed markdown source. `GET /<id>` deliberately omits a DOCUMENT's
-  // text (it lives in the collaborative store, `bodyLocation: "proof"`), so
-  // this is the only read that returns a document body — without it an agent
-  // cannot use an existing Atrium document as an input.
-  if (segments.length === 2 && segments[1] === "source") {
-    const source = await contentSourceService.read(req, segments[0])
-    return success(source, input.requestId)
-  }
-
-  if (segments.length === 2 && segments[1] === "assets") {
-    const assets = await contentAssetService.list(req, segments[0])
-    return success(assets, input.requestId)
+  if (segments.length === 2) {
+    return executeTwoSegmentRead(req, input, segments[0], segments[1])
   }
 
   if (

--- a/tests/unit/agent-atrium-owner-operation.test.ts
+++ b/tests/unit/agent-atrium-owner-operation.test.ts
@@ -311,6 +311,38 @@ describe("signed-owner Atrium artifact data reads", () => {
   })
 })
 
+describe("signed-owner Atrium artifact data content-kind guard", () => {
+  it("rejects a visible non-artifact before record or authoring access", async () => {
+    contentGetMock.mockResolvedValue({
+      id: "document-1",
+      kind: "document",
+    })
+
+    const result = await executeOwnerAtriumOperation({
+      ownerEmail: "owner@psd401.net",
+      requestId: "request-data-document",
+      method: "GET",
+      path: "/document-1/data",
+      query: { namespace: "leaderboard" },
+    })
+
+    expect(result).toEqual({
+      httpStatus: 400,
+      payload: {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Content is not an artifact",
+          details: { field: "contentId" },
+        },
+        requestId: "request-data-document",
+      },
+    })
+    expect(contentGetMock).toHaveBeenCalledWith(requester, "document-1")
+    expect(dataSelectMock).not.toHaveBeenCalled()
+    expect(assertContentAuthoringCapabilityMock).not.toHaveBeenCalled()
+  })
+})
+
 describe("signed-owner Atrium operations", () => {
   it("keeps archived manageable collections discoverable without widening content access", async () => {
     const district = {

--- a/tests/unit/agent-atrium-owner-operation.test.ts
+++ b/tests/unit/agent-atrium-owner-operation.test.ts
@@ -19,6 +19,28 @@ const collectionVisibleListMock = jest.fn()
 const collectionManageableListMock = jest.fn()
 const collectionCreateMock = jest.fn()
 const collectionUpdateMock = jest.fn()
+const contentGetMock = jest.fn()
+
+const dataLimitMock = jest.fn()
+const dataOrderByMock = jest.fn(() => ({ limit: dataLimitMock }))
+const dataWhereMock = jest.fn(() => ({ orderBy: dataOrderByMock }))
+const dataLeftJoinMock = jest.fn(() => ({ where: dataWhereMock }))
+const dataFromMock = jest.fn(() => ({ leftJoin: dataLeftJoinMock }))
+const dataSelectMock = jest.fn(() => ({ from: dataFromMock }))
+
+interface FakeDb {
+  select: typeof dataSelectMock
+}
+
+type QueryCallback = (db: FakeDb) => unknown
+const executeQueryMock = jest.fn(
+  async (query: QueryCallback, _operation: string) => query({ select: dataSelectMock })
+)
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (query: QueryCallback, operation: string) =>
+    executeQueryMock(query, operation),
+}))
 
 jest.mock("@/lib/db/drizzle/users", () => ({
   getUserByEmail: (...args: unknown[]) => getUserByEmailMock(...args),
@@ -60,6 +82,11 @@ jest.mock("@/lib/content", () => {
       super(message, "CONTENT_FORBIDDEN", 403)
     }
   }
+  class MockNotFoundError extends MockContentError {
+    constructor(message = "Not found") {
+      super(message, "CONTENT_NOT_FOUND", 404)
+    }
+  }
   class MockValidationError extends MockContentError {
     constructor(message = "Invalid", details?: Record<string, unknown>) {
       super(message, "VALIDATION_ERROR", 400, details)
@@ -68,12 +95,13 @@ jest.mock("@/lib/content", () => {
   return {
     ApprovalRequiredError: MockApprovalRequiredError,
     ForbiddenError: MockForbiddenError,
+    NotFoundError: MockNotFoundError,
     ValidationError: MockValidationError,
     isContentError: (error: unknown) => error instanceof MockContentError,
     contentService: {
       list: (...args: unknown[]) => contentListMock(...args),
       create: (...args: unknown[]) => contentCreateMock(...args),
-      get: jest.fn(),
+      get: (...args: unknown[]) => contentGetMock(...args),
       update: jest.fn(),
       createVersion: jest.fn(),
       loadForEdit: jest.fn(),
@@ -110,6 +138,7 @@ jest.mock("@/lib/content", () => {
 import {
   ApprovalRequiredError,
   ForbiddenError,
+  NotFoundError,
 } from "@/lib/content"
 import { executeOwnerAtriumOperation } from "@/lib/agent-workspace/atrium-owner-operation"
 
@@ -134,6 +163,152 @@ beforeEach(() => {
     async (_requester: unknown, value: unknown) => value
   )
   auditMock.mockResolvedValue(undefined)
+  contentGetMock.mockResolvedValue({
+    id: "content-1",
+    kind: "artifact",
+  })
+  dataLimitMock.mockResolvedValue([])
+})
+
+describe("signed-owner Atrium artifact data reads", () => {
+  it("returns the #1517 record and display-name shape as the signed owner", async () => {
+    dataLimitMock.mockResolvedValue([
+      {
+        id: "record-2",
+        payload: { score: 84 },
+        createdAt: new Date("2026-08-02T03:00:00.000Z"),
+        userFirstName: " Ada ",
+        userLastName: "Lovelace",
+      },
+      {
+        id: "record-1",
+        payload: { score: 42 },
+        createdAt: new Date("2026-08-02T02:00:00.000Z"),
+        userFirstName: null,
+        userLastName: null,
+      },
+    ])
+
+    await expect(
+      executeOwnerAtriumOperation({
+        ownerEmail: "owner@psd401.net",
+        requestId: "request-data",
+        method: "GET",
+        path: "/content-1/data",
+        query: { namespace: "leaderboard" },
+      })
+    ).resolves.toEqual({
+      httpStatus: 200,
+      payload: {
+        data: {
+          records: [
+            {
+              id: "record-2",
+              displayName: "Ada Lovelace",
+              payload: { score: 84 },
+              createdAt: "2026-08-02T03:00:00.000Z",
+            },
+            {
+              id: "record-1",
+              displayName: "Unknown user",
+              payload: { score: 42 },
+              createdAt: "2026-08-02T02:00:00.000Z",
+            },
+          ],
+        },
+        meta: { requestId: "request-data" },
+      },
+    })
+    expect(contentGetMock).toHaveBeenCalledWith(requester, "content-1")
+    expect(dataLimitMock).toHaveBeenCalledWith(50)
+    expect(executeQueryMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      "agentAtrium.listArtifactRecords"
+    )
+    expect(assertContentAuthoringCapabilityMock).not.toHaveBeenCalled()
+  })
+
+  it("clamps a requested limit above 200", async () => {
+    const result = await executeOwnerAtriumOperation({
+      ownerEmail: "owner@psd401.net",
+      requestId: "request-data-limit",
+      method: "GET",
+      path: "/content-1/data",
+      query: { namespace: "leaderboard", limit: "1000" },
+    })
+
+    expect(result.httpStatus).toBe(200)
+    expect(dataLimitMock).toHaveBeenCalledWith(200)
+  })
+
+  it.each([
+    {
+      query: {} as Record<string, string>,
+      field: "namespace",
+      constraint: "namespace",
+    },
+    {
+      query: { namespace: "Leaderboard!" },
+      field: "namespace",
+      constraint: "namespace must be 1-64 lowercase",
+    },
+    {
+      query: { namespace: "leaderboard", limit: "not-a-number" },
+      field: "limit",
+      constraint: "limit must be a positive base-10 integer",
+    },
+  ])(
+    "rejects malformed data query %# with a structured constraint",
+    async ({ query, field, constraint }) => {
+      const result = await executeOwnerAtriumOperation({
+        ownerEmail: "owner@psd401.net",
+        requestId: "request-data-invalid",
+        method: "GET",
+        path: "/content-1/data",
+        query,
+      })
+
+      expect(result.httpStatus).toBe(400)
+      expect(result.payload).toEqual(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            code: "VALIDATION_ERROR",
+            details: expect.arrayContaining([
+              expect.objectContaining({ path: [field] }),
+            ]),
+          }),
+        })
+      )
+      expect(JSON.stringify(result.payload)).toContain(constraint)
+      expect(contentGetMock).not.toHaveBeenCalled()
+      expect(dataSelectMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it("masks a non-viewable artifact as not found before record or permission access", async () => {
+    contentGetMock.mockRejectedValue(new NotFoundError("Content not found"))
+
+    const result = await executeOwnerAtriumOperation({
+      ownerEmail: "owner@psd401.net",
+      requestId: "request-data-hidden",
+      method: "GET",
+      path: "/hidden-content/data",
+      query: { namespace: "leaderboard" },
+    })
+
+    expect(result).toEqual({
+      httpStatus: 404,
+      payload: {
+        error: {
+          code: "CONTENT_NOT_FOUND",
+          message: "Content not found",
+        },
+        requestId: "request-data-hidden",
+      },
+    })
+    expect(dataSelectMock).not.toHaveBeenCalled()
+    expect(assertContentAuthoringCapabilityMock).not.toHaveBeenCalled()
+  })
 })
 
 describe("signed-owner Atrium operations", () => {

--- a/tests/unit/agent-atrium-route.test.ts
+++ b/tests/unit/agent-atrium-route.test.ts
@@ -57,7 +57,17 @@ beforeEach(() => {
 describe("POST /api/agent/atrium", () => {
   it("requires signed authority and rejects owner selectors", async () => {
     context = null
-    expect((await POST(request({ method: "GET", path: "" }))).status).toBe(403)
+    expect(
+      (
+        await POST(
+          request({
+            method: "GET",
+            path: "/content-1/data",
+            query: { namespace: "leaderboard" },
+          })
+        )
+      ).status
+    ).toBe(403)
     context = {
       ownerEmail: "owner@psd401.net",
       actorEmail: "owner@psd401.net",
@@ -117,6 +127,25 @@ describe("POST /api/agent/atrium", () => {
     )
   })
 
+  it("admits an owner-bound artifact data read and forwards its bounds", async () => {
+    const response = await POST(
+      request({
+        method: "GET",
+        path: "/content-1/data",
+        query: { namespace: "leaderboard", limit: "200" },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(executeOwnerAtriumOperationMock).toHaveBeenCalledWith({
+      ownerEmail: "owner@psd401.net",
+      requestId: "request-test",
+      method: "GET",
+      path: "/content-1/data",
+      query: { namespace: "leaderboard", limit: "200" },
+    })
+  })
+
   it.each([
     ["POST", "/content-1/publish/public_web"],
     ["GET", "/content-1/../../admin"],
@@ -133,6 +162,9 @@ describe("POST /api/agent/atrium", () => {
     ["PATCH", "/content-1/assets"],
     ["DELETE", "/collections/content-1"],
     ["PATCH", "/collections/content-1/archive"],
+    ["POST", "/content-1/data"],
+    ["PATCH", "/content-1/data"],
+    ["DELETE", "/content-1/data"],
   ])("rejects operation %s %s outside the fixed API surface", async (method, path) => {
     const response = await POST(request({ method, path }))
     expect(response.status).toBe(400)


### PR DESCRIPTION
## Summary

- allow only `GET /<id>/data` through the signed-owner Atrium broker
- validate the required `namespace`, default reads to 50 records, and clamp caller limits to 200
- preserve the shared `contentService.get` 404 existence mask before any record query or authoring-permission gate
- return the #1517-compatible `records[{ id, displayName, payload, createdAt }]` shape without user IDs or emails
- keep `POST`, `PATCH`, and `DELETE /<id>/data` outside the fixed allowlist
- add focused authorization, malformed-input, limit, existence-masking, content-kind, response-shape, and method-rejection coverage

## Verification

- `bun run lint` — passed with zero warnings
- `bun run typecheck` — passed
- `bun run test:ci` — 563 suites passed, 1 skipped; 5,272 tests passed, 15 skipped (5,287 total)
- `bun run test:ci --runInBand tests/unit/agent-atrium-route.test.ts tests/unit/agent-atrium-owner-operation.test.ts` — 2 suites / 59 tests passed on the review-follow-up head
- focused diff/security review — no material authorization, masking, bounding, privacy, or method-surface findings remained

The broad local pre-push E2E hook was bypassed only because this managed worktree has no `AUTH_SECRET`. Issue #1520 requires Jest, lint, and typecheck; it does not require an E2E or CDK command.

## Deployment notes

No schema migration, infrastructure change, deployment setting, API v1 documentation, or agent skill documentation change is included.

Closes #1520

Part of #1515
