### PR TITLE
feat: add deterministic retrieval-shadow samples

### DIFF
--- a/actions/admin/repository-migration.actions.ts
+++ b/actions/admin/repository-migration.actions.ts
@@ -19,6 +19,11 @@ import {
   type RepositoryMigrationException,
 } from "@/lib/repositories/content-platform/migration-control-service";
 import { reprocessRepositoryMigrationItem } from "@/lib/repositories/content-platform/migration-runner";
+import { getContentPlatformConfig } from "@/lib/repositories/content-platform/config";
+import { assertRepositoryReadAccess } from "@/lib/repositories/repository-access-guard";
+import { executeSearch } from "@/lib/repositories/search-execution";
+import { getRepositoryById } from "@/lib/db/drizzle";
+import { ErrorCode } from "@/types/error-types";
 import type {
   RepositoryMigrationMode,
   RepositoryMigrationRunRow,
@@ -26,14 +31,24 @@ import type {
 } from "@/lib/db/schema";
 
 const ADMIN_REPOSITORIES_PATH = "/admin/repositories";
+const ADMIN_SETTINGS_PATH = "/admin/settings";
+const MAX_RETRIEVAL_SHADOW_SAMPLE_QUERIES = 25;
 
-async function requireMigrationAdministrator(): Promise<number> {
+interface MigrationAdministrator {
+  userId: number;
+  cognitoSub: string;
+}
+
+async function requireMigrationAdministrator(): Promise<MigrationAdministrator> {
   const session = await getServerSession();
   if (!session?.sub) throw ErrorFactories.authNoSession();
   if (!(await hasRole("administrator"))) {
     throw ErrorFactories.authzAdminRequired();
   }
-  return getUserIdFromSession(session.sub);
+  return {
+    userId: await getUserIdFromSession(session.sub),
+    cognitoSub: session.sub,
+  };
 }
 
 export async function getRepositoryMigrationDashboardAction(): Promise<
@@ -83,7 +98,7 @@ export async function startRepositoryMigrationAction(input: {
     action: "admin.contentMigration.start",
   });
   try {
-    const requestedBy = await requireMigrationAdministrator();
+    const { userId: requestedBy } = await requireMigrationAdministrator();
     const run = await startRepositoryMigrationRun({
       ...input,
       requestedBy,
@@ -112,7 +127,7 @@ export async function retryRepositoryMigrationItemAction(
   const requestId = generateRequestId();
   const timer = startTimer("admin.contentMigration.retry");
   try {
-    const requestedBy = await requireMigrationAdministrator();
+    const { userId: requestedBy } = await requireMigrationAdministrator();
     const run = await retryRepositoryMigrationItem(
       migrationItemId,
       requestedBy,
@@ -158,7 +173,7 @@ export async function approveRepositoryMigrationMismatchAction(input: {
   const requestId = generateRequestId();
   const timer = startTimer("admin.contentMigration.approveMismatch");
   try {
-    const approvedBy = await requireMigrationAdministrator();
+    const { userId: approvedBy } = await requireMigrationAdministrator();
     await approveRepositoryMigrationMismatch({ ...input, approvedBy });
     timer({ status: "success" });
     revalidatePath(ADMIN_REPOSITORIES_PATH);
@@ -179,7 +194,7 @@ export async function runRepositoryMigrationRollbackDrillAction(): Promise<
   const requestId = generateRequestId();
   const timer = startTimer("admin.contentMigration.rollbackDrill");
   try {
-    const requestedBy = await requireMigrationAdministrator();
+    const { userId: requestedBy } = await requireMigrationAdministrator();
     const run = await runRepositoryMigrationRollbackDrill(requestedBy);
     timer({ status: "success" });
     revalidatePath(ADMIN_REPOSITORIES_PATH);
@@ -200,7 +215,7 @@ export async function startRepositoryMigrationRollbackAction(
   const requestId = generateRequestId();
   const timer = startTimer("admin.contentMigration.rollback");
   try {
-    const requestedBy = await requireMigrationAdministrator();
+    const { userId: requestedBy } = await requireMigrationAdministrator();
     const run = await startRepositoryRollbackRun({
       parentRunId,
       requestedBy,
@@ -215,5 +230,184 @@ export async function startRepositoryMigrationRollbackAction(
       requestId,
       operation: "startRepositoryMigrationRollbackAction",
     });
+  }
+}
+
+export interface RepositoryRetrievalShadowSampleOutcome {
+  query: string;
+  status: "recorded" | "skipped";
+  resultCount: number;
+  reason?: string;
+}
+
+export interface RepositoryRetrievalShadowSampleResult {
+  repositoryId: number;
+  repositoryName: string;
+  recorded: number;
+  skipped: number;
+  outcomes: RepositoryRetrievalShadowSampleOutcome[];
+}
+
+function isRecordNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === ErrorCode.DB_RECORD_NOT_FOUND
+  );
+}
+
+function validateRetrievalShadowSampleInput(input: {
+  repositoryId: number;
+  queries: string[];
+}): string[] {
+  if (!Number.isInteger(input.repositoryId) || input.repositoryId <= 0) {
+    throw ErrorFactories.invalidInput(
+      "repositoryId",
+      input.repositoryId,
+      "positive integer",
+      { userMessage: "Enter a valid repository ID." },
+    );
+  }
+  if (
+    !Array.isArray(input.queries) ||
+    input.queries.length === 0 ||
+    input.queries.length > MAX_RETRIEVAL_SHADOW_SAMPLE_QUERIES
+  ) {
+    throw ErrorFactories.invalidInput(
+      "queries",
+      Array.isArray(input.queries) ? input.queries.length : input.queries,
+      `1-${MAX_RETRIEVAL_SHADOW_SAMPLE_QUERIES} queries`,
+      {
+        userMessage: `Provide between 1 and ${MAX_RETRIEVAL_SHADOW_SAMPLE_QUERIES} sample queries.`,
+      },
+    );
+  }
+
+  return input.queries.map((query, index) => {
+    if (typeof query !== "string" || query.trim().length === 0) {
+      throw ErrorFactories.invalidInput(
+        `queries[${index}]`,
+        query,
+        "non-empty string",
+        { userMessage: `Sample query ${index + 1} must not be empty.` },
+      );
+    }
+    return query.trim();
+  });
+}
+
+/**
+ * Run a bounded, deterministic set of Repository Manager searches through the
+ * production search executor. The executor owns retrieval-shadow recording and
+ * preserves its fail-open behavior; this action never writes observations.
+ */
+export async function recordRepositoryRetrievalShadowSampleAction(input: {
+  repositoryId: number;
+  queries: string[];
+}): Promise<ActionState<RepositoryRetrievalShadowSampleResult>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("admin.contentMigration.retrievalShadowSample");
+  const log = createLogger({
+    requestId,
+    action: "admin.contentMigration.retrievalShadowSample",
+  });
+
+  try {
+    const administrator = await requireMigrationAdministrator();
+    const queries = validateRetrievalShadowSampleInput(input);
+    const repository = await getRepositoryById(input.repositoryId);
+    if (!repository) {
+      throw ErrorFactories.dbRecordNotFound(
+        "knowledge_repositories",
+        input.repositoryId,
+        { userMessage: `Repository ${input.repositoryId} was not found.` },
+      );
+    }
+
+    try {
+      await assertRepositoryReadAccess(
+        input.repositoryId,
+        administrator.cognitoSub,
+      );
+    } catch (error) {
+      if (!isRecordNotFoundError(error)) throw error;
+      throw ErrorFactories.authzResourceNotFound(
+        "repository",
+        repository.name,
+        {
+          userMessage: `Access to repository "${repository.name}" is required before recording a retrieval-shadow sample.`,
+        },
+      );
+    }
+
+    const contentConfig = await getContentPlatformConfig();
+    const outcomes: RepositoryRetrievalShadowSampleOutcome[] = [];
+    for (const query of queries) {
+      const search = await executeSearch({
+        searchType: "hybrid",
+        query,
+        repositoryId: input.repositoryId,
+        limit: 10,
+        vectorWeight: 0.7,
+        canonicalOnly: false,
+        userCognitoSub: administrator.cognitoSub,
+        contentConfig,
+        log,
+      });
+      const shadowOutcome = search.shadowOutcome ?? {
+        status: "skipped" as const,
+        reason: "No retrieval shadow observation was recorded",
+      };
+      outcomes.push({
+        query,
+        status: shadowOutcome.status,
+        resultCount: search.results.length,
+        ...(shadowOutcome.status === "skipped"
+          ? { reason: shadowOutcome.reason }
+          : {}),
+      });
+    }
+
+    const recorded = outcomes.filter(
+      (outcome) => outcome.status === "recorded",
+    ).length;
+    const result = {
+      repositoryId: input.repositoryId,
+      repositoryName: repository.name,
+      recorded,
+      skipped: outcomes.length - recorded,
+      outcomes,
+    };
+    log.info("Administrator completed retrieval-shadow sample", {
+      repositoryId: input.repositoryId,
+      queryCount: queries.length,
+      recorded: result.recorded,
+      skipped: result.skipped,
+    });
+    timer({
+      status: "success",
+      repositoryId: input.repositoryId,
+      queryCount: queries.length,
+      recorded: result.recorded,
+      skipped: result.skipped,
+    });
+    revalidatePath(ADMIN_SETTINGS_PATH);
+    return createSuccess(
+      result,
+      `Retrieval-shadow sample completed for ${repository.name}`,
+    );
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(
+      error,
+      "Failed to run the repository retrieval-shadow sample.",
+      {
+        context: "admin.contentMigration.retrievalShadowSample",
+        requestId,
+        operation: "recordRepositoryRetrievalShadowSampleAction",
+        metadata: { repositoryId: input.repositoryId },
+      },
+    );
   }
 }

--- a/actions/admin/repository-migration.actions.ts
+++ b/actions/admin/repository-migration.actions.ts
@@ -329,6 +329,7 @@ export async function recordRepositoryRetrievalShadowSampleAction(input: {
       await assertRepositoryReadAccess(
         input.repositoryId,
         administrator.cognitoSub,
+        { allowAdministratorOverride: false },
       );
     } catch (error) {
       if (!isRecordNotFoundError(error)) throw error;

--- a/actions/repositories/search.actions.ts
+++ b/actions/repositories/search.actions.ts
@@ -13,17 +13,14 @@ import {
   startTimer,
   sanitizeForLogging
 } from "@/lib/logger"
-import { vectorSearch, keywordSearch, hybridSearch, type SearchResult } from "@/lib/repositories/search-service"
-import { retrieveRepositoryContent } from "@/lib/repositories/retrieval-v2/service"
-import type { RetrievalResult } from "@/lib/repositories/retrieval-v2/types"
+import type { SearchResult } from "@/lib/repositories/search-service"
 import { hasCapabilityAccess } from "@/utils/roles"
 import { assertRepositoryReadAccess } from "@/lib/repositories/repository-access-guard"
 import {
   getContentPlatformConfig,
   isCanonicalRepositoryUploadActive,
-  type ContentPlatformConfig,
 } from "@/lib/repositories/content-platform/config"
-import { recordRepositoryRetrievalShadow } from "@/lib/repositories/content-platform/retrieval-shadow"
+import { executeSearch } from "@/lib/repositories/search-execution"
 
 export interface SearchRepositoryParams {
   query: string
@@ -31,144 +28,6 @@ export interface SearchRepositoryParams {
   searchType?: 'vector' | 'keyword' | 'hybrid'
   limit?: number
   vectorWeight?: number
-}
-
-interface SearchDispatchOptions {
-  searchType: 'vector' | 'keyword' | 'hybrid'
-  query: string
-  repositoryId: number
-  limit: number
-  vectorWeight: number
-  canonicalOnly: boolean
-}
-
-type RetrievalDiagnostics = Awaited<
-  ReturnType<typeof retrieveRepositoryContent>
->["diagnostics"]
-
-interface ExecuteSearchOptions extends SearchDispatchOptions {
-  userCognitoSub: string
-  contentConfig: ContentPlatformConfig
-  log: ReturnType<typeof createLogger>
-}
-
-// Dispatch to the requested search mode with pre-clamped bounds (not exported:
-// a "use server" file may only export async server actions).
-async function dispatchSearch({
-  searchType,
-  query,
-  repositoryId,
-  limit,
-  vectorWeight,
-  canonicalOnly,
-}: SearchDispatchOptions): Promise<SearchResult[]> {
-  const commonOptions = { repositoryId, limit, canonicalOnly }
-  switch (searchType) {
-    case 'vector':
-      return vectorSearch(query, commonOptions)
-    case 'keyword':
-      return keywordSearch(query, commonOptions)
-    case 'hybrid':
-    default:
-      return hybridSearch(query, { ...commonOptions, vectorWeight })
-  }
-}
-
-async function executeSearch(
-  options: ExecuteSearchOptions
-): Promise<{
-  results: SearchResult[]
-  diagnostics?: RetrievalDiagnostics
-}> {
-  if (options.canonicalOnly) {
-    const retrieval = await retrieveRepositoryContent({
-      query: options.query,
-      repositoryIds: [options.repositoryId],
-      userCognitoSub: options.userCognitoSub,
-      mode: options.searchType,
-      limit: options.limit,
-      denseWeight: options.vectorWeight,
-      includeLegacyCompatibility: false,
-    })
-    return {
-      results: retrieval.results.map(toLegacySearchResult),
-      diagnostics: retrieval.diagnostics,
-    }
-  }
-
-  const legacyStartedAt = Date.now()
-  const results = await dispatchSearch(options)
-  await recordRetrievalShadowIfEnabled(
-    options,
-    results,
-    Date.now() - legacyStartedAt
-  )
-  return { results }
-}
-
-async function recordRetrievalShadowIfEnabled(
-  options: ExecuteSearchOptions,
-  legacyResults: SearchResult[],
-  legacyDurationMs: number
-): Promise<void> {
-  const { contentConfig } = options
-  if (
-    !contentConfig.enabled ||
-    !contentConfig.readV2Enabled ||
-    !contentConfig.retrievalShadowEnabled
-  ) {
-    return
-  }
-
-  const canonicalStartedAt = Date.now()
-  try {
-    const canonicalShadow = await retrieveRepositoryContent({
-      query: options.query,
-      repositoryIds: [options.repositoryId],
-      userCognitoSub: options.userCognitoSub,
-      mode: options.searchType,
-      limit: options.limit,
-      denseWeight: options.vectorWeight,
-      includeLegacyCompatibility: false,
-    })
-    await recordRepositoryRetrievalShadow({
-      repositoryId: options.repositoryId,
-      product: "repository_manager",
-      searchMode: options.searchType,
-      legacyItemIds: legacyResults.map((result) => result.itemId),
-      canonicalItemIds: canonicalShadow.results.map((result) => result.itemId),
-      legacyDurationMs,
-      canonicalDurationMs: Date.now() - canonicalStartedAt,
-    })
-  } catch (shadowError) {
-    options.log.warn(
-      "Canonical retrieval shadow failed without affecting legacy search",
-      {
-        error:
-          shadowError instanceof Error
-            ? shadowError.message
-            : String(shadowError),
-      }
-    )
-  }
-}
-
-function toLegacySearchResult(result: RetrievalResult): SearchResult {
-  return {
-    chunkId: result.chunkId,
-    itemId: result.itemId,
-    itemName: result.itemName,
-    content: result.content,
-    similarity: result.similarity,
-    chunkIndex: result.chunkIndex,
-    metadata: result.metadata,
-    citation: {
-      itemStableId: result.itemStableId,
-      itemVersionId: result.itemVersionId,
-      versionNumber: result.versionNumber,
-      sourceLocator: result.sourceLocator,
-    },
-  }
 }
 
 export async function searchRepository(

--- a/app/(protected)/admin/settings/_components/content-platform-rollout-card.tsx
+++ b/app/(protected)/admin/settings/_components/content-platform-rollout-card.tsx
@@ -1,15 +1,23 @@
 "use client"
 
-import { useState } from "react"
+import { useState, type FormEvent } from "react"
 import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react"
+import {
+  recordRepositoryRetrievalShadowSampleAction,
+  type RepositoryRetrievalShadowSampleResult,
+} from "@/actions/admin/repository-migration.actions"
 import type {
   CreateSettingInput,
   Setting,
 } from "@/actions/db/settings-actions"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
 
 export const CONTENT_ROLLOUT_SETTING_KEYS = [
   "CONTENT_PLATFORM_ENABLED",
@@ -119,6 +127,8 @@ export function ContentPlatformRolloutCard({
           </span>
         </div>
 
+        <RetrievalShadowSampleForm />
+
         <div className="divide-y rounded-md border">
           {STAGES.map(([key, label], index) => {
             const setting = settingsByKey.get(key)
@@ -154,5 +164,128 @@ export function ContentPlatformRolloutCard({
         </div>
       </CardContent>
     </Card>
+  )
+}
+
+function RetrievalShadowSampleForm() {
+  const [repositoryId, setRepositoryId] = useState("")
+  const [queries, setQueries] = useState("")
+  const [isPending, setIsPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] =
+    useState<RepositoryRetrievalShadowSampleResult | null>(null)
+
+  async function runSample(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsPending(true)
+    setError(null)
+    setResult(null)
+    try {
+      const actionResult = await recordRepositoryRetrievalShadowSampleAction({
+        repositoryId: Number(repositoryId),
+        queries: queries.split(/\r?\n/).map(query => query.trim()),
+      })
+      if (!actionResult.isSuccess) {
+        setError(actionResult.message)
+        return
+      }
+      setResult(actionResult.data)
+    } catch {
+      setError("Failed to run the repository retrieval-shadow sample.")
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <form
+      className="space-y-3 rounded-md border p-4"
+      data-testid="retrieval-shadow-sample-form"
+      onSubmit={event => void runSample(event)}
+    >
+      <div>
+        <p className="font-medium">Record retrieval-shadow sample</p>
+        <p className="text-sm text-muted-foreground">
+          Run up to 25 queries through Repository Manager search without
+          changing rollout settings. Queries run in the order entered.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-[12rem_1fr]">
+        <div className="space-y-2">
+          <Label htmlFor="retrieval-shadow-repository-id">Repository ID</Label>
+          <Input
+            id="retrieval-shadow-repository-id"
+            inputMode="numeric"
+            min={1}
+            onChange={event => setRepositoryId(event.target.value)}
+            placeholder="41"
+            type="number"
+            value={repositoryId}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="retrieval-shadow-queries">
+            Sample queries (one per line)
+          </Label>
+          <Textarea
+            id="retrieval-shadow-queries"
+            onChange={event => setQueries(event.target.value)}
+            placeholder={"student handbook\nemergency closure procedure"}
+            rows={4}
+            value={queries}
+          />
+        </div>
+      </div>
+      <Button disabled={isPending} type="submit">
+        {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+        Run shadow sample
+      </Button>
+      {error ? (
+        <Alert variant="destructive" aria-live="polite">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Sample not run</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      {result ? <RetrievalShadowSampleOutcomes result={result} /> : null}
+    </form>
+  )
+}
+
+function RetrievalShadowSampleOutcomes({
+  result,
+}: {
+  result: RepositoryRetrievalShadowSampleResult
+}) {
+  return (
+    <div className="space-y-2 text-sm" aria-live="polite">
+      <p className="font-medium">
+        {result.repositoryName}: {result.recorded} recorded, {result.skipped}{" "}
+        skipped
+      </p>
+      <ul className="space-y-2">
+        {result.outcomes.map((outcome, index) => (
+          <li
+            className="rounded border px-3 py-2"
+            key={`${index}-${outcome.query}`}
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge
+                variant={outcome.status === "recorded" ? "secondary" : "outline"}
+              >
+                {outcome.status}
+              </Badge>
+              <span>{outcome.query}</span>
+              <span className="text-muted-foreground">
+                {outcome.resultCount} legacy results
+              </span>
+            </div>
+            {outcome.reason ? (
+              <p className="mt-1 text-muted-foreground">{outcome.reason}</p>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/lib/repositories/repository-access-guard.ts
+++ b/lib/repositories/repository-access-guard.ts
@@ -79,11 +79,13 @@ export async function assertUserManagedDurableRepository(
  * Throw `dbRecordNotFound` unless the caller (`cognitoSub`) can access the
  * active durable repository (public / owner / `repository_access` grant).
  * Administrators may inspect any durable repository through Repository Manager,
- * including private repositories they do not own.
+ * including private repositories they do not own. Callers that must match the
+ * canonical retrieval access model can disable that override.
  */
 export async function assertRepositoryReadAccess(
   repositoryId: number,
-  cognitoSub: string
+  cognitoSub: string,
+  options: { allowAdministratorOverride?: boolean } = {},
 ): Promise<void> {
   await assertUserManagedDurableRepository(repositoryId);
 
@@ -95,7 +97,10 @@ export async function assertRepositoryReadAccess(
     return;
   }
 
-  if (await checkUserRoleByCognitoSub(cognitoSub, "administrator")) {
+  if (
+    options.allowAdministratorOverride !== false &&
+    (await checkUserRoleByCognitoSub(cognitoSub, "administrator"))
+  ) {
     return;
   }
 

--- a/lib/repositories/search-execution.ts
+++ b/lib/repositories/search-execution.ts
@@ -1,0 +1,169 @@
+import "server-only"
+
+import { createLogger } from "@/lib/logger"
+import {
+  hybridSearch,
+  keywordSearch,
+  type SearchResult,
+  vectorSearch,
+} from "@/lib/repositories/search-service"
+import type { ContentPlatformConfig } from "@/lib/repositories/content-platform/config"
+import { recordRepositoryRetrievalShadow } from "@/lib/repositories/content-platform/retrieval-shadow"
+import { retrieveRepositoryContent } from "@/lib/repositories/retrieval-v2/service"
+import type { RetrievalResult } from "@/lib/repositories/retrieval-v2/types"
+
+export interface SearchDispatchOptions {
+  searchType: "vector" | "keyword" | "hybrid"
+  query: string
+  repositoryId: number
+  limit: number
+  vectorWeight: number
+  canonicalOnly: boolean
+}
+
+type RetrievalDiagnostics = Awaited<
+  ReturnType<typeof retrieveRepositoryContent>
+>["diagnostics"]
+
+export interface ExecuteSearchOptions extends SearchDispatchOptions {
+  userCognitoSub: string
+  contentConfig: ContentPlatformConfig
+  log: ReturnType<typeof createLogger>
+}
+
+export type RetrievalShadowExecutionOutcome =
+  | { status: "recorded" }
+  | { status: "skipped"; reason: string }
+
+export interface ExecuteSearchResult {
+  results: SearchResult[]
+  diagnostics?: RetrievalDiagnostics
+  shadowOutcome?: RetrievalShadowExecutionOutcome
+}
+
+async function dispatchSearch({
+  searchType,
+  query,
+  repositoryId,
+  limit,
+  vectorWeight,
+  canonicalOnly,
+}: SearchDispatchOptions): Promise<SearchResult[]> {
+  const commonOptions = { repositoryId, limit, canonicalOnly }
+  switch (searchType) {
+    case "vector":
+      return vectorSearch(query, commonOptions)
+    case "keyword":
+      return keywordSearch(query, commonOptions)
+    case "hybrid":
+    default:
+      return hybridSearch(query, { ...commonOptions, vectorWeight })
+  }
+}
+
+/**
+ * Shared Repository Manager search execution path. The normal search action and
+ * the bounded administrator sample action both enter here so shadow recording
+ * retains one implementation and remains fail-open.
+ */
+export async function executeSearch(
+  options: ExecuteSearchOptions,
+): Promise<ExecuteSearchResult> {
+  if (options.canonicalOnly) {
+    const retrieval = await retrieveRepositoryContent({
+      query: options.query,
+      repositoryIds: [options.repositoryId],
+      userCognitoSub: options.userCognitoSub,
+      mode: options.searchType,
+      limit: options.limit,
+      denseWeight: options.vectorWeight,
+      includeLegacyCompatibility: false,
+    })
+    return {
+      results: retrieval.results.map(toLegacySearchResult),
+      diagnostics: retrieval.diagnostics,
+    }
+  }
+
+  const legacyStartedAt = Date.now()
+  const results = await dispatchSearch(options)
+  const shadowOutcome = await recordRetrievalShadowIfEnabled(
+    options,
+    results,
+    Date.now() - legacyStartedAt,
+  )
+  return { results, shadowOutcome }
+}
+
+async function recordRetrievalShadowIfEnabled(
+  options: ExecuteSearchOptions,
+  legacyResults: SearchResult[],
+  legacyDurationMs: number,
+): Promise<RetrievalShadowExecutionOutcome> {
+  const { contentConfig } = options
+  if (
+    !contentConfig.enabled ||
+    !contentConfig.readV2Enabled ||
+    !contentConfig.retrievalShadowEnabled
+  ) {
+    return {
+      status: "skipped",
+      reason: "Retrieval shadow recording is disabled",
+    }
+  }
+
+  const canonicalStartedAt = Date.now()
+  try {
+    const canonicalShadow = await retrieveRepositoryContent({
+      query: options.query,
+      repositoryIds: [options.repositoryId],
+      userCognitoSub: options.userCognitoSub,
+      mode: options.searchType,
+      limit: options.limit,
+      denseWeight: options.vectorWeight,
+      includeLegacyCompatibility: false,
+    })
+    await recordRepositoryRetrievalShadow({
+      repositoryId: options.repositoryId,
+      product: "repository_manager",
+      searchMode: options.searchType,
+      legacyItemIds: legacyResults.map((result) => result.itemId),
+      canonicalItemIds: canonicalShadow.results.map((result) => result.itemId),
+      legacyDurationMs,
+      canonicalDurationMs: Date.now() - canonicalStartedAt,
+    })
+    return { status: "recorded" }
+  } catch (shadowError) {
+    options.log.warn(
+      "Canonical retrieval shadow failed without affecting legacy search",
+      {
+        error:
+          shadowError instanceof Error
+            ? shadowError.message
+            : String(shadowError),
+      },
+    )
+    return {
+      status: "skipped",
+      reason: "Canonical retrieval shadow failed; legacy results were served",
+    }
+  }
+}
+
+function toLegacySearchResult(result: RetrievalResult): SearchResult {
+  return {
+    chunkId: result.chunkId,
+    itemId: result.itemId,
+    itemName: result.itemName,
+    content: result.content,
+    similarity: result.similarity,
+    chunkIndex: result.chunkIndex,
+    metadata: result.metadata,
+    citation: {
+      itemStableId: result.itemStableId,
+      itemVersionId: result.itemVersionId,
+      versionNumber: result.versionNumber,
+      sourceLocator: result.sourceLocator,
+    },
+  }
+}

--- a/tests/e2e/admin-retrieval-shadow-sample.functional.spec.ts
+++ b/tests/e2e/admin-retrieval-shadow-sample.functional.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "./fixtures";
+import { authenticateContext } from "./helpers/session-auth";
+
+test.describe("Retrieval-shadow sample admin workflow", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires authenticated session against the host dev server",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await authenticateContext(page.context());
+    await page.goto("/admin/settings");
+    await page.getByRole("tab", { name: /Content Platform/ }).click();
+  });
+
+  test("runs a bounded sample from the guided rollout card", async ({ page }) => {
+    const postgres = (await import("postgres")).default;
+    const database = postgres(
+      process.env.E2E_DATABASE_URL ??
+        "postgresql://postgres:postgres@localhost:5432/aistudio",
+      { ssl: process.env.E2E_DB_SSL === "true" },
+    );
+    let repositoryId: number | null = null;
+    let previousObservationId = 0;
+
+    try {
+      const [repository] = await database<{ id: number }[]>`
+        SELECT id
+        FROM knowledge_repositories
+        WHERE metadata ->> 'e2eFixture' = 'unified-content'
+        LIMIT 1
+      `;
+      if (!repository) {
+        throw new Error("Unified-content E2E repository fixture is missing");
+      }
+      repositoryId = repository.id;
+      const [observation] = await database<{ id: number }[]>`
+        SELECT COALESCE(MAX(id), 0)::integer AS id
+        FROM repository_retrieval_shadow_observations
+        WHERE repository_id = ${repositoryId}
+      `;
+      previousObservationId = observation?.id ?? 0;
+
+      const form = page.getByTestId("retrieval-shadow-sample-form");
+      await expect(form).toBeVisible();
+      await form.getByLabel("Repository ID").fill(String(repositoryId));
+      await form
+        .getByLabel("Sample queries (one per line)")
+        .fill("attendance policy\nemergency closure procedure");
+      await form.getByRole("button", { name: "Run shadow sample" }).click();
+
+      await expect(
+        form.getByText(
+          /E2E Unified Content Repository: \d+ recorded, \d+ skipped/,
+        ),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(
+        form.getByText("attendance policy", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        form.getByText("emergency closure procedure", { exact: true }),
+      ).toBeVisible();
+    } finally {
+      if (repositoryId !== null) {
+        await database`
+          DELETE FROM repository_retrieval_shadow_observations
+          WHERE repository_id = ${repositoryId}
+            AND id > ${previousObservationId}
+        `;
+      }
+      await database.end();
+    }
+  });
+
+  test("shows an actionable error for an empty sample query", async ({ page }) => {
+    const form = page.getByTestId("retrieval-shadow-sample-form");
+    await expect(form).toBeVisible();
+    await form.getByLabel("Repository ID").fill("1");
+    await form.getByRole("button", { name: "Run shadow sample" }).click();
+
+    await expect(form.getByText("Sample query 1 must not be empty.")).toBeVisible();
+  });
+});

--- a/tests/e2e/admin-retrieval-shadow-sample.guard.spec.ts
+++ b/tests/e2e/admin-retrieval-shadow-sample.guard.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Retrieval-shadow sample admin guard", () => {
+  test("redirects unauthenticated callers before rendering the sample form", async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    await page.goto("/admin/settings");
+
+    await expect(page).toHaveURL(/\/api\/auth\/signin/);
+    await expect(
+      page.getByTestId("retrieval-shadow-sample-form"),
+    ).not.toBeVisible();
+  });
+});

--- a/tests/unit/actions/admin-repository-migration-shadow-sample.test.ts
+++ b/tests/unit/actions/admin-repository-migration-shadow-sample.test.ts
@@ -4,15 +4,17 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
 
-const mockGetServerSession = jest.fn();
-const mockGetUserIdFromSession = jest.fn();
-const mockHasRole = jest.fn();
-const mockGetRepositoryById = jest.fn();
-const mockAssertRepositoryReadAccess = jest.fn();
-const mockGetContentPlatformConfig = jest.fn();
-const mockExecuteSearch = jest.fn();
-const mockRevalidatePath = jest.fn();
-const mockTimer = jest.fn();
+type AsyncMock = (...args: unknown[]) => Promise<unknown>;
+
+const mockGetServerSession = jest.fn<AsyncMock>();
+const mockGetUserIdFromSession = jest.fn<AsyncMock>();
+const mockHasRole = jest.fn<AsyncMock>();
+const mockGetRepositoryById = jest.fn<AsyncMock>();
+const mockAssertRepositoryReadAccess = jest.fn<AsyncMock>();
+const mockGetContentPlatformConfig = jest.fn<AsyncMock>();
+const mockExecuteSearch = jest.fn<AsyncMock>();
+const mockRevalidatePath = jest.fn<(...args: unknown[]) => void>();
+const mockTimer = jest.fn<(...args: unknown[]) => void>();
 
 jest.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
 jest.mock("@/lib/auth/server-session", () => ({
@@ -172,6 +174,11 @@ describe("recordRepositoryRetrievalShadowSampleAction", () => {
       },
     });
     expect(mockExecuteSearch).toHaveBeenCalledTimes(2);
+    expect(mockAssertRepositoryReadAccess).toHaveBeenCalledWith(
+      41,
+      "admin-sub",
+      { allowAdministratorOverride: false },
+    );
     expect(mockExecuteSearch).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({

--- a/tests/unit/actions/admin-repository-migration-shadow-sample.test.ts
+++ b/tests/unit/actions/admin-repository-migration-shadow-sample.test.ts
@@ -1,0 +1,254 @@
+/** @jest-environment node */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockGetServerSession = jest.fn();
+const mockGetUserIdFromSession = jest.fn();
+const mockHasRole = jest.fn();
+const mockGetRepositoryById = jest.fn();
+const mockAssertRepositoryReadAccess = jest.fn();
+const mockGetContentPlatformConfig = jest.fn();
+const mockExecuteSearch = jest.fn();
+const mockRevalidatePath = jest.fn();
+const mockTimer = jest.fn();
+
+jest.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+jest.mock("@/lib/auth/server-session", () => ({
+  getServerSession: mockGetServerSession,
+}));
+jest.mock("@/actions/repositories/repository-permissions", () => ({
+  getUserIdFromSession: mockGetUserIdFromSession,
+}));
+jest.mock("@/utils/roles", () => ({ hasRole: mockHasRole }));
+jest.mock("@/lib/db/drizzle", () => ({
+  getRepositoryById: mockGetRepositoryById,
+}));
+jest.mock("@/lib/repositories/repository-access-guard", () => ({
+  assertRepositoryReadAccess: mockAssertRepositoryReadAccess,
+}));
+jest.mock("@/lib/repositories/content-platform/config", () => ({
+  getContentPlatformConfig: mockGetContentPlatformConfig,
+}));
+jest.mock("@/lib/repositories/search-execution", () => ({
+  executeSearch: mockExecuteSearch,
+}));
+jest.mock(
+  "@/lib/repositories/content-platform/migration-control-service",
+  () => ({
+    approveRepositoryMigrationMismatch: jest.fn(),
+    getRepositoryMigrationDashboard: jest.fn(),
+    listRepositoryMigrationExceptions: jest.fn(),
+    retryRepositoryMigrationItem: jest.fn(),
+    runRepositoryMigrationRollbackDrill: jest.fn(),
+    startRepositoryMigrationRun: jest.fn(),
+    startRepositoryRollbackRun: jest.fn(),
+  }),
+);
+jest.mock("@/lib/repositories/content-platform/migration-runner", () => ({
+  reprocessRepositoryMigrationItem: jest.fn(),
+}));
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  }),
+  generateRequestId: () => "shadow-sample-test",
+  getLogContext: () => ({}),
+  sanitizeForLogging: (value: unknown) => value,
+  startTimer: () => mockTimer,
+}));
+
+// eslint-disable-next-line max-lines-per-function -- One action contract with shared auth/search setup.
+describe("recordRepositoryRetrievalShadowSampleAction", () => {
+  let recordRepositoryRetrievalShadowSampleAction: typeof import("@/actions/admin/repository-migration.actions").recordRepositoryRetrievalShadowSampleAction;
+
+  beforeAll(async () => {
+    ({ recordRepositoryRetrievalShadowSampleAction } = await import(
+      "@/actions/admin/repository-migration.actions"
+    ));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({ sub: "admin-sub" });
+    mockGetUserIdFromSession.mockResolvedValue(7);
+    mockHasRole.mockResolvedValue(true);
+    mockGetRepositoryById.mockResolvedValue({ id: 41, name: "Policy Library" });
+    mockAssertRepositoryReadAccess.mockResolvedValue(undefined);
+    mockGetContentPlatformConfig.mockResolvedValue({
+      enabled: true,
+      readV2Enabled: true,
+      retrievalShadowEnabled: true,
+    });
+    mockExecuteSearch.mockResolvedValue({
+      results: [],
+      shadowOutcome: { status: "recorded" },
+    });
+  });
+
+  it("requires the administrator role before validating or searching", async () => {
+    mockHasRole.mockResolvedValue(false);
+
+    const result = await recordRepositoryRetrievalShadowSampleAction({
+      repositoryId: 41,
+      queries: ["attendance policy"],
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetRepositoryById).not.toHaveBeenCalled();
+    expect(mockExecuteSearch).not.toHaveBeenCalled();
+  });
+
+  it("enforces the 25-query cap", async () => {
+    const result = await recordRepositoryRetrievalShadowSampleAction({
+      repositoryId: 41,
+      queries: Array.from({ length: 26 }, (_, index) => `query ${index}`),
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: false,
+      message: "Provide between 1 and 25 sample queries.",
+    });
+    expect(mockGetRepositoryById).not.toHaveBeenCalled();
+    expect(mockExecuteSearch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty query", async () => {
+    const result = await recordRepositoryRetrievalShadowSampleAction({
+      repositoryId: 41,
+      queries: ["attendance policy", "   "],
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: false,
+      message: "Sample query 2 must not be empty.",
+    });
+    expect(mockExecuteSearch).not.toHaveBeenCalled();
+  });
+
+  it("runs each trimmed query in order through executeSearch with canonicalOnly false", async () => {
+    mockExecuteSearch
+      .mockResolvedValueOnce({
+        results: [{ itemId: 1 }],
+        shadowOutcome: { status: "recorded" },
+      })
+      .mockResolvedValueOnce({
+        results: [{ itemId: 2 }, { itemId: 3 }],
+        shadowOutcome: {
+          status: "skipped",
+          reason: "Retrieval shadow recording is disabled",
+        },
+      });
+
+    const result = await recordRepositoryRetrievalShadowSampleAction({
+      repositoryId: 41,
+      queries: ["  attendance policy ", "emergency closure"],
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: true,
+      data: {
+        repositoryId: 41,
+        repositoryName: "Policy Library",
+        recorded: 1,
+        skipped: 1,
+        outcomes: [
+          {
+            query: "attendance policy",
+            status: "recorded",
+            resultCount: 1,
+          },
+          {
+            query: "emergency closure",
+            status: "skipped",
+            resultCount: 2,
+            reason: "Retrieval shadow recording is disabled",
+          },
+        ],
+      },
+    });
+    expect(mockExecuteSearch).toHaveBeenCalledTimes(2);
+    expect(mockExecuteSearch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        canonicalOnly: false,
+        query: "attendance policy",
+        repositoryId: 41,
+        userCognitoSub: "admin-sub",
+      }),
+    );
+    expect(mockExecuteSearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        canonicalOnly: false,
+        query: "emergency closure",
+        repositoryId: 41,
+      }),
+    );
+  });
+
+  it("reports a repository access failure with the repository name", async () => {
+    mockAssertRepositoryReadAccess.mockRejectedValue(
+      Object.assign(new Error("masked"), { code: "DB_RECORD_NOT_FOUND" }),
+    );
+
+    const result = await recordRepositoryRetrievalShadowSampleAction({
+      repositoryId: 41,
+      queries: ["attendance policy"],
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: false,
+      message:
+        'Access to repository "Policy Library" is required before recording a retrieval-shadow sample.',
+    });
+    expect(mockExecuteSearch).not.toHaveBeenCalled();
+  });
+
+  it("keeps a shadow failure fail-open and reports the query as skipped", async () => {
+    mockExecuteSearch.mockResolvedValue({
+      results: [{ itemId: 1 }],
+      shadowOutcome: {
+        status: "skipped",
+        reason: "Canonical retrieval shadow failed; legacy results were served",
+      },
+    });
+
+    const result = await recordRepositoryRetrievalShadowSampleAction({
+      repositoryId: 41,
+      queries: ["attendance policy"],
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: true,
+      data: {
+        recorded: 0,
+        skipped: 1,
+        outcomes: [
+          {
+            status: "skipped",
+            reason:
+              "Canonical retrieval shadow failed; legacy results were served",
+          },
+        ],
+      },
+    });
+  });
+
+  it("does not write the observations table or invoke the recorder directly", () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        "actions/admin/repository-migration.actions.ts",
+      ),
+      "utf8",
+    );
+
+    expect(source).not.toContain("repository_retrieval_shadow_observations");
+    expect(source).not.toMatch(/\brecordRepositoryRetrievalShadow\(/);
+  });
+});

--- a/tests/unit/actions/repositories/search-actions.test.ts
+++ b/tests/unit/actions/repositories/search-actions.test.ts
@@ -17,6 +17,13 @@ const mockRetrieveV2 = jest.fn<(...a: unknown[]) => Promise<{ results: unknown[]
   () => Promise.resolve({ results: [], diagnostics: {} })
 )
 const mockIsCanonicalRepositoryUploadActive = jest.fn(() => false)
+const mockGetContentPlatformConfig = jest.fn(() => Promise.resolve({
+  enabled: false,
+  readV2Enabled: false,
+  retrievalShadowEnabled: false,
+}))
+const mockRecordRepositoryRetrievalShadow = jest.fn(() => Promise.resolve())
+const mockWarn = jest.fn()
 
 jest.mock('@/lib/auth/server-session', () => ({ getServerSession: mockGetServerSession }))
 jest.mock('@/utils/roles', () => ({ hasCapabilityAccess: mockHasCapabilityAccess }))
@@ -24,8 +31,11 @@ jest.mock('@/lib/repositories/repository-access-guard', () => ({
   assertRepositoryReadAccess: mockAssertRepositoryReadAccess,
 }))
 jest.mock('@/lib/repositories/content-platform/config', () => ({
-  getContentPlatformConfig: jest.fn(async () => ({ enabled: false, readV2Enabled: false })),
+  getContentPlatformConfig: mockGetContentPlatformConfig,
   isCanonicalRepositoryUploadActive: mockIsCanonicalRepositoryUploadActive,
+}))
+jest.mock('@/lib/repositories/content-platform/retrieval-shadow', () => ({
+  recordRepositoryRetrievalShadow: mockRecordRepositoryRetrievalShadow,
 }))
 jest.mock('@/lib/repositories/retrieval-v2/service', () => ({
   retrieveRepositoryContent: mockRetrieveV2,
@@ -34,7 +44,7 @@ jest.mock('@/lib/repositories/search-service', () => ({
   vectorSearch: mockVector, keywordSearch: mockKeyword, hybridSearch: mockHybrid,
 }))
 jest.mock('@/lib/logger', () => ({
-  createLogger: () => ({ info: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+  createLogger: () => ({ info: jest.fn(), debug: jest.fn(), warn: mockWarn, error: jest.fn() }),
   generateRequestId: () => 't', startTimer: () => jest.fn(), sanitizeForLogging: (x: unknown) => x, getLogContext: () => ({}),
 }))
 
@@ -47,6 +57,12 @@ describe('searchRepository authorization (REV-COR-062 / REV-SEC-081)', () => {
     mockHasCapabilityAccess.mockResolvedValue(true)
     mockAssertRepositoryReadAccess.mockResolvedValue(undefined)
     mockIsCanonicalRepositoryUploadActive.mockReturnValue(false)
+    mockGetContentPlatformConfig.mockResolvedValue({
+      enabled: false,
+      readV2Enabled: false,
+      retrievalShadowEnabled: false,
+    })
+    mockRetrieveV2.mockResolvedValue({ results: [], diagnostics: {} })
   })
 
   it('rejects a caller lacking the knowledge-repositories capability', async () => {
@@ -126,5 +142,56 @@ describe('searchRepository authorization (REV-COR-062 / REV-SEC-081)', () => {
       includeLegacyCompatibility: false,
     })
     expect(mockHybrid).not.toHaveBeenCalled()
+  })
+
+  it('records an enabled shadow observation through the shared executor', async () => {
+    mockGetContentPlatformConfig.mockResolvedValue({
+      enabled: true,
+      readV2Enabled: true,
+      retrievalShadowEnabled: true,
+    })
+    mockHybrid.mockResolvedValue([{ itemId: 11 }])
+    mockRetrieveV2.mockResolvedValue({
+      results: [{ itemId: 11 }],
+      diagnostics: {},
+    })
+
+    const result = await searchRepository({
+      query: 'policy',
+      repositoryId: 5,
+    })
+
+    expect(result.isSuccess).toBe(true)
+    expect(mockRecordRepositoryRetrievalShadow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryId: 5,
+        product: 'repository_manager',
+        searchMode: 'hybrid',
+        legacyItemIds: [11],
+        canonicalItemIds: [11],
+      })
+    )
+  })
+
+  it('keeps legacy search successful when the canonical shadow fails', async () => {
+    mockGetContentPlatformConfig.mockResolvedValue({
+      enabled: true,
+      readV2Enabled: true,
+      retrievalShadowEnabled: true,
+    })
+    mockHybrid.mockResolvedValue([{ itemId: 11 }])
+    mockRetrieveV2.mockRejectedValue(new Error('canonical unavailable'))
+
+    const result = await searchRepository({
+      query: 'policy',
+      repositoryId: 5,
+    })
+
+    expect(result.isSuccess).toBe(true)
+    expect(mockRecordRepositoryRetrievalShadow).not.toHaveBeenCalled()
+    expect(mockWarn).toHaveBeenCalledWith(
+      'Canonical retrieval shadow failed without affecting legacy search',
+      { error: 'canonical unavailable' }
+    )
   })
 })

--- a/tests/unit/actions/repositories/search-actions.test.ts
+++ b/tests/unit/actions/repositories/search-actions.test.ts
@@ -22,7 +22,9 @@ const mockGetContentPlatformConfig = jest.fn(() => Promise.resolve({
   readV2Enabled: false,
   retrievalShadowEnabled: false,
 }))
-const mockRecordRepositoryRetrievalShadow = jest.fn(() => Promise.resolve())
+const mockRecordRepositoryRetrievalShadow = jest.fn<(...a: unknown[]) => Promise<void>>(
+  () => Promise.resolve()
+)
 const mockWarn = jest.fn()
 
 jest.mock('@/lib/auth/server-session', () => ({ getServerSession: mockGetServerSession }))

--- a/tests/unit/atrium-system-repo-item-guard.test.ts
+++ b/tests/unit/atrium-system-repo-item-guard.test.ts
@@ -125,6 +125,11 @@ describe("shared repository-access guards", () => {
 
     isAdministrator = true;
     await expect(assertRepositoryReadAccess(8, "user-1")).resolves.toBeUndefined();
+    await expect(
+      assertRepositoryReadAccess(8, "user-1", {
+        allowAdministratorOverride: false,
+      })
+    ).rejects.toBeDefined();
     await expect(assertRepositoryReadAccess(4, "user-1")).rejects.toBeDefined();
     await expect(assertRepositoryReadAccess(9, "user-1")).rejects.toBeDefined();
   });


### PR DESCRIPTION
## Summary

- add an administrator-only, bounded deterministic retrieval-shadow sample action with validated repository and query inputs
- execute each sample through the real `executeSearch` path with `canonicalOnly: false`, preserving the existing recorder and fail-open behavior
- return per-query recorded/skipped outcomes and clear repository access errors without directly writing retrieval observations
- expose the action in the existing content-platform rollout UI
- add focused action/search tests and authenticated plus guard E2E coverage

## Verification

- `bun run lint` — passed
- `bun run typecheck` — passed
- `bun run test -- --runInBand` — passed
- focused Jest action/search suites — 18 passed
- issue-specific Playwright coverage — 3 passed
- mandatory authenticated pre-push E2E suite — 311 passed, 40 environment-gated skipped, 1 unrelated semantic-search test flaky and passed on retry; hook exited 0
- focused diff/security review — no material findings

The repository E2E wrapper frozen-install preflight exposed the existing `origin/dev` `package.json`/`bun.lock` mismatch, so the suite reused an existing complete dependency tree and an isolated local database/server. No dependency install was performed.

## Deployment notes

Application-only change. No schema migration or infrastructure change is required. No deployment, production settings change, production sample, or production data operation was performed.

Closes #1533
Parent epic: #1523