### PR TITLE
fix(repositories): restore locked recovery semantics

### DIFF
--- a/actions/repositories/repository-items.actions.ts
+++ b/actions/repositories/repository-items.actions.ts
@@ -1338,15 +1338,8 @@ async function prepareRepositoryItemRetry(
     await assertCanonicalRetryNotQuarantined(item.currentVersionId)
   }
 
-  // Retry is an explicit, operator-initiated recovery action for an item that
-  // already failed, so it registers through the canonical pipeline
-  // unconditionally — exactly as the URL branch below always has. Routing it
-  // through the dual-write gate instead would make every failure this action
-  // advertises as retryable ("Content processing never started", "Embedding
-  // generation could not be queued", …) unrecoverable in the legacy
-  // configuration where those failures are actually produced.
   if (item.type === "text") {
-    const canonical = await registerCanonicalText({
+    const canonical = await registerCanonicalTextIfEnabled({
       itemId: item.id,
       repositoryId: item.repositoryId,
       userId,
@@ -1354,6 +1347,11 @@ async function prepareRepositoryItemRetry(
       content: item.source,
       traceId: requestId,
     })
+    if (!canonical) {
+      throw ErrorFactories.sysConfigurationError(
+        "Canonical content processing is disabled"
+      )
+    }
     return {
       itemVersionId: canonical.version.id,
       processingJobId: canonical.inspectJob.id,
@@ -1411,7 +1409,7 @@ async function prepareRepositoryItemRetry(
       "A positive content length and content type are required"
     )
   }
-  const canonical = await registerCanonicalUpload({
+  const canonical = await registerCanonicalUploadIfEnabled({
     itemId: item.id,
     userId,
     objectKey: copied.key,
@@ -1420,6 +1418,11 @@ async function prepareRepositoryItemRetry(
     byteSize: copiedMetadata.contentLength,
     traceId: requestId,
   })
+  if (!canonical) {
+    throw ErrorFactories.sysConfigurationError(
+      "Canonical content processing is disabled"
+    )
+  }
   return {
     itemVersionId: canonical.version.id,
     processingJobId: canonical.inspectJob.id,

--- a/lib/repositories/content-platform/operational-metrics.ts
+++ b/lib/repositories/content-platform/operational-metrics.ts
@@ -1,9 +1,5 @@
 import { sql } from "drizzle-orm";
 import { executeQuery, toPgRows } from "@/lib/db/drizzle-client";
-import {
-  getContentPlatformConfig,
-  isCanonicalRepositoryUploadActive,
-} from "./config";
 import { ORPHANED_ITEM_SWEEP_MINUTES } from "./orphaned-item-sweep";
 
 export interface ContentPlatformOperationalSnapshot {
@@ -62,14 +58,22 @@ function finiteNumber(value: number | string | null | undefined): number {
 }
 
 /**
- * Version-less items past the sweep age bound. Only meaningful once canonical
- * registration is unconditional — before the repository cutover the legacy
- * pipeline's live SQS/Textract work is version-less by design, so this
- * predicate would report healthy backlog as orphaned. Mirrors the guard in
- * `failOrphanedRepositoryItems` so the metric never claims orphans the sweep
- * deliberately refuses to touch.
+ * Load one bounded operational snapshot for the unified-content CloudWatch
+ * dashboard. All time-series values use the same rolling 24-hour window.
  */
-const ORPHANED_ITEMS_COUNT_SQL = sql`(
+// eslint-disable-next-line complexity, max-lines-per-function -- A single bounded database round trip produces a point-in-time, internally consistent snapshot.
+export async function getContentPlatformOperationalSnapshot(): Promise<ContentPlatformOperationalSnapshot> {
+  const result = await executeQuery(
+    // eslint-disable-next-line max-lines-per-function -- The correlated aggregates intentionally share one snapshot and timestamp.
+    (db) =>
+      db.execute(sql`
+        SELECT
+          (
+            SELECT COUNT(*)::integer
+            FROM repository_items
+            WHERE lifecycle_status = 'unavailable'
+          ) AS unavailable_items,
+          (
             SELECT COUNT(*)::integer
             FROM repository_items item
             INNER JOIN knowledge_repositories repository
@@ -92,28 +96,7 @@ const ORPHANED_ITEMS_COUNT_SQL = sql`(
                   ON job.item_version_id = version.id
                 WHERE version.item_id = item.id
               )
-          )`;
-
-/**
- * Load one bounded operational snapshot for the unified-content CloudWatch
- * dashboard. All time-series values use the same rolling 24-hour window.
- */
-// eslint-disable-next-line complexity, max-lines-per-function -- A single bounded database round trip produces a point-in-time, internally consistent snapshot.
-export async function getContentPlatformOperationalSnapshot(): Promise<ContentPlatformOperationalSnapshot> {
-  const canonicalUploadActive = isCanonicalRepositoryUploadActive(
-    await getContentPlatformConfig(),
-  );
-  const result = await executeQuery(
-    // eslint-disable-next-line max-lines-per-function -- The correlated aggregates intentionally share one snapshot and timestamp.
-    (db) =>
-      db.execute(sql`
-        SELECT
-          (
-            SELECT COUNT(*)::integer
-            FROM repository_items
-            WHERE lifecycle_status = 'unavailable'
-          ) AS unavailable_items,
-          ${canonicalUploadActive ? ORPHANED_ITEMS_COUNT_SQL : sql`0::integer`} AS orphaned_items,
+          ) AS orphaned_items,
           (
             SELECT COUNT(*)::integer
             FROM repository_item_chunks chunk

--- a/lib/repositories/content-platform/orphaned-item-sweep.ts
+++ b/lib/repositories/content-platform/orphaned-item-sweep.ts
@@ -3,10 +3,6 @@ import {
   executeTransaction,
   toPgRows,
 } from "@/lib/db/drizzle-client";
-import {
-  getContentPlatformConfig,
-  isCanonicalRepositoryUploadActive,
-} from "./config";
 
 export const ORPHANED_ITEM_SWEEP_MINUTES = 60;
 export const ORPHANED_ITEM_SWEEP_BATCH = 100;
@@ -37,24 +33,10 @@ function requirePositiveInteger(value: number, name: string): number {
  * Fail one bounded batch of pre-canonical items whose registration never
  * created a current version or processing job. Locked rows are skipped so
  * overlapping scheduled invocations cannot claim the same item.
- *
- * The sweep only runs after the repository cutover. Before it, the legacy
- * pipeline owns processing and its live work is invisible to this predicate:
- * queued file work lives in SQS, OCR continues asynchronously through Textract,
- * and neither writes a `repository_item_versions` or `repository_processing_jobs`
- * row. Age alone would then mark a slow-but-healthy queue or a long OCR as
- * failed and let the UI start a competing canonical retry before the original
- * worker wrote its result. Once canonical registration is unconditional, every
- * active item is expected to carry a version, so a version-less item past the
- * age bound really is a registration that never started.
  */
 export async function failOrphanedRepositoryItems(
   options: FailOrphanedRepositoryItemsOptions = {},
 ): Promise<{ failed: number }> {
-  if (!isCanonicalRepositoryUploadActive(await getContentPlatformConfig())) {
-    return { failed: 0 };
-  }
-
   const now = options.now ?? new Date();
   const minimumAgeMinutes = requirePositiveInteger(
     options.minimumAgeMinutes ?? ORPHANED_ITEM_SWEEP_MINUTES,

--- a/tests/unit/actions/repositories/repository-items-actions.test.ts
+++ b/tests/unit/actions/repositories/repository-items-actions.test.ts
@@ -400,7 +400,7 @@ it('repairs failed inline text by creating a fresh immutable source version', as
     source: 'ORCHID-COMPASS-742',
     currentVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
   })
-  mockRegisterCanonicalText.mockResolvedValue({
+  mockRegisterCanonicalTextIfEnabled.mockResolvedValue({
     created: true,
     version: { id: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff' },
     inspectJob: { id: 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa' },
@@ -409,7 +409,7 @@ it('repairs failed inline text by creating a fresh immutable source version', as
   const result = await mod.retryRepositoryItemProcessing(38)
 
   expect(result.isSuccess).toBe(true)
-  expect(mockRegisterCanonicalText).toHaveBeenCalledWith({
+  expect(mockRegisterCanonicalTextIfEnabled).toHaveBeenCalledWith({
     itemId: 38,
     repositoryId: 5,
     userId: 1,
@@ -443,7 +443,7 @@ it('does not let inline text supersede a post-deployment recovery quarantine', a
   const result = await mod.retryRepositoryItemProcessing(38)
 
   expect(result.isSuccess).toBe(false)
-  expect(mockRegisterCanonicalText).not.toHaveBeenCalled()
+  expect(mockRegisterCanonicalTextIfEnabled).not.toHaveBeenCalled()
   expect(mockRetryCanonicalRepositoryItem).not.toHaveBeenCalled()
   expect(mockDispatchContentProcessingJob).not.toHaveBeenCalled()
 })
@@ -461,7 +461,7 @@ it('repairs a legacy file by copying it into the canonical source namespace', as
     },
     currentVersionId: null,
   })
-  mockRegisterCanonicalUpload.mockResolvedValue({
+  mockRegisterCanonicalUploadIfEnabled.mockResolvedValue({
     created: true,
     version: { id: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff' },
     inspectJob: { id: 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa' },
@@ -475,7 +475,7 @@ it('repairs a legacy file by copying it into the canonical source namespace', as
     sourceKey: '1/1700000000-legacy.pdf',
     fileName: 'legacy.pdf',
   })
-  expect(mockRegisterCanonicalUpload).toHaveBeenCalledWith({
+  expect(mockRegisterCanonicalUploadIfEnabled).toHaveBeenCalledWith({
     itemId: 39,
     userId: 1,
     objectKey: 'repositories/5/11111111-2222-4333-8444-555555555555/legacy.pdf',
@@ -484,11 +484,6 @@ it('repairs a legacy file by copying it into the canonical source namespace', as
     byteSize: 1,
     traceId: 't',
   })
-  // The default fixture is the legacy configuration (dual-write gate off).
-  // Recovery must not route through the gated helper there: it would resolve
-  // null and strand the very failures this action advertises as retryable,
-  // after having already copied the source object.
-  expect(mockRegisterCanonicalUploadIfEnabled).not.toHaveBeenCalled()
   expect(mockDispatchContentProcessingJob).toHaveBeenCalledWith({
     jobId: 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa',
     itemVersionId: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff',

--- a/tests/unit/lib/repositories/content-platform-orphaned-item-sweep.test.ts
+++ b/tests/unit/lib/repositories/content-platform-orphaned-item-sweep.test.ts
@@ -9,12 +9,7 @@ jest.mock("@/lib/db/drizzle-client", () => ({
   toPgRows: (rows: unknown) => rows,
 }));
 
-jest.mock("@/lib/settings-manager", () => ({
-  getSettings: jest.fn(),
-}));
-
 import { executeTransaction } from "@/lib/db/drizzle-client";
-import { getSettings } from "@/lib/settings-manager";
 import {
   failOrphanedRepositoryItems,
   ORPHANED_ITEM_FAILURE_MESSAGE,
@@ -26,23 +21,10 @@ import { isRetryableLegacyItemFailure } from "@/lib/repositories/content-platfor
 const mockExecuteTransaction = executeTransaction as jest.MockedFunction<
   typeof executeTransaction
 >;
-const mockGetSettings = getSettings as jest.MockedFunction<typeof getSettings>;
-
-/** The repository cutover requires the master switch, canonical reads, and the repository flag. */
-function cutoverSettings(active: boolean): Record<string, string | null> {
-  const flag = active ? "true" : "false";
-  return {
-    CONTENT_PLATFORM_ENABLED: flag,
-    CONTENT_READ_V2_ENABLED: flag,
-    CONTENT_REPOSITORY_CUTOVER_ENABLED: flag,
-  };
-}
 
 describe("orphaned repository item sweep", () => {
   beforeEach(() => {
     mockExecuteTransaction.mockReset();
-    mockGetSettings.mockReset();
-    mockGetSettings.mockResolvedValue(cutoverSettings(true));
   });
 
   it("atomically fails one bounded batch of active, job-less items", async () => {
@@ -78,20 +60,6 @@ describe("orphaned repository item sweep", () => {
     expect(compiled.params).toContain("2026-08-01T11:43:00.000Z");
     expect(compiled.params).toContain(23);
     expect(compiled.params).toContain(ORPHANED_ITEM_FAILURE_MESSAGE);
-  });
-
-  it("does not fail legacy in-flight items before the repository cutover", async () => {
-    mockGetSettings.mockResolvedValue(cutoverSettings(false));
-
-    await expect(
-      failOrphanedRepositoryItems({
-        now: new Date("2026-08-01T12:00:00.000Z"),
-      }),
-    ).resolves.toEqual({ failed: 0 });
-
-    // Legacy file work lives in SQS and Textract without a version or job row,
-    // so the sweep must not touch the database at all in that configuration.
-    expect(mockExecuteTransaction).not.toHaveBeenCalled();
   });
 
   it("uses the locked production bounds and produces a retryable failure", () => {


### PR DESCRIPTION
## Summary

PR #1543 was fully green and reviewed at head `683370d84`, but an external review workflow appended commits `ece13efbe` and `2c50a3bca` after the final head check and immediately before merge. Those commits changed two decisions explicitly locked in #1528 and were merged without checks on that new head.

This correction reverses only those two late commits:

- restore the accepted rollout-gated file/text retry helpers specified by #1528
- restore the specified bounded version-less orphan sweep and matching metric without a cutover guard
- retain #1529's valid generation-less embedding-health metric fix from `683370d84`

The five corrected files are byte-for-byte identical to the reviewed `683370d84` versions.

## Verification

- `bun run test -- --runInBand tests/unit/actions/repositories/repository-items-actions.test.ts tests/unit/lib/repositories/content-platform-orphaned-item-sweep.test.ts tests/unit/lib/repositories/content-operational-metrics.test.ts` — PASS, 3 suites / 34 tests
- focused ESLint on all five corrected files — PASS, zero warnings
- `git diff --exit-code 683370d84 -- <five corrected files>` — PASS

The full repository gates passed on PR #1543 at `683370d84`; this PR restores those exact source/test versions. CI will rerun the repository gates on this corrective diff.

## Deployment notes

No deployment, schema migration, IAM grant, legacy URL embedding wiring, production setting change, or production data operation is included.

Restores the locked acceptance criteria for #1528 and #1529 after #1543.
Part of #1523.
