### PR TITLE
Add bounded unified-content recovery controls

### DIFF
--- a/actions/admin/repository-migration.actions.ts
+++ b/actions/admin/repository-migration.actions.ts
@@ -11,6 +11,8 @@ import {
   approveRepositoryMigrationMismatch,
   getRepositoryMigrationDashboard,
   listRepositoryMigrationExceptions,
+  MAX_FAILED_REPOSITORY_MIGRATION_RETRIES,
+  retryFailedRepositoryMigrationItems,
   retryRepositoryMigrationItem,
   runRepositoryMigrationRollbackDrill,
   startRepositoryMigrationRun,
@@ -19,8 +21,17 @@ import {
   type RepositoryMigrationException,
 } from "@/lib/repositories/content-platform/migration-control-service";
 import { reprocessRepositoryMigrationItem } from "@/lib/repositories/content-platform/migration-runner";
+import { dispatchContentProcessingJob } from "@/lib/repositories/content-platform/dispatch-service";
+import {
+  getCanonicalRepositoryItemStatuses,
+  retryCanonicalRepositoryItem,
+  type CanonicalRepositoryItemStatus,
+} from "@/lib/repositories/content-platform/status-service";
 import { getContentPlatformConfig } from "@/lib/repositories/content-platform/config";
-import { assertRepositoryReadAccess } from "@/lib/repositories/repository-access-guard";
+import {
+  assertNotSystemManagedRepository,
+  assertRepositoryReadAccess,
+} from "@/lib/repositories/repository-access-guard";
 import { executeSearch } from "@/lib/repositories/search-execution";
 import { getRepositoryById } from "@/lib/db/drizzle";
 import { ErrorCode } from "@/types/error-types";
@@ -33,6 +44,8 @@ import type {
 const ADMIN_REPOSITORIES_PATH = "/admin/repositories";
 const ADMIN_SETTINGS_PATH = "/admin/settings";
 const MAX_RETRIEVAL_SHADOW_SAMPLE_QUERIES = 25;
+const MAX_MIGRATION_MISMATCH_REPROCESSES = 50;
+const MAX_REPOSITORY_ITEM_BULK_RETRIES = 100;
 
 interface MigrationAdministrator {
   userId: number;
@@ -49,6 +62,27 @@ async function requireMigrationAdministrator(): Promise<MigrationAdministrator> 
     userId: await getUserIdFromSession(session.sub),
     cognitoSub: session.sub,
   };
+}
+
+function validateBulkLimit(limit: number, maximum: number): void {
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximum) {
+    throw ErrorFactories.valueOutOfRange("limit", limit, 1, maximum, {
+      userMessage: `Limit must be between 1 and ${maximum}.`,
+    });
+  }
+}
+
+function isRepositoryItemBulkRetryCandidate(
+  status: CanonicalRepositoryItemStatus,
+): boolean {
+  const activeAndUnderEmbedded =
+    status.processingStatus === "embedded" &&
+    !status.activeEmbeddingComplete;
+  const buildingAndUnderEmbedded =
+    status.processingStatus === "processing_embeddings" &&
+    status.totalChunks > 0 &&
+    status.embeddedChunks < status.totalChunks;
+  return status.canRetry || activeAndUnderEmbedded || buildingAndUnderEmbedded;
 }
 
 export async function getRepositoryMigrationDashboardAction(): Promise<
@@ -162,6 +196,148 @@ export async function reprocessRepositoryMigrationItemAction(
       context: "admin.contentMigration.reprocess",
       requestId,
       operation: "reprocessRepositoryMigrationItemAction",
+    });
+  }
+}
+
+/** Queue one bounded set of terminal migration sources behind a single run. */
+export async function retryFailedRepositoryMigrationItemsAction(input: {
+  limit: number;
+}): Promise<ActionState<RepositoryMigrationRunRow>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("admin.contentMigration.retryFailedBulk");
+  try {
+    const { userId: requestedBy } = await requireMigrationAdministrator();
+    validateBulkLimit(input.limit, MAX_FAILED_REPOSITORY_MIGRATION_RETRIES);
+    const run = await retryFailedRepositoryMigrationItems({
+      requestedBy,
+      limit: input.limit,
+    });
+    timer({ status: "success", runId: run.id, limit: input.limit });
+    revalidatePath(ADMIN_REPOSITORIES_PATH);
+    return createSuccess(run, "Failed migration sources queued for retry");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to queue migration retries.", {
+      context: "admin.contentMigration.retryFailedBulk",
+      requestId,
+      operation: "retryFailedRepositoryMigrationItemsAction",
+    });
+  }
+}
+
+export interface RepositoryMigrationMismatchReprocessResult {
+  reprocessed: number;
+  migrationItemIds: string[];
+}
+
+/** Reprocess a bounded set of reconciliation mismatches using the item service. */
+export async function reprocessRepositoryMigrationMismatchesAction(input: {
+  limit: number;
+}): Promise<ActionState<RepositoryMigrationMismatchReprocessResult>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("admin.contentMigration.reprocessMismatches");
+  try {
+    await requireMigrationAdministrator();
+    validateBulkLimit(input.limit, MAX_MIGRATION_MISMATCH_REPROCESSES);
+    const exceptions = await listRepositoryMigrationExceptions(200);
+    const mismatches = exceptions
+      .filter((exception) => exception.status === "mismatch")
+      .slice(0, input.limit);
+    for (const mismatch of mismatches) {
+      await reprocessRepositoryMigrationItem(mismatch.id);
+    }
+    const result = {
+      reprocessed: mismatches.length,
+      migrationItemIds: mismatches.map((mismatch) => mismatch.id),
+    };
+    timer({ status: "success", reprocessed: result.reprocessed });
+    revalidatePath(ADMIN_REPOSITORIES_PATH);
+    return createSuccess(result, "Migration mismatches queued for reprocessing");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to reprocess migration mismatches.", {
+      context: "admin.contentMigration.reprocessMismatches",
+      requestId,
+      operation: "reprocessRepositoryMigrationMismatchesAction",
+    });
+  }
+}
+
+export interface RepositoryItemsBulkRetryResult {
+  retried: number;
+  dispatchDeferred: number;
+  itemIds: number[];
+}
+
+/** Retry terminal or completed-but-under-embedded canonical repository items. */
+export async function retryRepositoryItemsBulkAction(input: {
+  repositoryId: number;
+  limit: number;
+}): Promise<ActionState<RepositoryItemsBulkRetryResult>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("admin.contentMigration.retryRepositoryItemsBulk");
+  const log = createLogger({
+    requestId,
+    action: "admin.contentMigration.retryRepositoryItemsBulk",
+  });
+  try {
+    await requireMigrationAdministrator();
+    if (!Number.isSafeInteger(input.repositoryId) || input.repositoryId < 1) {
+      throw ErrorFactories.invalidInput(
+        "repositoryId",
+        input.repositoryId,
+        "positive integer",
+      );
+    }
+    validateBulkLimit(input.limit, MAX_REPOSITORY_ITEM_BULK_RETRIES);
+    await assertNotSystemManagedRepository(input.repositoryId);
+    const statuses = await getCanonicalRepositoryItemStatuses(
+      input.repositoryId,
+    );
+    const candidates = [...statuses.values()]
+      .filter(isRepositoryItemBulkRetryCandidate)
+      .sort((left, right) => left.itemId - right.itemId)
+      .slice(0, input.limit);
+
+    let dispatchDeferred = 0;
+    for (const candidate of candidates) {
+      const retry = await retryCanonicalRepositoryItem(
+        candidate.itemId,
+        requestId,
+      );
+      try {
+        await dispatchContentProcessingJob({
+          jobId: retry.processingJobId,
+          itemVersionId: retry.itemVersionId,
+        });
+      } catch (error) {
+        dispatchDeferred += 1;
+        log.warn("Bulk retry is pending scheduled dispatch", {
+          repositoryId: input.repositoryId,
+          itemId: candidate.itemId,
+          processingJobId: retry.processingJobId,
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    }
+
+    const result = {
+      retried: candidates.length,
+      dispatchDeferred,
+      itemIds: candidates.map((candidate) => candidate.itemId),
+    };
+    timer({ status: "success", ...result });
+    revalidatePath(ADMIN_REPOSITORIES_PATH);
+    revalidatePath(`/repositories/${input.repositoryId}`);
+    return createSuccess(result, "Repository item retries queued");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to retry repository items.", {
+      context: "admin.contentMigration.retryRepositoryItemsBulk",
+      requestId,
+      operation: "retryRepositoryItemsBulkAction",
+      metadata: { repositoryId: input.repositoryId },
     });
   }
 }

--- a/actions/admin/repository-migration.actions.ts
+++ b/actions/admin/repository-migration.actions.ts
@@ -228,7 +228,9 @@ export async function retryFailedRepositoryMigrationItemsAction(input: {
 
 export interface RepositoryMigrationMismatchReprocessResult {
   reprocessed: number;
+  failed: number;
   migrationItemIds: string[];
+  failedMigrationItemIds: string[];
 }
 
 /** Reprocess a bounded set of reconciliation mismatches using the item service. */
@@ -237,21 +239,42 @@ export async function reprocessRepositoryMigrationMismatchesAction(input: {
 }): Promise<ActionState<RepositoryMigrationMismatchReprocessResult>> {
   const requestId = generateRequestId();
   const timer = startTimer("admin.contentMigration.reprocessMismatches");
+  const log = createLogger({
+    requestId,
+    action: "admin.contentMigration.reprocessMismatches",
+  });
   try {
     await requireMigrationAdministrator();
     validateBulkLimit(input.limit, MAX_MIGRATION_MISMATCH_REPROCESSES);
-    const exceptions = await listRepositoryMigrationExceptions(200);
-    const mismatches = exceptions
-      .filter((exception) => exception.status === "mismatch")
-      .slice(0, input.limit);
+    const mismatches = await listRepositoryMigrationExceptions(
+      input.limit,
+      "mismatch",
+    );
+    const migrationItemIds: string[] = [];
+    const failedMigrationItemIds: string[] = [];
     for (const mismatch of mismatches) {
-      await reprocessRepositoryMigrationItem(mismatch.id);
+      try {
+        await reprocessRepositoryMigrationItem(mismatch.id);
+        migrationItemIds.push(mismatch.id);
+      } catch (error) {
+        failedMigrationItemIds.push(mismatch.id);
+        log.warn("Migration mismatch reprocess was skipped", {
+          migrationItemId: mismatch.id,
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
     }
     const result = {
-      reprocessed: mismatches.length,
-      migrationItemIds: mismatches.map((mismatch) => mismatch.id),
+      reprocessed: migrationItemIds.length,
+      failed: failedMigrationItemIds.length,
+      migrationItemIds,
+      failedMigrationItemIds,
     };
-    timer({ status: "success", reprocessed: result.reprocessed });
+    timer({
+      status: "success",
+      reprocessed: result.reprocessed,
+      failed: result.failed,
+    });
     revalidatePath(ADMIN_REPOSITORIES_PATH);
     return createSuccess(result, "Migration mismatches queued for reprocessing");
   } catch (error) {
@@ -266,8 +289,10 @@ export async function reprocessRepositoryMigrationMismatchesAction(input: {
 
 export interface RepositoryItemsBulkRetryResult {
   retried: number;
+  failed: number;
   dispatchDeferred: number;
   itemIds: number[];
+  failedItemIds: number[];
 }
 
 /** Retry terminal or completed-but-under-embedded canonical repository items. */
@@ -301,11 +326,25 @@ export async function retryRepositoryItemsBulkAction(input: {
       .slice(0, input.limit);
 
     let dispatchDeferred = 0;
+    const itemIds: number[] = [];
+    const failedItemIds: number[] = [];
     for (const candidate of candidates) {
-      const retry = await retryCanonicalRepositoryItem(
-        candidate.itemId,
-        requestId,
-      );
+      let retry: Awaited<ReturnType<typeof retryCanonicalRepositoryItem>>;
+      try {
+        retry = await retryCanonicalRepositoryItem(
+          candidate.itemId,
+          requestId,
+        );
+        itemIds.push(candidate.itemId);
+      } catch (error) {
+        failedItemIds.push(candidate.itemId);
+        log.warn("Bulk retry candidate changed before it could be retried", {
+          repositoryId: input.repositoryId,
+          itemId: candidate.itemId,
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+        continue;
+      }
       try {
         await dispatchContentProcessingJob({
           jobId: retry.processingJobId,
@@ -323,9 +362,11 @@ export async function retryRepositoryItemsBulkAction(input: {
     }
 
     const result = {
-      retried: candidates.length,
+      retried: itemIds.length,
+      failed: failedItemIds.length,
       dispatchDeferred,
-      itemIds: candidates.map((candidate) => candidate.itemId),
+      itemIds,
+      failedItemIds,
     };
     timer({ status: "success", ...result });
     revalidatePath(ADMIN_REPOSITORIES_PATH);

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -163,6 +163,7 @@
     "170-nexus-durable-repository-bindings.sql",
     "171-workspace-upload-zero-byte-files.sql",
     "172-content-data-records.sql",
-    "173-repository-index-generation-retention.sql"
+    "173-repository-index-generation-retention.sql",
+    "174-unified-content-message-sanitizer-recovery.sql"
   ]
 }

--- a/infra/database/schema/174-unified-content-message-sanitizer-recovery.sql
+++ b/infra/database/schema/174-unified-content-message-sanitizer-recovery.sql
@@ -1,0 +1,39 @@
+-- Migration 174: quarantine inspect jobs exhausted by the pre-sanitizer
+-- embedding dispatch runtime. Match only the two known transient signatures;
+-- repository identity is deliberately not part of recovery eligibility.
+
+UPDATE repository_processing_jobs job
+SET status = 'cancelled',
+    attempt = 0,
+    max_attempts = 5,
+    available_at = 'infinity'::timestamptz,
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_error_code = 'POST_DEPLOY_RECOVERY_QUARANTINED',
+    last_error_message = 'Awaiting the sanitized embedding dispatch runtime',
+    post_deploy_recovery = 'content-message-sanitizer-v1',
+    metrics = '{"postDeployRecovery":"content-message-sanitizer-v1"}'::jsonb,
+    started_at = NULL,
+    finished_at = now(),
+    updated_at = now()
+WHERE job.stage = 'inspect'
+  AND job.status = 'failed'
+  AND job.attempt >= job.max_attempts
+  AND (
+    job.last_error_message LIKE '%set of allowed characters is%'
+    OR job.last_error_message LIKE 'Failed query:%repository_index_generations%'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM repository_item_versions version
+    JOIN repository_items item
+      ON item.current_version_id = version.id
+    WHERE version.id = job.item_version_id
+      AND item.lifecycle_status = 'active'
+      AND version.storage_status <> 'blocked'
+      AND version.inspection_status <> 'blocked'
+      AND version.object_key ~ (
+        '^repositories/' || item.repository_id::text ||
+        '/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/[^/]+$'
+      )
+  );

--- a/lib/db/schema/tables/repository-migration-runs.ts
+++ b/lib/db/schema/tables/repository-migration-runs.ts
@@ -34,6 +34,7 @@ export interface RepositoryMigrationCursor {
 export interface RepositoryMigrationSnapshot {
   maximumIds?: Partial<Record<RepositoryMigrationSourceKind, number>>;
   counts?: Partial<Record<RepositoryMigrationSourceKind, number>>;
+  retryOnly?: boolean;
   rollbackDrill?: boolean;
   migrationItemId?: string;
   canonicalItemId?: number;

--- a/lib/db/schema/tables/repository-processing-jobs.ts
+++ b/lib/db/schema/tables/repository-processing-jobs.ts
@@ -37,7 +37,8 @@ export interface RepositoryProcessingMetrics {
   postDeployRecovery?:
     | "unified-content-runtime-v2"
     | "unified-content-artifact-v3"
-    | "embedding-concurrency-v1";
+    | "embedding-concurrency-v1"
+    | "content-message-sanitizer-v1";
   /** Current managed-service wait, used to enforce or observe its deadline. */
   waitReason?:
     | "CONTENT_PLATFORM_DISABLED"
@@ -125,6 +126,7 @@ export const repositoryProcessingJobs = pgTable(
       | "unified-content-runtime-v2"
       | "unified-content-artifact-v3"
       | "embedding-concurrency-v1"
+      | "content-message-sanitizer-v1"
     >(),
     metrics: jsonb("metrics")
       .$type<RepositoryProcessingMetrics>()

--- a/lib/repositories/content-platform/migration-control-service.ts
+++ b/lib/repositories/content-platform/migration-control-service.ts
@@ -9,6 +9,7 @@ import {
   repositoryMigrationItems,
   repositoryMigrationRuns,
   type RepositoryMigrationItemStatus,
+  type RepositoryMigrationCursor,
   type RepositoryMigrationMetrics,
   type RepositoryMigrationMode,
   type RepositoryMigrationRunRow,
@@ -28,6 +29,7 @@ export const REPOSITORY_MIGRATION_SOURCE_KINDS = [
 ] as const satisfies readonly RepositoryMigrationSourceKind[];
 
 const ACTIVE_RUN_STATUSES = ["queued", "running"] as const;
+export const MAX_FAILED_REPOSITORY_MIGRATION_RETRIES = 250;
 
 export interface RepositoryMigrationInventoryEntry {
   sourceKind: RepositoryMigrationSourceKind;
@@ -416,6 +418,7 @@ export async function retryRepositoryMigrationItem(
     const snapshot: RepositoryMigrationSnapshot = {
       maximumIds: { [item.sourceKind]: item.sourceId },
       counts: { [item.sourceKind]: 1 },
+      retryOnly: true,
     };
     const [run] = await tx
       .insert(repositoryMigrationRuns)
@@ -442,6 +445,106 @@ export async function retryRepositoryMigrationItem(
       .where(eq(repositoryMigrationItems.id, item.id));
     return run;
   }, "contentMigration.retryItem");
+}
+
+/**
+ * Reassign one bounded set of terminal migration items to a single backfill run.
+ * The run-id reassignment is what makes previously attempted sources eligible to
+ * the migration runner again; creating one run per item would serialize recovery.
+ */
+export async function retryFailedRepositoryMigrationItems(input: {
+  requestedBy: number;
+  limit: number;
+}): Promise<RepositoryMigrationRunRow> {
+  if (
+    !Number.isSafeInteger(input.limit) ||
+    input.limit < 1 ||
+    input.limit > MAX_FAILED_REPOSITORY_MIGRATION_RETRIES
+  ) {
+    throw new Error(
+      `Migration retry limit must be between 1 and ${MAX_FAILED_REPOSITORY_MIGRATION_RETRIES}`,
+    );
+  }
+
+  return executeTransaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('repository-content-migration'))`,
+    );
+    await assertLegacyRetirementNotFinalized(tx);
+    const [active] = await tx
+      .select({ id: repositoryMigrationRuns.id })
+      .from(repositoryMigrationRuns)
+      .where(inArray(repositoryMigrationRuns.status, [...ACTIVE_RUN_STATUSES]))
+      .limit(1);
+    if (active) throw new Error("Another content migration run is active");
+
+    const items = await tx
+      .select({
+        id: repositoryMigrationItems.id,
+        sourceKind: repositoryMigrationItems.sourceKind,
+        sourceId: repositoryMigrationItems.sourceId,
+      })
+      .from(repositoryMigrationItems)
+      .where(
+        inArray(repositoryMigrationItems.status, ["failed", "unrecoverable"]),
+      )
+      .orderBy(
+        repositoryMigrationItems.sourceKind,
+        repositoryMigrationItems.sourceId,
+      )
+      .limit(input.limit)
+      .for("update");
+    if (items.length === 0) {
+      throw new Error("No failed migration items are available to retry");
+    }
+
+    const sourceKinds = [
+      ...new Set(items.map((item) => item.sourceKind)),
+    ];
+    const cursor: RepositoryMigrationCursor = {};
+    const maximumIds: Partial<
+      Record<RepositoryMigrationSourceKind, number>
+    > = {};
+    const counts: Partial<Record<RepositoryMigrationSourceKind, number>> = {};
+    for (const item of items) {
+      const cursorValue = Math.max(0, item.sourceId - 1);
+      cursor[item.sourceKind] = Math.min(
+        cursor[item.sourceKind] ?? cursorValue,
+        cursorValue,
+      );
+      maximumIds[item.sourceKind] = Math.max(
+        maximumIds[item.sourceKind] ?? item.sourceId,
+        item.sourceId,
+      );
+      counts[item.sourceKind] = (counts[item.sourceKind] ?? 0) + 1;
+    }
+
+    const [run] = await tx
+      .insert(repositoryMigrationRuns)
+      .values({
+        mode: "backfill",
+        status: "queued",
+        requestedBy: input.requestedBy,
+        sourceKinds,
+        cursor,
+        snapshot: { maximumIds, counts, retryOnly: true },
+        metrics: { discovered: items.length },
+      })
+      .returning();
+    if (!run) throw new Error("Failed to create bulk migration retry run");
+
+    await tx
+      .update(repositoryMigrationItems)
+      .set({
+        runId: run.id,
+        status: "pending",
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        updatedAt: new Date(),
+      })
+      .where(inArray(repositoryMigrationItems.id, items.map((item) => item.id)));
+    return run;
+  }, "contentMigration.retryFailedItems");
 }
 
 export async function approveRepositoryMigrationMismatch(input: {

--- a/lib/repositories/content-platform/migration-control-service.ts
+++ b/lib/repositories/content-platform/migration-control-service.ts
@@ -590,10 +590,19 @@ export async function approveRepositoryMigrationMismatch(input: {
   }, "contentMigration.approveMismatch");
 }
 
+export type RepositoryMigrationExceptionStatus = Extract<
+  RepositoryMigrationItemStatus,
+  "failed" | "unrecoverable" | "mismatch"
+>;
+
 export async function listRepositoryMigrationExceptions(
   limit = 50,
+  status?: RepositoryMigrationExceptionStatus,
 ): Promise<RepositoryMigrationException[]> {
   const safeLimit = Math.min(200, Math.max(1, Math.floor(limit)));
+  const statuses: RepositoryMigrationExceptionStatus[] = status
+    ? [status]
+    : ["failed", "unrecoverable", "mismatch"];
   return executeQuery(
     (db) =>
       db
@@ -612,13 +621,7 @@ export async function listRepositoryMigrationExceptions(
           updatedAt: repositoryMigrationItems.updatedAt,
         })
         .from(repositoryMigrationItems)
-        .where(
-          inArray(repositoryMigrationItems.status, [
-            "failed",
-            "unrecoverable",
-            "mismatch",
-          ]),
-        )
+        .where(inArray(repositoryMigrationItems.status, statuses))
         .orderBy(desc(repositoryMigrationItems.updatedAt))
         .limit(safeLimit),
     "contentMigration.listExceptions",

--- a/lib/repositories/content-platform/migration-runner.ts
+++ b/lib/repositories/content-platform/migration-runner.ts
@@ -241,6 +241,7 @@ async function loadNextRepositoryCandidate(
   cursor: number,
   maximumId: number,
 ): Promise<RepositoryCandidate | null> {
+  const discoverUntrackedSources = run.snapshot.retryOnly !== true;
   const row = toPgRows<{
     id: number;
     owner_id: number;
@@ -298,12 +299,12 @@ async function loadNextRepositoryCandidate(
               )
             )
             AND (
-              NOT EXISTS (
+              (${discoverUntrackedSources} = TRUE AND NOT EXISTS (
                 SELECT 1
                 FROM repository_migration_items migration
                 WHERE migration.source_kind = 'repository_item'
                   AND migration.source_id = item.id
-              )
+              ))
               OR EXISTS (
                 SELECT 1
                 FROM repository_migration_items migration
@@ -347,6 +348,7 @@ async function loadNextCandidate(
 ): Promise<MigrationCandidate | null> {
   const cursor = run.cursor[sourceKind] ?? 0;
   const maximumId = run.snapshot.maximumIds?.[sourceKind] ?? 0;
+  const discoverUntrackedSources = run.snapshot.retryOnly !== true;
   if (cursor >= maximumId) return null;
 
   if (sourceKind === "repository_item") {
@@ -388,6 +390,22 @@ async function loadNextCandidate(
             FROM documents document
             WHERE document.id > ${cursor}
               AND document.id <= ${maximumId}
+              AND (
+                ${discoverUntrackedSources} = TRUE
+                OR EXISTS (
+                  SELECT 1
+                  FROM repository_migration_items migration
+                  WHERE migration.source_kind = 'nexus_document'
+                    AND migration.source_id = document.id
+                    AND migration.run_id = ${run.id}::uuid
+                    AND migration.status IN (
+                      'pending',
+                      'migrating',
+                      'failed',
+                      'unrecoverable'
+                    )
+                )
+              )
             ORDER BY document.id
             LIMIT 1
           `),
@@ -425,6 +443,22 @@ async function loadNextCandidate(
           WHERE job.type = 'pdf-to-markdown'
             AND job.id > ${cursor}
             AND job.id <= ${maximumId}
+            AND (
+              ${discoverUntrackedSources} = TRUE
+              OR EXISTS (
+                SELECT 1
+                FROM repository_migration_items migration
+                WHERE migration.source_kind = 'assistant_pdf_job'
+                  AND migration.source_id = job.id
+                  AND migration.run_id = ${run.id}::uuid
+                  AND migration.status IN (
+                    'pending',
+                    'migrating',
+                    'failed',
+                    'unrecoverable'
+                  )
+              )
+            )
           ORDER BY job.id
           LIMIT 1
         `),

--- a/lib/repositories/content-platform/post-deploy-recovery.ts
+++ b/lib/repositories/content-platform/post-deploy-recovery.ts
@@ -15,6 +15,8 @@ export const POST_DEPLOY_ARTIFACT_RECOVERY_MARKER =
   "unified-content-artifact-v3" as const;
 export const POST_DEPLOY_EMBEDDING_CONCURRENCY_MARKER =
   "embedding-concurrency-v1" as const;
+export const POST_DEPLOY_CONTENT_MESSAGE_SANITIZER_MARKER =
+  "content-message-sanitizer-v1" as const;
 export const POST_DEPLOY_RECOVERY_BATCH_SIZE = 25;
 export const POST_DEPLOY_EMBEDDING_RECOVERY_BATCH_SIZE = 10;
 /** Let every invocation of the previous 15-minute Lambda runtime drain first. */
@@ -69,7 +71,8 @@ export async function releasePostDeployRecoveryJobs(
             AND job.post_deploy_recovery IN (
               ${POST_DEPLOY_RECOVERY_MARKER},
               ${POST_DEPLOY_ARTIFACT_RECOVERY_MARKER},
-              ${POST_DEPLOY_EMBEDDING_CONCURRENCY_MARKER}
+              ${POST_DEPLOY_EMBEDDING_CONCURRENCY_MARKER},
+              ${POST_DEPLOY_CONTENT_MESSAGE_SANITIZER_MARKER}
             )
             AND job.updated_at <= ${eligibleBefore}::timestamptz
             AND item.lifecycle_status = 'active'

--- a/lib/repositories/content-platform/status-service.ts
+++ b/lib/repositories/content-platform/status-service.ts
@@ -297,7 +297,12 @@ export async function getCanonicalRepositoryItemStatuses(
             eq(repositoryProcessingJobs.stage, "inspect")
           )
         )
-        .where(eq(repositoryItems.repositoryId, repositoryId)),
+        .where(
+          and(
+            eq(repositoryItems.repositoryId, repositoryId),
+            eq(repositoryItems.lifecycleStatus, "active"),
+          ),
+        ),
     "contentPlatform.getCanonicalRepositoryItemStatuses"
   );
 
@@ -353,6 +358,7 @@ export async function retryCanonicalRepositoryItem(
       const [context] = await tx
         .select({
           itemVersionId: repositoryItemVersions.id,
+          lifecycleStatus: repositoryItems.lifecycleStatus,
           storageStatus: repositoryItemVersions.storageStatus,
           inspectionStatus: repositoryItemVersions.inspectionStatus,
           active: sql<boolean>`EXISTS (
@@ -375,6 +381,9 @@ export async function retryCanonicalRepositoryItem(
         .limit(1)
         .for("update");
       if (!context) throw new Error("The item has no canonical version to retry");
+      if (context.lifecycleStatus !== "active") {
+        throw new Error("Only active repository items can be retried");
+      }
       if (context.storageStatus === "blocked" || context.inspectionStatus === "blocked") {
         throw new Error("Security-blocked content cannot be retried");
       }

--- a/lib/repositories/content-platform/status-service.ts
+++ b/lib/repositories/content-platform/status-service.ts
@@ -26,6 +26,7 @@ export interface CanonicalRepositoryItemStatus {
   canRetry: boolean;
   embeddedChunks: number;
   totalChunks: number;
+  activeEmbeddingComplete: boolean;
 }
 
 /** Legacy/pre-canonical failure messages a repository manager can retry through the canonical pipeline. */
@@ -66,8 +67,10 @@ interface CanonicalStatusRow {
     | "unified-content-runtime-v2"
     | "unified-content-artifact-v3"
     | "embedding-concurrency-v1"
+    | "content-message-sanitizer-v1"
     | null;
   active: boolean;
+  activeEmbeddingComplete: boolean;
   buildingGeneration: boolean;
   failedGeneration: boolean;
   generationError: string | null;
@@ -86,6 +89,7 @@ export function resolveCanonicalItemStatus(
       canRetry: false,
       embeddedChunks: row.embeddedChunks,
       totalChunks: row.totalChunks,
+      activeEmbeddingComplete: row.activeEmbeddingComplete,
     };
   }
 
@@ -97,6 +101,7 @@ export function resolveCanonicalItemStatus(
       canRetry: false,
       embeddedChunks: row.embeddedChunks,
       totalChunks: row.totalChunks,
+      activeEmbeddingComplete: row.activeEmbeddingComplete,
     };
   }
 
@@ -108,6 +113,7 @@ export function resolveCanonicalItemStatus(
       canRetry: row.storageStatus !== "blocked" && row.inspectionStatus !== "blocked",
       embeddedChunks: row.embeddedChunks,
       totalChunks: row.totalChunks,
+      activeEmbeddingComplete: row.activeEmbeddingComplete,
     };
   }
 
@@ -119,6 +125,7 @@ export function resolveCanonicalItemStatus(
       canRetry: false,
       embeddedChunks: row.embeddedChunks,
       totalChunks: row.totalChunks,
+      activeEmbeddingComplete: row.activeEmbeddingComplete,
     };
   }
 
@@ -134,6 +141,7 @@ export function resolveCanonicalItemStatus(
       canRetry: false,
       embeddedChunks: row.embeddedChunks,
       totalChunks: row.totalChunks,
+      activeEmbeddingComplete: row.activeEmbeddingComplete,
     };
   }
 
@@ -147,6 +155,7 @@ export function resolveCanonicalItemStatus(
     canRetry: false,
     embeddedChunks: row.embeddedChunks,
     totalChunks: row.totalChunks,
+    activeEmbeddingComplete: row.activeEmbeddingComplete,
   };
 }
 
@@ -199,6 +208,13 @@ export async function getCanonicalRepositoryItemStatuses(
             FROM ${repositoryItemChunks} active_chunk
             WHERE active_chunk.item_version_id = ${repositoryItemVersions.id}
               AND active_chunk.index_generation_id = ${knowledgeRepositories.activeIndexGenerationId}
+          )`,
+          activeEmbeddingComplete: sql<boolean>`NOT EXISTS (
+            SELECT 1
+            FROM ${repositoryItemChunks} active_chunk
+            WHERE active_chunk.item_version_id = ${repositoryItemVersions.id}
+              AND active_chunk.index_generation_id = ${knowledgeRepositories.activeIndexGenerationId}
+              AND active_chunk.embedding IS NULL
           )`,
           buildingGeneration: sql<boolean>`EXISTS (
             SELECT 1

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -1433,6 +1433,7 @@ try {
     canRetry: true,
     embeddedChunks: 0,
     totalChunks: 0,
+    activeEmbeddingComplete: true,
   });
 
   // Migration 123 must not replay an unrelated terminal user failure merely
@@ -1570,6 +1571,7 @@ try {
     canRetry: false,
     embeddedChunks: 0,
     totalChunks: 0,
+    activeEmbeddingComplete: true,
   });
   await assert.rejects(
     retryCanonicalRepositoryItem(

--- a/tests/unit/actions/admin-repository-migration-recovery.test.ts
+++ b/tests/unit/actions/admin-repository-migration-recovery.test.ts
@@ -1,0 +1,293 @@
+/** @jest-environment node */
+
+import { beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { CanonicalRepositoryItemStatus } from "@/lib/repositories/content-platform/status-service";
+
+type AsyncMock = (...args: unknown[]) => Promise<unknown>;
+
+const mockGetServerSession = jest.fn<AsyncMock>();
+const mockGetUserIdFromSession = jest.fn<AsyncMock>();
+const mockHasRole = jest.fn<AsyncMock>();
+const mockRetryFailedRepositoryMigrationItems = jest.fn<AsyncMock>();
+const mockListRepositoryMigrationExceptions = jest.fn<AsyncMock>();
+const mockReprocessRepositoryMigrationItem = jest.fn<AsyncMock>();
+const mockAssertNotSystemManagedRepository = jest.fn<AsyncMock>();
+const mockGetCanonicalRepositoryItemStatuses = jest.fn<AsyncMock>();
+const mockRetryCanonicalRepositoryItem = jest.fn<AsyncMock>();
+const mockDispatchContentProcessingJob = jest.fn<AsyncMock>();
+const mockRevalidatePath = jest.fn<(...args: unknown[]) => void>();
+const mockTimer = jest.fn<(...args: unknown[]) => void>();
+
+jest.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+jest.mock("@/lib/auth/server-session", () => ({
+  getServerSession: mockGetServerSession,
+}));
+jest.mock("@/actions/repositories/repository-permissions", () => ({
+  getUserIdFromSession: mockGetUserIdFromSession,
+}));
+jest.mock("@/utils/roles", () => ({ hasRole: mockHasRole }));
+jest.mock(
+  "@/lib/repositories/content-platform/migration-control-service",
+  () => ({
+    approveRepositoryMigrationMismatch: jest.fn(),
+    getRepositoryMigrationDashboard: jest.fn(),
+    listRepositoryMigrationExceptions: mockListRepositoryMigrationExceptions,
+    MAX_FAILED_REPOSITORY_MIGRATION_RETRIES: 250,
+    retryFailedRepositoryMigrationItems:
+      mockRetryFailedRepositoryMigrationItems,
+    retryRepositoryMigrationItem: jest.fn(),
+    runRepositoryMigrationRollbackDrill: jest.fn(),
+    startRepositoryMigrationRun: jest.fn(),
+    startRepositoryRollbackRun: jest.fn(),
+  }),
+);
+jest.mock("@/lib/repositories/content-platform/migration-runner", () => ({
+  reprocessRepositoryMigrationItem: mockReprocessRepositoryMigrationItem,
+}));
+jest.mock("@/lib/repositories/content-platform/status-service", () => ({
+  getCanonicalRepositoryItemStatuses:
+    mockGetCanonicalRepositoryItemStatuses,
+  retryCanonicalRepositoryItem: mockRetryCanonicalRepositoryItem,
+}));
+jest.mock("@/lib/repositories/content-platform/dispatch-service", () => ({
+  dispatchContentProcessingJob: mockDispatchContentProcessingJob,
+}));
+jest.mock("@/lib/repositories/repository-access-guard", () => ({
+  assertNotSystemManagedRepository: mockAssertNotSystemManagedRepository,
+  assertRepositoryReadAccess: jest.fn(),
+}));
+jest.mock("@/lib/repositories/content-platform/config", () => ({
+  getContentPlatformConfig: jest.fn(),
+}));
+jest.mock("@/lib/repositories/search-execution", () => ({
+  executeSearch: jest.fn(),
+}));
+jest.mock("@/lib/db/drizzle", () => ({ getRepositoryById: jest.fn() }));
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  }),
+  generateRequestId: () => "recovery-test",
+  getLogContext: () => ({}),
+  sanitizeForLogging: (value: unknown) => value,
+  startTimer: () => mockTimer,
+}));
+
+function status(
+  itemId: number,
+  overrides: Partial<CanonicalRepositoryItemStatus> = {},
+): CanonicalRepositoryItemStatus {
+  return {
+    itemId,
+    processingStatus: "embedded",
+    processingError: null,
+    canRetry: false,
+    embeddedChunks: 10,
+    totalChunks: 10,
+    activeEmbeddingComplete: true,
+    ...overrides,
+  };
+}
+
+// eslint-disable-next-line max-lines-per-function -- The three actions share one administrator and service mock harness.
+describe("repository recovery administrator actions", () => {
+  let retryFailedRepositoryMigrationItemsAction: typeof import("@/actions/admin/repository-migration.actions").retryFailedRepositoryMigrationItemsAction;
+  let reprocessRepositoryMigrationMismatchesAction: typeof import("@/actions/admin/repository-migration.actions").reprocessRepositoryMigrationMismatchesAction;
+  let retryRepositoryItemsBulkAction: typeof import("@/actions/admin/repository-migration.actions").retryRepositoryItemsBulkAction;
+
+  beforeAll(async () => {
+    ({
+      retryFailedRepositoryMigrationItemsAction,
+      reprocessRepositoryMigrationMismatchesAction,
+      retryRepositoryItemsBulkAction,
+    } = await import("@/actions/admin/repository-migration.actions"));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({ sub: "admin-sub" });
+    mockGetUserIdFromSession.mockResolvedValue(7);
+    mockHasRole.mockResolvedValue(true);
+    mockAssertNotSystemManagedRepository.mockResolvedValue(undefined);
+    mockListRepositoryMigrationExceptions.mockResolvedValue([]);
+    mockGetCanonicalRepositoryItemStatuses.mockResolvedValue(new Map());
+    mockDispatchContentProcessingJob.mockResolvedValue(undefined);
+  });
+
+  it("queues a bounded failed migration set through one bulk service call", async () => {
+    const run = { id: "run-1", mode: "backfill", status: "queued" };
+    mockRetryFailedRepositoryMigrationItems.mockResolvedValue(run);
+
+    const result = await retryFailedRepositoryMigrationItemsAction({
+      limit: 219,
+    });
+
+    expect(result).toMatchObject({ isSuccess: true, data: run });
+    expect(mockRetryFailedRepositoryMigrationItems).toHaveBeenCalledTimes(1);
+    expect(mockRetryFailedRepositoryMigrationItems).toHaveBeenCalledWith({
+      requestedBy: 7,
+      limit: 219,
+    });
+  });
+
+  it("rejects a failed migration retry beyond the 250-item bound", async () => {
+    const result = await retryFailedRepositoryMigrationItemsAction({
+      limit: 251,
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: false,
+      message: "Limit must be between 1 and 250.",
+    });
+    expect(mockRetryFailedRepositoryMigrationItems).not.toHaveBeenCalled();
+  });
+
+  it("reprocesses only mismatches and enforces the requested limit", async () => {
+    mockListRepositoryMigrationExceptions.mockResolvedValue([
+      { id: "failed-1", status: "failed" },
+      { id: "mismatch-1", status: "mismatch" },
+      { id: "mismatch-2", status: "mismatch" },
+      { id: "mismatch-3", status: "mismatch" },
+    ]);
+
+    const result = await reprocessRepositoryMigrationMismatchesAction({
+      limit: 2,
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: true,
+      data: {
+        reprocessed: 2,
+        migrationItemIds: ["mismatch-1", "mismatch-2"],
+      },
+    });
+    expect(mockListRepositoryMigrationExceptions).toHaveBeenCalledWith(200);
+    expect(mockReprocessRepositoryMigrationItem.mock.calls).toEqual([
+      ["mismatch-1"],
+      ["mismatch-2"],
+    ]);
+  });
+
+  it("selects repository 41's 73 completed under-embedded items without healthy content", async () => {
+    const underEmbeddedItems = Array.from({ length: 73 }, (_, index) => {
+      const itemId = 1_000 + index;
+      return [
+        itemId,
+        status(itemId, {
+          embeddedChunks: index === 0 ? 21_486 : 1,
+          totalChunks: index === 0 ? 217_281 : 2,
+          activeEmbeddingComplete: false,
+        }),
+      ] as const;
+    });
+    mockGetCanonicalRepositoryItemStatuses.mockResolvedValue(
+      new Map<number, CanonicalRepositoryItemStatus>([
+        [1, status(1)],
+        [
+          2,
+          status(2, {
+            embeddedChunks: 1,
+            totalChunks: 10,
+            activeEmbeddingComplete: true,
+          }),
+        ],
+        [
+          3,
+          status(3, {
+            processingStatus: "retrying",
+            embeddedChunks: 1,
+            totalChunks: 10,
+            activeEmbeddingComplete: false,
+          }),
+        ],
+        ...underEmbeddedItems,
+      ]),
+    );
+    mockRetryCanonicalRepositoryItem.mockImplementation(async (...args) => {
+      const itemId = args[0] as number;
+      return {
+        itemVersionId: `version-${itemId}`,
+        processingJobId: `job-${itemId}`,
+      };
+    });
+
+    const result = await retryRepositoryItemsBulkAction({
+      repositoryId: 41,
+      limit: 100,
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: true,
+      data: {
+        retried: 73,
+        dispatchDeferred: 0,
+        itemIds: underEmbeddedItems.map(([itemId]) => itemId),
+      },
+    });
+    expect(mockAssertNotSystemManagedRepository).toHaveBeenCalledWith(41);
+    expect(mockRetryCanonicalRepositoryItem.mock.calls).toEqual(
+      underEmbeddedItems.map(([itemId]) => [itemId, "recovery-test"]),
+    );
+  });
+
+  it("also retries terminal and building under-embedded items with deferred dispatch", async () => {
+    mockGetCanonicalRepositoryItemStatuses.mockResolvedValue(
+      new Map([
+        [3, status(3, { processingStatus: "failed", canRetry: true })],
+        [
+          5,
+          status(5, {
+            processingStatus: "processing_embeddings",
+            embeddedChunks: 0,
+            totalChunks: 9,
+          }),
+        ],
+        [
+          6,
+          status(6, {
+            processingStatus: "pending",
+            embeddedChunks: 0,
+            totalChunks: 8,
+            activeEmbeddingComplete: false,
+          }),
+        ],
+      ]),
+    );
+    mockRetryCanonicalRepositoryItem.mockImplementation(async (...args) => {
+      const itemId = args[0] as number;
+      return {
+        itemVersionId: `version-${itemId}`,
+        processingJobId: `job-${itemId}`,
+      };
+    });
+    mockDispatchContentProcessingJob.mockImplementation(async (...args) => {
+      const message = args[0] as { jobId: string };
+      if (message.jobId === "job-3") throw new Error("SQS unavailable");
+    });
+
+    const result = await retryRepositoryItemsBulkAction({
+      repositoryId: 41,
+      limit: 100,
+    });
+
+    expect(result).toMatchObject({
+      isSuccess: true,
+      data: {
+        retried: 2,
+        dispatchDeferred: 1,
+        itemIds: [3, 5],
+      },
+    });
+    expect(mockRetryCanonicalRepositoryItem.mock.calls).toEqual([
+      [3, "recovery-test"],
+      [5, "recovery-test"],
+    ]);
+    expect(mockRetryCanonicalRepositoryItem).not.toHaveBeenCalledWith(
+      6,
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/actions/admin-repository-migration-recovery.test.ts
+++ b/tests/unit/actions/admin-repository-migration-recovery.test.ts
@@ -145,29 +145,37 @@ describe("repository recovery administrator actions", () => {
     expect(mockRetryFailedRepositoryMigrationItems).not.toHaveBeenCalled();
   });
 
-  it("reprocesses only mismatches and enforces the requested limit", async () => {
+  it("queries only mismatches and reports partial reprocess outcomes", async () => {
     mockListRepositoryMigrationExceptions.mockResolvedValue([
-      { id: "failed-1", status: "failed" },
       { id: "mismatch-1", status: "mismatch" },
       { id: "mismatch-2", status: "mismatch" },
       { id: "mismatch-3", status: "mismatch" },
     ]);
+    mockReprocessRepositoryMigrationItem.mockImplementation(async (...args) => {
+      if (args[0] === "mismatch-2") throw new Error("State changed");
+    });
 
     const result = await reprocessRepositoryMigrationMismatchesAction({
-      limit: 2,
+      limit: 3,
     });
 
     expect(result).toMatchObject({
       isSuccess: true,
       data: {
         reprocessed: 2,
-        migrationItemIds: ["mismatch-1", "mismatch-2"],
+        failed: 1,
+        migrationItemIds: ["mismatch-1", "mismatch-3"],
+        failedMigrationItemIds: ["mismatch-2"],
       },
     });
-    expect(mockListRepositoryMigrationExceptions).toHaveBeenCalledWith(200);
+    expect(mockListRepositoryMigrationExceptions).toHaveBeenCalledWith(
+      3,
+      "mismatch",
+    );
     expect(mockReprocessRepositoryMigrationItem.mock.calls).toEqual([
       ["mismatch-1"],
       ["mismatch-2"],
+      ["mismatch-3"],
     ]);
   });
 
@@ -245,6 +253,7 @@ describe("repository recovery administrator actions", () => {
             totalChunks: 9,
           }),
         ],
+        [7, status(7, { processingStatus: "failed", canRetry: true })],
         [
           6,
           status(6, {
@@ -258,6 +267,7 @@ describe("repository recovery administrator actions", () => {
     );
     mockRetryCanonicalRepositoryItem.mockImplementation(async (...args) => {
       const itemId = args[0] as number;
+      if (itemId === 5) throw new Error("Item state changed");
       return {
         itemVersionId: `version-${itemId}`,
         processingJobId: `job-${itemId}`,
@@ -277,13 +287,16 @@ describe("repository recovery administrator actions", () => {
       isSuccess: true,
       data: {
         retried: 2,
+        failed: 1,
         dispatchDeferred: 1,
-        itemIds: [3, 5],
+        itemIds: [3, 7],
+        failedItemIds: [5],
       },
     });
     expect(mockRetryCanonicalRepositoryItem.mock.calls).toEqual([
       [3, "recovery-test"],
       [5, "recovery-test"],
+      [7, "recovery-test"],
     ]);
     expect(mockRetryCanonicalRepositoryItem).not.toHaveBeenCalledWith(
       6,

--- a/tests/unit/actions/admin-repository-migration-shadow-sample.test.ts
+++ b/tests/unit/actions/admin-repository-migration-shadow-sample.test.ts
@@ -42,6 +42,8 @@ jest.mock(
     approveRepositoryMigrationMismatch: jest.fn(),
     getRepositoryMigrationDashboard: jest.fn(),
     listRepositoryMigrationExceptions: jest.fn(),
+    MAX_FAILED_REPOSITORY_MIGRATION_RETRIES: 250,
+    retryFailedRepositoryMigrationItems: jest.fn(),
     retryRepositoryMigrationItem: jest.fn(),
     runRepositoryMigrationRollbackDrill: jest.fn(),
     startRepositoryMigrationRun: jest.fn(),

--- a/tests/unit/content-message-sanitizer-recovery-migration.test.ts
+++ b/tests/unit/content-message-sanitizer-recovery-migration.test.ts
@@ -1,0 +1,77 @@
+/** @jest-environment node */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationName = "174-unified-content-message-sanitizer-recovery.sql";
+const migration = fs.readFileSync(
+  path.join(process.cwd(), "infra/database/schema", migrationName),
+  "utf8",
+);
+const manifest = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), "infra/database/migrations.json"),
+    "utf8",
+  ),
+) as { migrationFiles: string[] };
+const schema = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    "lib/db/schema/tables/repository-processing-jobs.ts",
+  ),
+  "utf8",
+);
+const releaseService = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    "lib/repositories/content-platform/post-deploy-recovery.ts",
+  ),
+  "utf8",
+);
+
+describe("migration 174 content message sanitizer recovery", () => {
+  it("runs immediately after the globally previous migration", () => {
+    const previousIndex = manifest.migrationFiles.indexOf(
+      "173-repository-index-generation-retention.sql",
+    );
+
+    expect(previousIndex).toBeGreaterThanOrEqual(0);
+    expect(manifest.migrationFiles[previousIndex + 1]).toBe(migrationName);
+  });
+
+  it("quarantines only exhausted inspect jobs with a locked error signature", () => {
+    expect(migration).toContain("job.stage = 'inspect'");
+    expect(migration).toContain("job.status = 'failed'");
+    expect(migration).toContain("job.attempt >= job.max_attempts");
+    expect(migration).toContain(
+      "job.last_error_message LIKE '%set of allowed characters is%'",
+    );
+    expect(migration).toContain(
+      "job.last_error_message LIKE 'Failed query:%repository_index_generations%'",
+    );
+    expect(migration).toContain(
+      "post_deploy_recovery = 'content-message-sanitizer-v1'",
+    );
+    expect(migration).not.toContain("No searchable text was extracted");
+  });
+
+  it("never scopes recovery eligibility to a repository id", () => {
+    expect(migration).not.toMatch(/repository_id\s*=\s*\d+/i);
+    expect(migration).not.toMatch(/repository_id\s+IN\s*\(\s*\d+/i);
+    expect(migration).toContain("item.current_version_id = version.id");
+    expect(migration).toContain("item.lifecycle_status = 'active'");
+    expect(migration).toContain("version.storage_status <> 'blocked'");
+    expect(migration).toContain("version.inspection_status <> 'blocked'");
+    expect(migration).toContain("version.object_key ~ (");
+  });
+
+  it("plumbs the marker through durable types and the release allowlist", () => {
+    expect(schema.match(/"content-message-sanitizer-v1"/g)).toHaveLength(2);
+    expect(releaseService).toContain(
+      'POST_DEPLOY_CONTENT_MESSAGE_SANITIZER_MARKER =\n  "content-message-sanitizer-v1" as const',
+    );
+    expect(releaseService).toContain(
+      "${POST_DEPLOY_CONTENT_MESSAGE_SANITIZER_MARKER}",
+    );
+  });
+});

--- a/tests/unit/content-migration-retry-targeting.test.ts
+++ b/tests/unit/content-migration-retry-targeting.test.ts
@@ -1,0 +1,60 @@
+/** @jest-environment node */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "@jest/globals";
+
+const migrationRunSchema = readFileSync(
+  resolve(
+    process.cwd(),
+    "lib/db/schema/tables/repository-migration-runs.ts",
+  ),
+  "utf8",
+);
+const migrationControlService = readFileSync(
+  resolve(
+    process.cwd(),
+    "lib/repositories/content-platform/migration-control-service.ts",
+  ),
+  "utf8",
+);
+const migrationRunner = readFileSync(
+  resolve(
+    process.cwd(),
+    "lib/repositories/content-platform/migration-runner.ts",
+  ),
+  "utf8",
+);
+
+describe("repository migration retry targeting", () => {
+  it("marks both single and bounded bulk retry runs as retry-only", () => {
+    expect(migrationRunSchema).toContain("retryOnly?: boolean;");
+    expect(migrationControlService.match(/retryOnly: true/g)).toHaveLength(2);
+  });
+
+  it("requires a current-run migration row for every retry-only source kind", () => {
+    expect(
+      migrationRunner.match(/\$\{discoverUntrackedSources\} = TRUE/g),
+    ).toHaveLength(3);
+
+    for (const assignmentPredicate of [
+      /migration\.source_kind = 'repository_item'[\s\S]*?migration\.run_id = \$\{run\.id\}::uuid/,
+      /migration\.source_kind = 'nexus_document'[\s\S]*?migration\.run_id = \$\{run\.id\}::uuid/,
+      /migration\.source_kind = 'assistant_pdf_job'[\s\S]*?migration\.run_id = \$\{run\.id\}::uuid/,
+    ]) {
+      expect(migrationRunner).toMatch(assignmentPredicate);
+    }
+  });
+
+  it("keeps sparse retry selection exact instead of admitting in-range sources", () => {
+    const selectedRetryIds = new Set([2, 1_000_000]);
+    const sourceIdsInRange = [2, 3, 4, 500_000, 1_000_000];
+
+    const retryOnlyIds = sourceIdsInRange.filter((sourceId) =>
+      selectedRetryIds.has(sourceId),
+    );
+
+    expect(retryOnlyIds).toEqual([2, 1_000_000]);
+    expect(retryOnlyIds).toHaveLength(selectedRetryIds.size);
+  });
+});

--- a/tests/unit/content-migration-retry-targeting.test.ts
+++ b/tests/unit/content-migration-retry-targeting.test.ts
@@ -57,4 +57,25 @@ describe("repository migration retry targeting", () => {
     expect(retryOnlyIds).toEqual([2, 1_000_000]);
     expect(retryOnlyIds).toHaveLength(selectedRetryIds.size);
   });
+
+  it("applies an exception-status filter before the bounded query limit", () => {
+    const functionStart = migrationControlService.indexOf(
+      "export async function listRepositoryMigrationExceptions",
+    );
+    const statusFilter = migrationControlService.indexOf(
+      ".where(inArray(repositoryMigrationItems.status, statuses))",
+      functionStart,
+    );
+    const limit = migrationControlService.indexOf(
+      ".limit(safeLimit)",
+      functionStart,
+    );
+
+    expect(functionStart).toBeGreaterThanOrEqual(0);
+    expect(migrationControlService).toContain(
+      "status?: RepositoryMigrationExceptionStatus",
+    );
+    expect(statusFilter).toBeGreaterThan(functionStart);
+    expect(limit).toBeGreaterThan(statusFilter);
+  });
 });

--- a/tests/unit/lib/repositories/content-platform-status.test.ts
+++ b/tests/unit/lib/repositories/content-platform-status.test.ts
@@ -199,6 +199,12 @@ describe("canonical repository item embedding coverage", () => {
       "active_chunk.index_generation_id = ${knowledgeRepositories.activeIndexGenerationId}",
     );
     expect(statusServiceSource).toContain("active_chunk.embedding IS NULL");
+    expect(statusServiceSource).toContain(
+      'eq(repositoryItems.lifecycleStatus, "active")',
+    );
+    expect(statusServiceSource).toContain(
+      'context.lifecycleStatus !== "active"',
+    );
   });
 
   it("exposes a terminal failed embedding generation", () => {

--- a/tests/unit/lib/repositories/content-platform-status.test.ts
+++ b/tests/unit/lib/repositories/content-platform-status.test.ts
@@ -1,11 +1,21 @@
 /** @jest-environment node */
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "@jest/globals";
 import {
   isRetryableLegacyItemFailure,
   resolveCanonicalItemStatus,
   RETRYABLE_LEGACY_FAILURE_PREFIXES,
 } from "@/lib/repositories/content-platform/status-service";
+
+const statusServiceSource = readFileSync(
+  resolve(
+    process.cwd(),
+    "lib/repositories/content-platform/status-service.ts",
+  ),
+  "utf8",
+);
 
 function statusRow(
   overrides: Partial<Parameters<typeof resolveCanonicalItemStatus>[0]> = {}
@@ -26,6 +36,7 @@ function statusRow(
     generationError: null,
     embeddedChunks: 4,
     totalChunks: 9,
+    activeEmbeddingComplete: false,
     ...overrides,
   };
 }
@@ -49,6 +60,7 @@ describe("canonical repository item status", () => {
       canRetry: false,
       embeddedChunks: 9,
       totalChunks: 9,
+      activeEmbeddingComplete: false,
     });
   });
 
@@ -83,6 +95,7 @@ describe("canonical repository item status", () => {
       canRetry: true,
       embeddedChunks: 4,
       totalChunks: 9,
+      activeEmbeddingComplete: false,
     });
   });
 
@@ -136,6 +149,7 @@ describe("canonical repository item status", () => {
       "unified-content-runtime-v2",
       "unified-content-artifact-v3",
       "embedding-concurrency-v1",
+      "content-message-sanitizer-v1",
     ] as const) {
       expect(
         resolveCanonicalItemStatus(
@@ -153,6 +167,7 @@ describe("canonical repository item status", () => {
         canRetry: false,
         embeddedChunks: 4,
         totalChunks: 9,
+        activeEmbeddingComplete: false,
       });
     }
   });
@@ -176,6 +191,16 @@ describe("canonical repository item status", () => {
 });
 
 describe("canonical repository item embedding coverage", () => {
+  it("checks active-generation embedding completeness independently of newer builds", () => {
+    expect(statusServiceSource).toContain(
+      "activeEmbeddingComplete: sql<boolean>`NOT EXISTS (",
+    );
+    expect(statusServiceSource).toContain(
+      "active_chunk.index_generation_id = ${knowledgeRepositories.activeIndexGenerationId}",
+    );
+    expect(statusServiceSource).toContain("active_chunk.embedding IS NULL");
+  });
+
   it("exposes a terminal failed embedding generation", () => {
     expect(
       resolveCanonicalItemStatus(
@@ -211,6 +236,7 @@ describe("canonical repository item embedding coverage", () => {
       expect(resolveCanonicalItemStatus(statusRow(overrides))).toMatchObject({
         embeddedChunks: 4,
         totalChunks: 9,
+        activeEmbeddingComplete: false,
       });
     }
   });


### PR DESCRIPTION
## Summary

- add migration 174 with the `content-message-sanitizer-v1` recovery marker, scoped only to the two locked failure signatures and canonical active/current content invariants (never a repository ID)
- plumb the marker through durable job schema, post-deploy release allowlisting, and repository status reporting
- add the three bounded administrator actions for failed migration retries (250), reconciliation mismatch reprocessing (50), and canonical repository-item retries (100), reusing the existing migration, reprocess, retry, and dispatch services
- make retry migration runs exact-source-only and distinguish active-generation embedding completeness from newer partial builds
- explicitly cover repository 41's 73 completed under-embedded items while excluding healthy active content, including healthy content whose newest building generation is partial

## Verification

- `bun run lint` — passed
- targeted CI Jest gate (6 suites / 45 tests) — passed
- focused security diff review — no reportable findings; fixed exact-source retry targeting and active-vs-building generation selection findings before commit
- `bun run typecheck` — blocked by the existing reused-installation baseline in `infra/lambdas/agent-router/index.ts` (`@aws-sdk/client-ecs` / nested agent-router dependencies missing); no changed file reported an error
- `bun run test:ci --runInBand` — 569 suites and 5,319 tests passed; the sole failing suite is the same unrelated missing `@aws-sdk/client-ecs` baseline in `tests/unit/agent-workspace-identity.test.ts`
- raw `bun run test -- --runInBand` was also attempted; the default local config incorrectly discovers Playwright, Bun, CDK, and server-dependent performance suites (585 suites / 5,472 tests passed before those cross-runner baselines failed)
- E2E and CDK were not required by this issue; the documented one-push `SKIP_E2E=1` bypass was used because this managed worktree has no local `AUTH_SECRET`
- fresh-install GitHub checks — all green: test/lint/typecheck, unified-content PostgreSQL lifecycle, CDK validation, auth production artifact, CodeQL, and automated review

## Deployment notes

- code and migration only; no deployment, administrator action, production setting change, or production repair was performed
- production verification and the actual repair remain follow-up work, so this PR intentionally references rather than closes the issue

Refs #1530

Part of #1523
