### PR TITLE
fix(content): add audited migration source exclusions

### DIFF
--- a/actions/admin/repository-migration.actions.ts
+++ b/actions/admin/repository-migration.actions.ts
@@ -9,6 +9,7 @@ import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
 import type { ActionState } from "@/types/actions-types";
 import {
   approveRepositoryMigrationMismatch,
+  excludeRepositoryMigrationException,
   getRepositoryMigrationDashboard,
   listRepositoryMigrationExceptions,
   MAX_FAILED_REPOSITORY_MIGRATION_RETRIES,
@@ -401,6 +402,29 @@ export async function approveRepositoryMigrationMismatchAction(input: {
       context: "admin.contentMigration.approveMismatch",
       requestId,
       operation: "approveRepositoryMigrationMismatchAction",
+    });
+  }
+}
+
+export async function excludeRepositoryMigrationExceptionAction(input: {
+  migrationItemId: string;
+  reason: string;
+}): Promise<ActionState<void>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("admin.contentMigration.excludeException");
+  try {
+    const { userId: excludedBy } = await requireMigrationAdministrator();
+    await excludeRepositoryMigrationException({ ...input, excludedBy });
+    timer({ status: "success" });
+    revalidatePath(ADMIN_REPOSITORIES_PATH);
+    revalidatePath(ADMIN_SETTINGS_PATH);
+    return createSuccess(undefined, "Migration source excluded from cutover");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to exclude migration source.", {
+      context: "admin.contentMigration.excludeException",
+      requestId,
+      operation: "excludeRepositoryMigrationExceptionAction",
     });
   }
 }

--- a/app/(protected)/admin/repositories/_components/migration-control-panel.tsx
+++ b/app/(protected)/admin/repositories/_components/migration-control-panel.tsx
@@ -24,6 +24,7 @@ import {
 import { useToast } from "@/components/ui/use-toast";
 import {
   approveRepositoryMigrationMismatchAction,
+  excludeRepositoryMigrationExceptionAction,
   getRepositoryMigrationDashboardAction,
   reprocessRepositoryMigrationItemAction,
   retryRepositoryMigrationItemAction,
@@ -246,11 +247,13 @@ function MigrationExceptions({
   disabled,
   runAction,
   approveMismatch,
+  excludeException,
 }: {
   exceptions: RepositoryMigrationException[];
   disabled: boolean;
   runAction: MigrationActionRunner;
   approveMismatch: (item: RepositoryMigrationException) => Promise<void>;
+  excludeException: (item: RepositoryMigrationException) => Promise<void>;
 }) {
   if (exceptions.length === 0) return null;
   return (
@@ -290,6 +293,7 @@ function MigrationExceptions({
                   disabled={disabled}
                   runAction={runAction}
                   approveMismatch={approveMismatch}
+                  excludeException={excludeException}
                 />
               </TableCell>
             </TableRow>
@@ -305,26 +309,38 @@ function ExceptionRecoveryActions({
   disabled,
   runAction,
   approveMismatch,
+  excludeException,
 }: {
   item: RepositoryMigrationException;
   disabled: boolean;
   runAction: MigrationActionRunner;
   approveMismatch: (item: RepositoryMigrationException) => Promise<void>;
+  excludeException: (item: RepositoryMigrationException) => Promise<void>;
 }) {
   if (item.status !== "mismatch") {
     return (
-      <Button
-        size="sm"
-        variant="outline"
-        onClick={() =>
-          void runAction(`retry:${item.id}`, () =>
-            retryRepositoryMigrationItemAction(item.id),
-          )
-        }
-        disabled={disabled}
-      >
-        Retry
-      </Button>
+      <>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() =>
+            void runAction(`retry:${item.id}`, () =>
+              retryRepositoryMigrationItemAction(item.id),
+            )
+          }
+          disabled={disabled}
+        >
+          Retry
+        </Button>
+        <Button
+          size="sm"
+          variant="destructive"
+          onClick={() => void excludeException(item)}
+          disabled={disabled}
+        >
+          Exclude
+        </Button>
+      </>
     );
   }
   return (
@@ -426,6 +442,22 @@ export function MigrationControlPanel() {
     [runAction],
   );
 
+  const excludeException = useCallback(
+    async (item: RepositoryMigrationException) => {
+      const reason = window.prompt(
+        "Document why this failed or unrecoverable legacy source is intentionally excluded from cutover (10-1000 characters):",
+      );
+      if (!reason) return;
+      await runAction(`exclude:${item.id}`, () =>
+        excludeRepositoryMigrationExceptionAction({
+          migrationItemId: item.id,
+          reason,
+        }),
+      );
+    },
+    [runAction],
+  );
+
   if (loading && !state) {
     return (
       <Card data-testid="content-migration-panel">
@@ -482,6 +514,7 @@ export function MigrationControlPanel() {
           disabled={controlsDisabled}
           runAction={runAction}
           approveMismatch={approveMismatch}
+          excludeException={excludeException}
         />
       </CardContent>
     </Card>

--- a/lib/db/schema/tables/repository-migration-items.ts
+++ b/lib/db/schema/tables/repository-migration-items.ts
@@ -47,6 +47,10 @@ export interface RepositoryMigrationItemMetadata {
   rollbackObjectKeys?: string[];
   exclusionReason?: string;
   excludedAt?: string;
+  excludedBy?: number;
+  exclusionPreviousStatus?: "failed" | "unrecoverable";
+  exclusionPreviousErrorCode?: string;
+  exclusionPreviousErrorMessage?: string;
   lastReconciledRunId?: string;
 }
 

--- a/lib/repositories/content-platform/legacy-retirement.ts
+++ b/lib/repositories/content-platform/legacy-retirement.ts
@@ -201,10 +201,10 @@ async function loadRetirementGateRow(
             )
             AND NOT EXISTS (
               SELECT 1
-              FROM repository_migration_items migration
-              WHERE migration.source_kind = 'repository_item'
-                AND migration.source_id = item.id
-                AND migration.status = 'verified'
+                FROM repository_migration_items migration
+                WHERE migration.source_kind = 'repository_item'
+                  AND migration.source_id = item.id
+                  AND migration.status IN ('verified', 'excluded')
             )
         ) + (
           SELECT COUNT(*)::integer
@@ -214,7 +214,7 @@ async function loadRetirementGateRow(
             FROM repository_migration_items migration
             WHERE migration.source_kind = 'nexus_document'
               AND migration.source_id = document.id
-              AND migration.status = 'verified'
+              AND migration.status IN ('verified', 'excluded')
           )
         ) + (
           SELECT COUNT(*)::integer
@@ -225,7 +225,7 @@ async function loadRetirementGateRow(
               FROM repository_migration_items migration
               WHERE migration.source_kind = 'assistant_pdf_job'
                 AND migration.source_id = job.id
-                AND migration.status = 'verified'
+                AND migration.status IN ('verified', 'excluded')
             )
         ) AS uncovered
       FROM repository_migration_runs

--- a/lib/repositories/content-platform/migration-control-service.ts
+++ b/lib/repositories/content-platform/migration-control-service.ts
@@ -140,7 +140,7 @@ export async function getRepositoryMigrationInventory(): Promise<
               FROM repository_migration_items migration
               WHERE migration.source_kind = 'repository_item'
                 AND migration.source_id = item.id
-                AND migration.status = 'verified'
+                AND migration.status IN ('verified', 'excluded')
             )
           )::integer AS uncovered
         FROM repository_items item
@@ -183,7 +183,7 @@ export async function getRepositoryMigrationInventory(): Promise<
                   FROM repository_migration_items migration
                   WHERE migration.source_kind = 'nexus_document'
                     AND migration.source_id = document.id
-                    AND migration.status = 'verified'
+                    AND migration.status IN ('verified', 'excluded')
                 )
               )::integer AS uncovered
             FROM documents document
@@ -203,7 +203,7 @@ export async function getRepositoryMigrationInventory(): Promise<
               FROM repository_migration_items migration
               WHERE migration.source_kind = 'assistant_pdf_job'
                 AND migration.source_id = job.id
-                AND migration.status = 'verified'
+                AND migration.status IN ('verified', 'excluded')
             )
           )::integer AS uncovered
         FROM jobs job
@@ -588,6 +588,80 @@ export async function approveRepositoryMigrationMismatch(input: {
       })
       .where(eq(repositoryMigrationItems.id, item.id));
   }, "contentMigration.approveMismatch");
+}
+
+/**
+ * Classify a terminal legacy source as intentionally excluded from cutover.
+ *
+ * This is deliberately limited to failed and unrecoverable rows. Mismatches
+ * require the separate hash-evidence approval flow, while successful rows are
+ * never eligible for administrative exclusion.
+ */
+export async function excludeRepositoryMigrationException(input: {
+  migrationItemId: string;
+  excludedBy: number;
+  reason: string;
+}): Promise<void> {
+  const reason = input.reason.trim();
+  if (reason.length < 10 || reason.length > 1_000) {
+    throw new Error("A 10-1000 character exclusion reason is required");
+  }
+  if (!Number.isSafeInteger(input.excludedBy) || input.excludedBy < 1) {
+    throw new Error("A valid administrator is required for exclusion");
+  }
+
+  await executeTransaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('repository-content-migration'))`,
+    );
+    await assertLegacyRetirementNotFinalized(tx);
+    const [active] = await tx
+      .select({ id: repositoryMigrationRuns.id })
+      .from(repositoryMigrationRuns)
+      .where(inArray(repositoryMigrationRuns.status, [...ACTIVE_RUN_STATUSES]))
+      .limit(1);
+    if (active) throw new Error("Another content migration run is active");
+
+    const [item] = await tx
+      .select()
+      .from(repositoryMigrationItems)
+      .where(eq(repositoryMigrationItems.id, input.migrationItemId))
+      .limit(1)
+      .for("update");
+    if (
+      !item ||
+      (item.status !== "failed" && item.status !== "unrecoverable")
+    ) {
+      throw new Error(
+        "Migration exception no longer exists or is not excludable",
+      );
+    }
+
+    const excludedAt = new Date();
+    await tx
+      .update(repositoryMigrationItems)
+      .set({
+        status: "excluded",
+        lastErrorCode: "MIGRATION_SOURCE_EXCLUDED",
+        lastErrorMessage: reason,
+        verifiedAt: null,
+        metadata: {
+          ...item.metadata,
+          exclusionReason: reason,
+          excludedAt: excludedAt.toISOString(),
+          excludedBy: input.excludedBy,
+          exclusionPreviousStatus: item.status,
+          ...(item.lastErrorCode
+            ? { exclusionPreviousErrorCode: item.lastErrorCode }
+            : {}),
+          ...(item.lastErrorMessage
+            ? { exclusionPreviousErrorMessage: item.lastErrorMessage }
+            : {}),
+        },
+        updatedAt: excludedAt,
+      })
+      .where(eq(repositoryMigrationItems.id, item.id));
+  }, "contentMigration.excludeException");
 }
 
 export type RepositoryMigrationExceptionStatus = Extract<

--- a/scripts/db/finalize-unified-content-retirement.ts
+++ b/scripts/db/finalize-unified-content-retirement.ts
@@ -278,7 +278,7 @@ async function readUncoveredCount(
             FROM repository_migration_items migration
             WHERE migration.source_kind = 'repository_item'
               AND migration.source_id = item.id
-              AND migration.status = 'verified'
+              AND migration.status IN ('verified', 'excluded')
           )
       ) + (
         SELECT COUNT(*)::integer
@@ -288,7 +288,7 @@ async function readUncoveredCount(
           FROM repository_migration_items migration
           WHERE migration.source_kind = 'nexus_document'
             AND migration.source_id = document.id
-            AND migration.status = 'verified'
+            AND migration.status IN ('verified', 'excluded')
         )
       ) + (
         SELECT COUNT(*)::integer
@@ -299,7 +299,7 @@ async function readUncoveredCount(
             FROM repository_migration_items migration
             WHERE migration.source_kind = 'assistant_pdf_job'
               AND migration.source_id = job.id
-              AND migration.status = 'verified'
+              AND migration.status IN ('verified', 'excluded')
         )
       ) AS count
     `;

--- a/tests/unit/actions/admin-repository-migration-recovery.test.ts
+++ b/tests/unit/actions/admin-repository-migration-recovery.test.ts
@@ -9,6 +9,7 @@ const mockGetServerSession = jest.fn<AsyncMock>();
 const mockGetUserIdFromSession = jest.fn<AsyncMock>();
 const mockHasRole = jest.fn<AsyncMock>();
 const mockRetryFailedRepositoryMigrationItems = jest.fn<AsyncMock>();
+const mockExcludeRepositoryMigrationException = jest.fn<AsyncMock>();
 const mockListRepositoryMigrationExceptions = jest.fn<AsyncMock>();
 const mockReprocessRepositoryMigrationItem = jest.fn<AsyncMock>();
 const mockAssertNotSystemManagedRepository = jest.fn<AsyncMock>();
@@ -30,6 +31,8 @@ jest.mock(
   "@/lib/repositories/content-platform/migration-control-service",
   () => ({
     approveRepositoryMigrationMismatch: jest.fn(),
+    excludeRepositoryMigrationException:
+      mockExcludeRepositoryMigrationException,
     getRepositoryMigrationDashboard: jest.fn(),
     listRepositoryMigrationExceptions: mockListRepositoryMigrationExceptions,
     MAX_FAILED_REPOSITORY_MIGRATION_RETRIES: 250,
@@ -97,12 +100,14 @@ describe("repository recovery administrator actions", () => {
   let retryFailedRepositoryMigrationItemsAction: typeof import("@/actions/admin/repository-migration.actions").retryFailedRepositoryMigrationItemsAction;
   let reprocessRepositoryMigrationMismatchesAction: typeof import("@/actions/admin/repository-migration.actions").reprocessRepositoryMigrationMismatchesAction;
   let retryRepositoryItemsBulkAction: typeof import("@/actions/admin/repository-migration.actions").retryRepositoryItemsBulkAction;
+  let excludeRepositoryMigrationExceptionAction: typeof import("@/actions/admin/repository-migration.actions").excludeRepositoryMigrationExceptionAction;
 
   beforeAll(async () => {
     ({
       retryFailedRepositoryMigrationItemsAction,
       reprocessRepositoryMigrationMismatchesAction,
       retryRepositoryItemsBulkAction,
+      excludeRepositoryMigrationExceptionAction,
     } = await import("@/actions/admin/repository-migration.actions"));
   });
 
@@ -131,6 +136,24 @@ describe("repository recovery administrator actions", () => {
       requestedBy: 7,
       limit: 219,
     });
+  });
+
+  it("records an audited administrator exclusion through the migration service", async () => {
+    mockExcludeRepositoryMigrationException.mockResolvedValue(undefined);
+
+    const result = await excludeRepositoryMigrationExceptionAction({
+      migrationItemId: "migration-failed-1",
+      reason: "The legacy object was intentionally removed after replacement.",
+    });
+
+    expect(result).toMatchObject({ isSuccess: true });
+    expect(mockExcludeRepositoryMigrationException).toHaveBeenCalledWith({
+      migrationItemId: "migration-failed-1",
+      reason: "The legacy object was intentionally removed after replacement.",
+      excludedBy: 7,
+    });
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/admin/repositories");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/admin/settings");
   });
 
   it("rejects a failed migration retry beyond the 250-item bound", async () => {

--- a/tests/unit/content-migration-retry-targeting.test.ts
+++ b/tests/unit/content-migration-retry-targeting.test.ts
@@ -78,4 +78,18 @@ describe("repository migration retry targeting", () => {
     expect(statusFilter).toBeGreaterThan(functionStart);
     expect(limit).toBeGreaterThan(statusFilter);
   });
+
+  it("treats audited exclusions as accounted-for migration inventory", () => {
+    expect(
+      migrationControlService.match(
+        /migration\.status IN \('verified', 'excluded'\)/g,
+      ),
+    ).toHaveLength(3);
+    expect(migrationControlService).toContain(
+      "export async function excludeRepositoryMigrationException",
+    );
+    expect(migrationControlService).toContain(
+      'contentMigration.excludeException',
+    );
+  });
 });

--- a/tests/unit/scripts/unified-content-retirement-exclusion.test.ts
+++ b/tests/unit/scripts/unified-content-retirement-exclusion.test.ts
@@ -38,6 +38,9 @@ describe.each(retirementGateSources)(
         "FROM repository_connector_sources connector_source",
       );
       expect(source).toContain("connector_source.status = 'unsupported'");
+      expect(
+        source.match(/migration\.status IN \('verified', 'excluded'\)/g),
+      ).toHaveLength(3);
     });
   },
 );


### PR DESCRIPTION
## Summary
- add an administrator-only, reason-required audit action for terminal failed or unrecoverable migration sources
- preserve the previous failure status and error details in migration metadata
- treat audited exclusions as accounted-for inventory across cutover and legacy-retirement gates
- expose Retry and Exclude as distinct recovery controls while keeping mismatch approval separate

## Validation
- production Next.js build passes
- lint passes for all tracked files (the local checkout contains an unrelated untracked lib/utils/text-sanitizer.js that shadows the tracked TypeScript module)
- typecheck passes
- focused migration tests: 13 passed
- CI Jest suite: 569 suites / 5,303 tests passed; only the same untracked local shadow file fails locally and it is not part of this PR
- pre-push authenticated E2E: 311 passed, 40 skipped, 1 flaky passed on retry

## Operations
This provides the missing audited classification control needed to clear the two known terminal production migration exceptions before enabling repository cutover. No direct database writes are used.

Refs #1531
Refs #1523