### PR TITLE
fix(content): unblock production cutover verification

### DIFF
--- a/actions/admin/repository-migration.actions.ts
+++ b/actions/admin/repository-migration.actions.ts
@@ -583,7 +583,10 @@ export async function recordRepositoryRetrievalShadowSampleAction(input: {
       );
     }
 
-    const contentConfig = await getContentPlatformConfig();
+    // Rollout toggles are operational controls. Read them directly from the
+    // database so a just-enabled shadow cannot be hidden by another bundle or
+    // task's settings cache.
+    const contentConfig = await getContentPlatformConfig({ fresh: true });
     const outcomes: RepositoryRetrievalShadowSampleOutcome[] = [];
     for (const query of queries) {
       const search = await executeSearch({

--- a/actions/db/settings-actions.ts
+++ b/actions/db/settings-actions.ts
@@ -135,7 +135,7 @@ export async function upsertSettingAction(input: CreateSettingInput): Promise<Ac
 
     if (isContentRolloutBooleanKey(input.key)) {
       const value = parseContentRolloutBoolean(input.value)
-      const current = await getContentPlatformConfig()
+      const current = await getContentPlatformConfig({ fresh: true })
       const prospective = applyProspectiveRolloutSetting(
         current,
         input.key,

--- a/app/(protected)/admin/repositories/_components/migration-control-panel.tsx
+++ b/app/(protected)/admin/repositories/_components/migration-control-panel.tsx
@@ -36,6 +36,10 @@ import type {
   RepositoryMigrationDashboard,
   RepositoryMigrationException,
 } from "@/lib/repositories/content-platform/migration-control-service";
+import {
+  MigrationExceptionReasonDialog,
+  type MigrationExceptionReasonRequest,
+} from "./migration-exception-reason-dialog";
 
 interface MigrationPanelState {
   dashboard: RepositoryMigrationDashboard;
@@ -252,8 +256,8 @@ function MigrationExceptions({
   exceptions: RepositoryMigrationException[];
   disabled: boolean;
   runAction: MigrationActionRunner;
-  approveMismatch: (item: RepositoryMigrationException) => Promise<void>;
-  excludeException: (item: RepositoryMigrationException) => Promise<void>;
+  approveMismatch: (item: RepositoryMigrationException) => void;
+  excludeException: (item: RepositoryMigrationException) => void;
 }) {
   if (exceptions.length === 0) return null;
   return (
@@ -314,8 +318,8 @@ function ExceptionRecoveryActions({
   item: RepositoryMigrationException;
   disabled: boolean;
   runAction: MigrationActionRunner;
-  approveMismatch: (item: RepositoryMigrationException) => Promise<void>;
-  excludeException: (item: RepositoryMigrationException) => Promise<void>;
+  approveMismatch: (item: RepositoryMigrationException) => void;
+  excludeException: (item: RepositoryMigrationException) => void;
 }) {
   if (item.status !== "mismatch") {
     return (
@@ -335,7 +339,7 @@ function ExceptionRecoveryActions({
         <Button
           size="sm"
           variant="destructive"
-          onClick={() => void excludeException(item)}
+          onClick={() => excludeException(item)}
           disabled={disabled}
         >
           Exclude
@@ -360,13 +364,60 @@ function ExceptionRecoveryActions({
       <Button
         size="sm"
         variant="secondary"
-        onClick={() => void approveMismatch(item)}
+        onClick={() => approveMismatch(item)}
         disabled={disabled}
       >
         Approve
       </Button>
     </>
   );
+}
+
+function useMigrationExceptionReason(runAction: MigrationActionRunner) {
+  const [request, setRequest] =
+    useState<MigrationExceptionReasonRequest | null>(null);
+  const [reason, setReason] = useState("");
+  const close = useCallback(() => {
+    setRequest(null);
+    setReason("");
+  }, []);
+  const approveMismatch = useCallback((item: RepositoryMigrationException) => {
+    setReason("");
+    setRequest({ kind: "approve", item });
+  }, []);
+  const excludeException = useCallback((item: RepositoryMigrationException) => {
+    setReason("");
+    setRequest({ kind: "exclude", item });
+  }, []);
+  const submit = useCallback(async () => {
+    if (!request || reason.trim().length < 10) return;
+    const auditReason = reason.trim();
+    close();
+    if (request.kind === "exclude") {
+      await runAction(`exclude:${request.item.id}`, () =>
+        excludeRepositoryMigrationExceptionAction({
+          migrationItemId: request.item.id,
+          reason: auditReason,
+        }),
+      );
+      return;
+    }
+    await runAction(`approve:${request.item.id}`, () =>
+      approveRepositoryMigrationMismatchAction({
+        migrationItemId: request.item.id,
+        reason: auditReason,
+      }),
+    );
+  }, [close, reason, request, runAction]);
+  return {
+    approveMismatch,
+    close,
+    excludeException,
+    reason,
+    request,
+    setReason,
+    submit,
+  };
 }
 
 export function MigrationControlPanel() {
@@ -426,37 +477,7 @@ export function MigrationControlPanel() {
     [load, toast],
   );
 
-  const approveMismatch = useCallback(
-    async (item: RepositoryMigrationException) => {
-      const reason = window.prompt(
-        "Document why this extraction difference is acceptable (10-1000 characters):",
-      );
-      if (!reason) return;
-      await runAction(`approve:${item.id}`, () =>
-        approveRepositoryMigrationMismatchAction({
-          migrationItemId: item.id,
-          reason,
-        }),
-      );
-    },
-    [runAction],
-  );
-
-  const excludeException = useCallback(
-    async (item: RepositoryMigrationException) => {
-      const reason = window.prompt(
-        "Document why this failed or unrecoverable legacy source is intentionally excluded from cutover (10-1000 characters):",
-      );
-      if (!reason) return;
-      await runAction(`exclude:${item.id}`, () =>
-        excludeRepositoryMigrationExceptionAction({
-          migrationItemId: item.id,
-          reason,
-        }),
-      );
-    },
-    [runAction],
-  );
+  const exceptionReason = useMigrationExceptionReason(runAction);
 
   if (loading && !state) {
     return (
@@ -513,10 +534,18 @@ export function MigrationControlPanel() {
           exceptions={exceptions}
           disabled={controlsDisabled}
           runAction={runAction}
-          approveMismatch={approveMismatch}
-          excludeException={excludeException}
+          approveMismatch={exceptionReason.approveMismatch}
+          excludeException={exceptionReason.excludeException}
         />
       </CardContent>
+      <MigrationExceptionReasonDialog
+        busy={pendingAction !== null}
+        onClose={exceptionReason.close}
+        onReasonChange={exceptionReason.setReason}
+        onSubmit={() => void exceptionReason.submit()}
+        reason={exceptionReason.reason}
+        request={exceptionReason.request}
+      />
     </Card>
   );
 }

--- a/app/(protected)/admin/repositories/_components/migration-exception-reason-dialog.tsx
+++ b/app/(protected)/admin/repositories/_components/migration-exception-reason-dialog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { meridianPortalClassName } from "@/lib/meridian/fonts";
+import type { RepositoryMigrationException } from "@/lib/repositories/content-platform/migration-control-service";
+
+export interface MigrationExceptionReasonRequest {
+  kind: "approve" | "exclude";
+  item: RepositoryMigrationException;
+}
+
+export function MigrationExceptionReasonDialog({
+  request,
+  reason,
+  busy,
+  onClose,
+  onReasonChange,
+  onSubmit,
+}: {
+  request: MigrationExceptionReasonRequest | null;
+  reason: string;
+  busy: boolean;
+  onClose: () => void;
+  onReasonChange: (reason: string) => void;
+  onSubmit: () => void;
+}) {
+  const trimmedReasonLength = reason.trim().length;
+  const isExclude = request?.kind === "exclude";
+  return (
+    <Dialog
+      open={request !== null}
+      onOpenChange={(open) => {
+        if (!open && !busy) onClose();
+      }}
+    >
+      <DialogContent className={`sm:max-w-lg ${meridianPortalClassName}`}>
+        <DialogHeader>
+          <DialogTitle>
+            {isExclude
+              ? "Exclude legacy source?"
+              : "Approve extraction mismatch?"}
+          </DialogTitle>
+          <DialogDescription>
+            {isExclude
+              ? "Record why this failed or unrecoverable legacy source is intentionally excluded from cutover. The reason and administrator identity are retained in the migration audit trail."
+              : "Record why this extraction difference is acceptable. The reason and administrator identity are retained in the migration audit trail."}
+          </DialogDescription>
+        </DialogHeader>
+        {request ? (
+          <div className="space-y-3">
+            <p className="text-sm font-medium">
+              {request.item.sourceKind.replaceAll("_", " ")} #
+              {request.item.sourceId}
+            </p>
+            <div className="space-y-2">
+              <Label htmlFor="migration-exception-reason">Audit reason</Label>
+              <Textarea
+                id="migration-exception-reason"
+                maxLength={1000}
+                minLength={10}
+                onChange={(event) => onReasonChange(event.target.value)}
+                placeholder="Describe the evidence and why this decision is safe."
+                rows={5}
+                value={reason}
+              />
+              <p className="text-xs text-muted-foreground">
+                {trimmedReasonLength}/1000 characters; at least 10 required.
+              </p>
+            </div>
+          </div>
+        ) : null}
+        <DialogFooter>
+          <Button
+            disabled={busy}
+            onClick={onClose}
+            type="button"
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={busy || trimmedReasonLength < 10}
+            onClick={onSubmit}
+            type="button"
+            variant={isExclude ? "destructive" : "default"}
+          >
+            {isExclude ? "Exclude source" : "Approve mismatch"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/repositories/content-platform/config.ts
+++ b/lib/repositories/content-platform/config.ts
@@ -1,4 +1,5 @@
 import { getSettings } from "@/lib/settings-manager";
+import { getSettingValue } from "@/lib/db/drizzle";
 
 export const CONTENT_PLATFORM_SETTING_KEYS = {
   enabled: "CONTENT_PLATFORM_ENABLED",
@@ -310,8 +311,16 @@ export function parseContentPlatformConfig(
   };
 }
 
-export async function getContentPlatformConfig(): Promise<ContentPlatformConfig> {
+export async function getContentPlatformConfig(options?: {
+  fresh?: boolean;
+}): Promise<ContentPlatformConfig> {
   const keys = Object.values(CONTENT_PLATFORM_SETTING_KEYS);
+  if (options?.fresh) {
+    const entries = await Promise.all(
+      keys.map(async (key) => [key, await getSettingValue(key)] as const),
+    );
+    return parseContentPlatformConfig(Object.fromEntries(entries));
+  }
   return parseContentPlatformConfig(await getSettings(keys));
 }
 

--- a/lib/repositories/content-platform/migration-control-service.ts
+++ b/lib/repositories/content-platform/migration-control-service.ts
@@ -785,6 +785,9 @@ export async function runRepositoryMigrationRollbackDrill(
         sourceKinds: ["repository_item"],
         snapshot: {
           counts: { repository_item: 1 },
+          rollbackDrill: true,
+          migrationItemId: sample.migration_id,
+          canonicalItemId: sample.item_id,
         },
         metrics: { rolledBack: 1 },
         startedAt: now,
@@ -792,24 +795,7 @@ export async function runRepositoryMigrationRollbackDrill(
       })
       .returning();
     if (!run) throw new Error("Failed to record rollback drill");
-    await tx.execute(sql`
-      UPDATE repository_migration_runs
-      SET snapshot = snapshot || jsonb_build_object(
-        'rollbackDrill', true,
-        'migrationItemId', ${sample.migration_id},
-        'canonicalItemId', ${sample.item_id}
-      )
-      WHERE id = ${run.id}::uuid
-    `);
-    return {
-      ...run,
-      snapshot: {
-        ...run.snapshot,
-        rollbackDrill: true,
-        migrationItemId: sample.migration_id,
-        canonicalItemId: sample.item_id,
-      } as RepositoryMigrationSnapshot,
-    };
+    return run;
   }, "contentMigration.rollbackDrill");
 }
 

--- a/lib/settings-manager.ts
+++ b/lib/settings-manager.ts
@@ -1,15 +1,41 @@
 import { getSettingValue as getSettingValueDrizzle } from "@/lib/db/drizzle"
 import logger from "@/lib/logger"
 
+interface SettingsCacheEntry {
+  value: string | null
+  timestamp: number
+}
+
+interface SettingsCacheState {
+  values: Map<string, SettingsCacheEntry>
+  pendingRefreshes: Map<string, symbol>
+  revision: number
+}
+
+const globalSettingsCache = globalThis as typeof globalThis & {
+  __aiStudioSettingsCache?: SettingsCacheState
+}
+const sharedSettingsCache =
+  globalSettingsCache.__aiStudioSettingsCache ??
+  (globalSettingsCache.__aiStudioSettingsCache = {
+    values: new Map<string, SettingsCacheEntry>(),
+    pendingRefreshes: new Map<string, symbol>(),
+    revision: 0,
+  })
+
 // Cache for settings to avoid repeated database queries
 // Uses stale-while-revalidate: serves stale value immediately while refreshing in background
-const settingsCache = new Map<string, { value: string | null; timestamp: number }>()
+// The state lives on globalThis so independently bundled Next.js route and
+// server-action modules invalidate the same in-process cache.
+const settingsCache = sharedSettingsCache.values
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
 // On DB error, retry after this shorter window rather than waiting the full TTL
 const RETRY_AFTER_ERROR_MS = 30 * 1000 // 30 seconds
 
-// Track in-flight background refreshes to avoid duplicate fetches
-const pendingRefreshes = new Set<string>()
+// Track in-flight background refreshes to avoid duplicate fetches. Tokens let
+// invalidation supersede an older request without that request later deleting
+// or overwriting newer cache state.
+const pendingRefreshes = sharedSettingsCache.pendingRefreshes
 
 // Mask credential/secret key names in log output to avoid leaking config surface
 const SENSITIVE_KEY_PATTERN = /KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL/i
@@ -23,10 +49,18 @@ export function maskKey(key: string): string {
 // Do not call backgroundRefresh() for Lambda+Bedrock keys from other code paths.
 function backgroundRefresh(key: string): void {
   if (pendingRefreshes.has(key)) return
-  pendingRefreshes.add(key)
+  const refreshToken = Symbol(key)
+  const refreshRevision = sharedSettingsCache.revision
+  pendingRefreshes.set(key, refreshToken)
 
   getSettingValueDrizzle(key)
     .then((dbValue) => {
+      if (
+        sharedSettingsCache.revision !== refreshRevision ||
+        pendingRefreshes.get(key) !== refreshToken
+      ) {
+        return
+      }
       if (dbValue !== null) {
         // Fresh value from DB — update cache
         settingsCache.set(key, { value: dbValue, timestamp: Date.now() })
@@ -48,6 +82,12 @@ function backgroundRefresh(key: string): void {
     })
     .catch((error) => {
       logger.error(`[SettingsManager] Background refresh failed for ${maskKey(key)}:`, error)
+      if (
+        sharedSettingsCache.revision !== refreshRevision ||
+        pendingRefreshes.get(key) !== refreshToken
+      ) {
+        return
+      }
       // On error, retry after a short window (not full TTL) so we recover quickly when DB is back
       const stale = settingsCache.get(key)
       if (stale) {
@@ -58,7 +98,9 @@ function backgroundRefresh(key: string): void {
       }
     })
     .finally(() => {
-      pendingRefreshes.delete(key)
+      if (pendingRefreshes.get(key) === refreshToken) {
+        pendingRefreshes.delete(key)
+      }
     })
 }
 
@@ -134,6 +176,7 @@ export async function getSettings(keys: string[]): Promise<Record<string, string
 // Also cancels any pending background refresh for the key to prevent a stale
 // in-flight promise from writing old data back into the cache after invalidation.
 export async function revalidateSettingsCache(key?: string): Promise<void> {
+  sharedSettingsCache.revision += 1
   if (key) {
     settingsCache.delete(key)
     pendingRefreshes.delete(key)

--- a/tests/unit/actions/admin-repository-migration-shadow-sample.test.ts
+++ b/tests/unit/actions/admin-repository-migration-shadow-sample.test.ts
@@ -176,6 +176,7 @@ describe("recordRepositoryRetrievalShadowSampleAction", () => {
       },
     });
     expect(mockExecuteSearch).toHaveBeenCalledTimes(2);
+    expect(mockGetContentPlatformConfig).toHaveBeenCalledWith({ fresh: true });
     expect(mockAssertRepositoryReadAccess).toHaveBeenCalledWith(
       41,
       "admin-sub",

--- a/tests/unit/content-migration-retry-targeting.test.ts
+++ b/tests/unit/content-migration-retry-targeting.test.ts
@@ -25,6 +25,20 @@ const migrationRunner = readFileSync(
   ),
   "utf8",
 );
+const migrationControlPanel = readFileSync(
+  resolve(
+    process.cwd(),
+    "app/(protected)/admin/repositories/_components/migration-control-panel.tsx",
+  ),
+  "utf8",
+);
+const migrationReasonDialog = readFileSync(
+  resolve(
+    process.cwd(),
+    "app/(protected)/admin/repositories/_components/migration-exception-reason-dialog.tsx",
+  ),
+  "utf8",
+);
 
 describe("repository migration retry targeting", () => {
   it("marks both single and bounded bulk retry runs as retry-only", () => {
@@ -91,5 +105,35 @@ describe("repository migration retry targeting", () => {
     expect(migrationControlService).toContain(
       'contentMigration.excludeException',
     );
+  });
+
+  it("records rollback-drill audit evidence in the initial run insert", () => {
+    const functionStart = migrationControlService.indexOf(
+      "export async function runRepositoryMigrationRollbackDrill",
+    );
+    const functionEnd = migrationControlService.indexOf(
+      "function migrationMetricsFromRows",
+      functionStart,
+    );
+    const rollbackDrill = migrationControlService.slice(
+      functionStart,
+      functionEnd,
+    );
+
+    expect(rollbackDrill).toContain("rollbackDrill: true");
+    expect(rollbackDrill).toContain("migrationItemId: sample.migration_id");
+    expect(rollbackDrill).toContain("canonicalItemId: sample.item_id");
+    expect(rollbackDrill).not.toContain("UPDATE repository_migration_runs");
+  });
+
+  it("collects audit reasons in an accessible application dialog", () => {
+    expect(migrationControlPanel).not.toContain("window.prompt");
+    expect(migrationControlPanel).toContain("MigrationExceptionReasonDialog");
+    expect(migrationReasonDialog).toContain("<DialogTitle>");
+    expect(migrationReasonDialog).toContain(
+      'Label htmlFor="migration-exception-reason"',
+    );
+    expect(migrationReasonDialog).toContain("minLength={10}");
+    expect(migrationReasonDialog).toContain("maxLength={1000}");
   });
 });

--- a/tests/unit/lib/settings-manager-s3.test.ts
+++ b/tests/unit/lib/settings-manager-s3.test.ts
@@ -18,7 +18,11 @@ jest.mock("@/lib/aws/s3-client", () => ({
   clearS3Cache: jest.fn(),
 }));
 
-import { revalidateSettingsCache, Settings } from "@/lib/settings-manager";
+import {
+  getSetting,
+  revalidateSettingsCache,
+  Settings,
+} from "@/lib/settings-manager";
 
 describe("Settings.getS3", () => {
   beforeEach(async () => {
@@ -57,5 +61,43 @@ describe("Settings.getS3", () => {
       bucket: "environment-documents",
       region: "us-east-2",
     });
+  });
+
+  it("does not let an invalidated background refresh overwrite a newer value", async () => {
+    jest.useFakeTimers({ now: new Date("2026-08-02T00:00:00.000Z") });
+    let resolveStaleRefresh: ((value: string | null) => void) | undefined;
+    try {
+      mockGetSettingValue.mockReset();
+      mockGetSettingValue.mockResolvedValueOnce("false");
+      await expect(getSetting("CONTENT_RETRIEVAL_SHADOW_ENABLED")).resolves.toBe(
+        "false",
+      );
+
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+      mockGetSettingValue.mockImplementationOnce(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveStaleRefresh = resolve;
+          }),
+      );
+      await expect(getSetting("CONTENT_RETRIEVAL_SHADOW_ENABLED")).resolves.toBe(
+        "false",
+      );
+
+      await revalidateSettingsCache("CONTENT_RETRIEVAL_SHADOW_ENABLED");
+      mockGetSettingValue.mockResolvedValueOnce("true");
+      await expect(getSetting("CONTENT_RETRIEVAL_SHADOW_ENABLED")).resolves.toBe(
+        "true",
+      );
+
+      resolveStaleRefresh?.("false");
+      await Promise.resolve();
+      await Promise.resolve();
+      await expect(getSetting("CONTENT_RETRIEVAL_SHADOW_ENABLED")).resolves.toBe(
+        "true",
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- record rollback-drill evidence atomically in the migration run insert
- read operational rollout flags fresh and make settings cache invalidation race-safe across Next.js bundles
- replace native migration prompts with an accessible audited-reason dialog

## Verification
- focused Jest: 21 passed
- full TypeScript check: passed
- full tracked-code lint: passed
- production build: passed
- authenticated pre-push E2E: 312 passed, 40 skipped

Follow-up for #1531.