### PR TITLE
fix(content): recover incomplete migration runs

### DIFF
--- a/lib/repositories/content-platform/migration-runner.ts
+++ b/lib/repositories/content-platform/migration-runner.ts
@@ -1301,6 +1301,24 @@ export async function getRepositoryMigrationRunMetrics(
 async function finishBackfillRun(
   run: RepositoryMigrationRunRow,
 ): Promise<void> {
+  await executeQuery(
+    (db) =>
+      db.execute(sql`
+        UPDATE repository_migration_items
+        SET status = 'unrecoverable',
+            last_error_code = 'MIGRATION_RUN_SOURCE_UNPROCESSED',
+            last_error_message =
+              'Migration run ended without processing this source; retry the source',
+            metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+              'unprocessedRunId', ${run.id}::text
+            ),
+            verified_at = NULL,
+            updated_at = NOW()
+        WHERE run_id = ${run.id}::uuid
+          AND status IN ('pending', 'migrating')
+      `),
+    "contentMigration.failUnprocessedBackfillItems",
+  );
   // A retry preserves origin_run_id for rollback ownership, but its result
   // belongs to the retry run that currently owns the item.
   const metrics = await getRepositoryMigrationRunMetrics(run.id);
@@ -1508,6 +1526,29 @@ async function reconcileMigrationCandidate(
 async function reconcileNextBatch(
   run: RepositoryMigrationRunRow,
 ): Promise<void> {
+  await executeQuery(
+    (db) =>
+      db.execute(sql`
+        UPDATE repository_migration_items migration
+        SET status = 'unrecoverable',
+            last_error_code = 'MIGRATION_RUN_SOURCE_UNPROCESSED',
+            last_error_message =
+              'Migration run ended without processing this source; retry the source',
+            metadata = COALESCE(migration.metadata, '{}'::jsonb) ||
+              jsonb_build_object(
+                'unprocessedRunId', migration.run_id::text,
+                'lastReconciledRunId', ${run.id}::text
+              ),
+            verified_at = NULL,
+            updated_at = NOW()
+        FROM repository_migration_runs owner_run
+        WHERE owner_run.id = migration.run_id
+          AND owner_run.id <> ${run.id}::uuid
+          AND owner_run.status NOT IN ('queued', 'running')
+          AND migration.status IN ('pending', 'migrating')
+      `),
+    "contentMigration.recoverTerminalRunOrphans",
+  );
   const migrations = await executeQuery(
     (db) =>
       db

--- a/tests/unit/content-migration-retry-targeting.test.ts
+++ b/tests/unit/content-migration-retry-targeting.test.ts
@@ -96,6 +96,24 @@ describe("repository migration retry targeting", () => {
     );
   });
 
+  it("turns unprocessed terminal-run items back into retryable exceptions", () => {
+    expect(migrationRunner).toContain(
+      "contentMigration.failUnprocessedBackfillItems",
+    );
+    expect(migrationRunner).toContain(
+      "contentMigration.recoverTerminalRunOrphans",
+    );
+    expect(migrationRunner.match(/MIGRATION_RUN_SOURCE_UNPROCESSED/g)).toHaveLength(
+      2,
+    );
+    expect(migrationRunner).toContain(
+      "owner_run.status NOT IN ('queued', 'running')",
+    );
+    expect(migrationRunner).toContain(
+      "migration.status IN ('pending', 'migrating')",
+    );
+  });
+
   it("applies an exception-status filter before the bounded query limit", () => {
     const functionStart = migrationControlService.indexOf(
       "export async function listRepositoryMigrationExceptions",


### PR DESCRIPTION
## Summary
- convert unprocessed pending/migrating items to retryable exceptions when a backfill run finishes
- recover historical pending items whose owning run is already terminal during reconciliation
- preserve audit metadata linking the unprocessed and reconciliation runs
- add regression coverage for terminal-run orphan recovery

## Production evidence
Repository item #37 is pending under a completed retry run, leaving production at 84/85 tracked even though no exception is visible. This repair makes that state visible and retryable, then the existing canonical-version retry fix can complete it.

## Validation
- bunx jest tests/unit/content-migration-retry-targeting.test.ts --runInBand
- bunx eslint lib/repositories/content-platform/migration-runner.ts tests/unit/content-migration-retry-targeting.test.ts
- bun run typecheck
- bunx eslint . --max-warnings 0 --ignore-pattern lib/utils/text-sanitizer.js