### PR TITLE
fix(agent): name failed-turn side effects, allow access-proposal resolution

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -246,6 +246,7 @@ def _classify_chat_error(error_message: str) -> str:
 def _frame_failed_partial(
     partial: str,
     completed_tools: Optional[List[Dict[str, Any]]] = None,
+    in_flight_tools: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Wrap a failed/degraded turn so it is never presented as a clean answer.
 
@@ -264,7 +265,7 @@ def _frame_failed_partial(
     nothing at all happened. We KNOW which tools completed, so say so.
     """
     partial = (partial or "").strip()
-    ran = _describe_completed_tools(completed_tools)
+    ran = _describe_completed_tools(completed_tools, in_flight_tools)
     if partial:
         return (
             "⚠️ I couldn't finish that — I hit a problem partway "
@@ -278,6 +279,7 @@ def _frame_failed_partial(
 
 def _describe_completed_tools(
     tool_calls: Optional[List[Dict[str, Any]]],
+    in_flight: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Render the finished tool calls as a short clause, or '' when none ran.
 
@@ -297,6 +299,25 @@ def _describe_completed_tools(
     # created — precisely the failure this function exists to prevent. So an
     # unreadable terminal record suppresses the safe-to-retry claim.
     unnamed_terminal = False
+    # A tool that STARTED and never reported back is the most dangerous case,
+    # not the safest: the request may have reached the broker and created the
+    # Doc before the turn died, and its result event simply never arrived.
+    # Started calls live in `tool_starts` and are removed from it when they
+    # complete, so anything still there is genuinely in flight — and it never
+    # appears in `tool_calls` at all, which is how an interrupted side effect
+    # could leave that list empty and produce a "safe to retry".
+    started_names = []
+    if isinstance(in_flight, dict):
+        for start in in_flight.values():
+            if not isinstance(start, dict):
+                unnamed_terminal = True
+                continue
+            name = start.get("name")
+            if isinstance(name, str) and name and name != "unknown":
+                if name not in started_names:
+                    started_names.append(name)
+            else:
+                unnamed_terminal = True
     for call in tool_calls:
         if not isinstance(call, dict):
             unnamed_terminal = True
@@ -309,18 +330,33 @@ def _describe_completed_tools(
                 names.append(name)
         else:
             unnamed_terminal = True
+    # An in-flight call is reported as uncertain rather than as completed: we
+    # know it was requested, not whether it landed.
+    if started_names:
+        started_shown = ", ".join(started_names[:3])
+        started_more = (
+            f" (+{len(started_names) - 3} more)" if len(started_names) > 3 else ""
+        )
+        started_note = (
+            f" {started_shown}{started_more} was still running and may or may not "
+            "have completed."
+        )
+    else:
+        started_note = ""
+
     if not names:
-        if unnamed_terminal:
+        if started_names or unnamed_terminal:
             return (
-                " Some steps may have already run, so please check before retrying."
-            )
+                f"{started_note} Some steps may have already run, so please check "
+                "before retrying."
+            ).lstrip()
         return " Nothing had run yet, so it's safe to retry."
     shown = ", ".join(names[:5])
     more = f" (+{len(names) - 5} more)" if len(names) > 5 else ""
     unknown_note = " (and possibly others)" if unnamed_terminal else ""
     return (
         f" I had already run: {shown}{more}{unknown_note} — "
-        "please check those before retrying."
+        f"please check those before retrying.{started_note}"
     )
 
 
@@ -1347,6 +1383,7 @@ class OpenClawAdapter(HarnessAdapter):
                                 if visible_response
                                 else "",
                                 tool_calls,
+                                tool_starts,
                             )
                             # An errored turn can still have burned tokens
                             # before it failed — bill them rather than
@@ -1626,7 +1663,7 @@ class OpenClawAdapter(HarnessAdapter):
             )
             return _result(
                 _frame_failed_partial(
-                    _format_for_chat(response_text.strip()), tool_calls
+                    _format_for_chat(response_text.strip()), tool_calls, tool_starts
                 ),
                 failed=True,
                 error_class=error_class,
@@ -1672,7 +1709,9 @@ class OpenClawAdapter(HarnessAdapter):
                 # answer (issue #1138 F4).
                 return _result(
                     _frame_failed_partial(
-                        _format_for_chat(response_text.strip()), tool_calls
+                        _format_for_chat(response_text.strip()),
+                        tool_calls,
+                        tool_starts,
                     ),
                     failed=True,
                     error_class="ChatDeadlineExpiredPartial",

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -243,7 +243,10 @@ def _classify_chat_error(error_message: str) -> str:
     return "OpenClawChatError"
 
 
-def _frame_failed_partial(partial: str, completed_tools=None) -> str:
+def _frame_failed_partial(
+    partial: str,
+    completed_tools: Optional[List[Dict[str, Any]]] = None,
+) -> str:
     """Wrap a failed/degraded turn so it is never presented as a clean answer.
 
     When a turn dies mid-task the model has usually emitted some scratchpad
@@ -269,11 +272,13 @@ def _frame_failed_partial(partial: str, completed_tools=None) -> str:
         )
     return (
         "⚠️ I couldn't complete that — I hit a problem partway "
-        f"through.{ran} Please check before retrying."
+        f"through.{ran}"
     )
 
 
-def _describe_completed_tools(tool_calls) -> str:
+def _describe_completed_tools(
+    tool_calls: Optional[List[Dict[str, Any]]],
+) -> str:
     """Render the finished tool calls as a short clause, or '' when none ran.
 
     Deduplicated and capped: a turn that looped over 40 files should not paste
@@ -284,21 +289,71 @@ def _describe_completed_tools(tool_calls) -> str:
     if not isinstance(tool_calls, list):
         return " Some steps may have already run, so please check before retrying."
     names = []
+    # A record we cannot read is NOT evidence that nothing ran. Two ingestion
+    # paths feed tool_calls and only the newer one normalizes `status`, so the
+    # legacy tool_result stream can carry a terminal status we do not recognise
+    # ("completed", "ok", …) or a missing name. Counting those as "nothing
+    # happened" would tell the user a retry is safe when a Doc had already been
+    # created — precisely the failure this function exists to prevent. So an
+    # unreadable terminal record suppresses the safe-to-retry claim.
+    unnamed_terminal = False
     for call in tool_calls:
         if not isinstance(call, dict):
+            unnamed_terminal = True
             continue
-        if call.get("status") not in ("success", "error"):
+        if _tool_call_is_pending(call):
             continue
         name = call.get("name")
-        if isinstance(name, str) and name and name != "unknown" and name not in names:
-            names.append(name)
+        if isinstance(name, str) and name and name != "unknown":
+            if name not in names:
+                names.append(name)
+        else:
+            unnamed_terminal = True
     if not names:
-        return " No actions had run yet, so it's safe to retry."
+        if unnamed_terminal:
+            return (
+                " Some steps may have already run, so please check before retrying."
+            )
+        return " Nothing had run yet, so it's safe to retry."
     shown = ", ".join(names[:5])
     more = f" (+{len(names) - 5} more)" if len(names) > 5 else ""
+    unknown_note = " (and possibly others)" if unnamed_terminal else ""
     return (
-        f" I had already run: {shown}{more} — please check those before retrying."
+        f" I had already run: {shown}{more}{unknown_note} — "
+        "please check those before retrying."
     )
+
+
+# Statuses that mean a call had NOT finished when the turn died. Anything else
+# terminal — including a status this build does not know — counts as completed,
+# because assuming an unknown status means "did not run" is the unsafe
+# direction.
+_PENDING_TOOL_STATUSES = frozenset({"running", "pending", "started", "in_progress"})
+
+
+def _normalize_tool_status(raw: Any, error: Any) -> str:
+    """Collapse a wire status into "success" / "error" / a pending status.
+
+    The item path already does this inline; the legacy tool_result path did not,
+    so a completion could reach telemetry as "completed" or "ok".
+    """
+    if isinstance(raw, str) and raw.strip():
+        lowered = raw.strip().lower()
+        if lowered in _PENDING_TOOL_STATUSES:
+            return lowered
+        if lowered in ("error", "failed"):
+            return "error"
+        return "error" if error else "success"
+    return "error" if error else "success"
+
+
+def _tool_call_is_pending(call: dict) -> bool:
+    status = call.get("status")
+    if status is None:
+        return False
+    if not isinstance(status, str):
+        return False
+    return status.strip().lower() in _PENDING_TOOL_STATUSES
 
 
 class HarnessAdapter(abc.ABC):
@@ -1162,8 +1217,14 @@ class OpenClawAdapter(HarnessAdapter):
                                 "result": data.get("result")
                                 or data.get("output")
                                 or data.get("content"),
-                                "status": data.get("status")
-                                or ("error" if data.get("error") else "success"),
+                                # Normalized to the same success/error vocabulary
+                                # the item path uses: a raw wire status like
+                                # "completed" would otherwise flow straight into
+                                # telemetry and the failed-turn summary, which
+                                # gate on these exact values.
+                                "status": _normalize_tool_status(
+                                    data.get("status"), data.get("error")
+                                ),
                                 "error_text": (
                                     str(data.get("error"))[:2000]
                                     if data.get("error") else None

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -243,7 +243,7 @@ def _classify_chat_error(error_message: str) -> str:
     return "OpenClawChatError"
 
 
-def _frame_failed_partial(partial: str) -> str:
+def _frame_failed_partial(partial: str, completed_tools=None) -> str:
     """Wrap a failed/degraded turn so it is never presented as a clean answer.
 
     When a turn dies mid-task the model has usually emitted some scratchpad
@@ -254,18 +254,50 @@ def _frame_failed_partial(partial: str) -> str:
     is no partial, return a standalone error.
 
     `partial` must already be chat-formatted (the frame text is plain).
+
+    `completed_tools` names the tool calls that finished before the turn died.
+    "Some steps may have already run" is unactionable on its own — a principal
+    told that has no way to know whether a doc was created, an event booked, or
+    nothing at all happened. We KNOW which tools completed, so say so.
     """
     partial = (partial or "").strip()
+    ran = _describe_completed_tools(completed_tools)
     if partial:
         return (
             "⚠️ I couldn't finish that — I hit a problem partway "
-            "through and some steps may have already run. Here's how far I "
-            "got:\n\n" + partial
+            f"through.{ran} Here's how far I got:\n\n" + partial
         )
     return (
         "⚠️ I couldn't complete that — I hit a problem partway "
-        "through. Some steps may have already run, so please check before "
-        "retrying."
+        f"through.{ran} Please check before retrying."
+    )
+
+
+def _describe_completed_tools(tool_calls) -> str:
+    """Render the finished tool calls as a short clause, or '' when none ran.
+
+    Deduplicated and capped: a turn that looped over 40 files should not paste
+    40 identical names into a Chat message. When nothing completed we say so
+    outright, because "nothing ran" is the single most useful thing a user can
+    be told here — it means retrying is safe.
+    """
+    if not isinstance(tool_calls, list):
+        return " Some steps may have already run, so please check before retrying."
+    names = []
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        if call.get("status") not in ("success", "error"):
+            continue
+        name = call.get("name")
+        if isinstance(name, str) and name and name != "unknown" and name not in names:
+            names.append(name)
+    if not names:
+        return " No actions had run yet, so it's safe to retry."
+    shown = ", ".join(names[:5])
+    more = f" (+{len(names) - 5} more)" if len(names) > 5 else ""
+    return (
+        f" I had already run: {shown}{more} — please check those before retrying."
     )
 
 
@@ -1252,7 +1284,8 @@ class OpenClawAdapter(HarnessAdapter):
                             err_text = _frame_failed_partial(
                                 _format_for_chat(visible_response)
                                 if visible_response
-                                else ""
+                                else "",
+                                tool_calls,
                             )
                             # An errored turn can still have burned tokens
                             # before it failed — bill them rather than
@@ -1531,7 +1564,9 @@ class OpenClawAdapter(HarnessAdapter):
                 },
             )
             return _result(
-                _frame_failed_partial(_format_for_chat(response_text.strip())),
+                _frame_failed_partial(
+                    _format_for_chat(response_text.strip()), tool_calls
+                ),
                 failed=True,
                 error_class=error_class,
             )
@@ -1575,7 +1610,9 @@ class OpenClawAdapter(HarnessAdapter):
                 # failed turn — frame it so it doesn't read as a finished
                 # answer (issue #1138 F4).
                 return _result(
-                    _frame_failed_partial(_format_for_chat(response_text.strip())),
+                    _frame_failed_partial(
+                        _format_for_chat(response_text.strip()), tool_calls
+                    ),
                     failed=True,
                     error_class="ChatDeadlineExpiredPartial",
                 )

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -253,8 +253,13 @@ agent-owned file, Drive records an access proposal. List them with
 
 ```bash
 gws drive.accessproposals.resolve --scope agent --user hagelk@psd401.net \
-  --json '{"fileId":"<id>","proposalId":"<id>","action":"accept","role":"writer"}'
+  --params '{"fileId":"<id>","proposalId":"<id>"}' \
+  --json '{"action":"accept","role":"writer"}'
 ```
+
+The two IDs address the endpoint, so they ride `--params`; `action` and `role`
+are the request body and ride `--json` — the same split as every other command
+in this skill.
 
 Use `"action":"deny"` to decline; a denial needs no role.
 

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -246,6 +246,18 @@ gws drive.permissions.create --scope agent --user hagelk@psd401.net \
   --json '{"fileId":"<id>","type":"domain","role":"reader","domain":"psd401.net"}'
 ```
 
+**Granting a request someone already made.** When a user hits "request access" on an
+agent-owned file, Drive records an access proposal. List them with
+`drive accessproposals list` and grant one with `drive accessproposals resolve`
+— the same reader/commenter/writer ceiling as a named share, never `owner`:
+
+```bash
+gws drive.accessproposals.resolve --scope agent --user hagelk@psd401.net \
+  --json '{"fileId":"<id>","proposalId":"<id>","action":"accept","role":"writer"}'
+```
+
+Use `"action":"deny"` to decline; a denial needs no role.
+
 When you post a doc link into a shared Chat space, share it district-wide (domain/reader) FIRST — otherwise members hit "request access". Anything outside these shapes is still blocked.
 
 If a user explicitly asks the agent to send something, post the draft + a clear "I drafted it; reply 'send' if it's right" in Chat instead. The user clicks send themselves.

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -840,3 +840,32 @@ describe('#1305 marker injection marks the nested resource, not the envelope', (
     });
   }
 });
+
+// Codex asked for coverage beyond the broker validator: the skill layer must
+// also let the documented accessproposals shape through, or the operation is
+// allowlisted server-side and still unreachable from the agent.
+describe('drive accessproposals reach the broker', () => {
+  const AGENT = { scope: 'agent_account', ownerEmail: 'hagelk@psd401.net' };
+  const USER = { scope: 'user_account', ownerEmail: 'hagelk@psd401.net' };
+
+  test('resolve passes the skill gate on the agent slot', () => {
+    const cmd = `drive accessproposals resolve --json '{"fileId":"f","proposalId":"p","action":"accept","role":"writer"}'`;
+    expect(enforcePhase1Gates(cmd, AGENT).allowed).toBe(true);
+    expect(enforcePhase1Gates(cmd.replace(/ /g, '.').replace(/\.--json.*/, '') , AGENT).allowed).toBe(true);
+  });
+
+  test('list is an ordinary read on either slot', () => {
+    const cmd = `drive accessproposals list --params '{"fileId":"f"}'`;
+    expect(enforcePhase1Gates(cmd, AGENT).allowed).toBe(true);
+    expect(enforcePhase1Gates(cmd, USER).allowed).toBe(true);
+  });
+
+  test('the permissions denylist does not accidentally catch it', () => {
+    // `permissions create|update|delete` must not match `accessproposals`.
+    const gate = enforcePhase1Gates(
+      `drive accessproposals resolve --json '{"fileId":"f","proposalId":"p","action":"deny"}'`,
+      AGENT,
+    );
+    expect(gate.allowed).toBe(true);
+  });
+});

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -849,7 +849,8 @@ describe('drive accessproposals reach the broker', () => {
   const USER = { scope: 'user_account', ownerEmail: 'hagelk@psd401.net' };
 
   test('resolve passes the skill gate on the agent slot', () => {
-    const cmd = `drive accessproposals resolve --json '{"fileId":"f","proposalId":"p","action":"accept","role":"writer"}'`;
+    // The documented shape: IDs in --params, body in --json.
+    const cmd = `drive accessproposals resolve --params '{"fileId":"f","proposalId":"p"}' --json '{"action":"accept","role":"writer"}'`;
     expect(enforcePhase1Gates(cmd, AGENT).allowed).toBe(true);
     expect(enforcePhase1Gates(cmd.replace(/ /g, '.').replace(/\.--json.*/, '') , AGENT).allowed).toBe(true);
   });

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1478,11 +1478,38 @@ class TestFailedPartialNamesSideEffects(unittest.TestCase):
         # Must not also tell them to go check — that was contradictory.
         self.assertNotIn("check before retrying", text)
 
-    def test_ignores_tools_still_in_flight(self):
-        # A started-but-unfinished call is not a known side effect.
+    def test_a_tool_still_in_flight_is_never_safe_to_retry(self):
+        # The dangerous case, not the safe one: the request may have reached the
+        # broker and created the Doc before the turn died, with its result event
+        # simply never arriving. Started calls live in tool_starts and never
+        # appear in tool_calls, so this is exactly how an interrupted side effect
+        # could otherwise leave the list empty and claim a safe retry.
         text = harness_adapter._frame_failed_partial(
-            "", [{"name": "docs.create", "status": "running"}]
+            "", [], {"t1": {"name": "docs.create", "started_at": 0}}
         )
+        self.assertNotIn("safe to retry", text)
+        self.assertIn("docs.create", text)
+        self.assertIn("may or may not have completed", text)
+
+    def test_in_flight_reported_alongside_completed_tools(self):
+        text = harness_adapter._frame_failed_partial(
+            "",
+            [{"name": "psd-data.query", "status": "success"}],
+            {"t1": {"name": "drive.share", "started_at": 0}},
+        )
+        self.assertIn("psd-data.query", text)
+        self.assertIn("drive.share", text)
+        self.assertNotIn("safe to retry", text)
+
+    def test_an_unnamed_in_flight_call_still_blocks_the_safe_claim(self):
+        text = harness_adapter._frame_failed_partial(
+            "", [], {"t1": {"started_at": 0}}
+        )
+        self.assertNotIn("safe to retry", text)
+        self.assertIn("may have already run", text)
+
+    def test_safe_to_retry_needs_both_lists_empty(self):
+        text = harness_adapter._frame_failed_partial("", [], {})
         self.assertIn("safe to retry", text)
 
     def test_an_unrecognized_terminal_status_still_counts_as_run(self):

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1453,3 +1453,54 @@ class ChatErrorClassificationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFailedPartialNamesSideEffects(unittest.TestCase):
+    """"Some steps may have already run" is unactionable — name them.
+
+    A principal told only that something *may* have happened cannot tell whether
+    a doc was created, an event booked, or nothing at all. The harness records
+    every completed tool call, so it can say which (agent_failures: 11 rows /
+    7 users got the vague form).
+    """
+
+    def test_names_the_tools_that_completed(self):
+        text = harness_adapter._frame_failed_partial(
+            "",
+            [
+                {"name": "docs.create", "status": "success"},
+                {"name": "drive.share", "status": "error"},
+            ],
+        )
+        self.assertIn("docs.create", text)
+        self.assertIn("drive.share", text)
+        self.assertIn("check those before retrying", text)
+
+    def test_says_retry_is_safe_when_nothing_ran(self):
+        text = harness_adapter._frame_failed_partial("", [])
+        self.assertIn("safe to retry", text)
+
+    def test_ignores_tools_still_in_flight(self):
+        # A started-but-unfinished call is not a known side effect.
+        text = harness_adapter._frame_failed_partial(
+            "", [{"name": "docs.create", "status": "running"}]
+        )
+        self.assertIn("safe to retry", text)
+
+    def test_dedupes_and_caps_a_long_tool_list(self):
+        calls = [{"name": f"tool{i}", "status": "success"} for i in range(9)]
+        calls += [{"name": "tool0", "status": "success"}]  # duplicate
+        text = harness_adapter._frame_failed_partial("", calls)
+        self.assertIn("+4 more", text)
+        self.assertEqual(text.count("tool0"), 1)
+
+    def test_preserves_the_partial_answer(self):
+        text = harness_adapter._frame_failed_partial(
+            "Here is what I found", [{"name": "psd-data.query", "status": "success"}]
+        )
+        self.assertIn("Here is what I found", text)
+        self.assertIn("psd-data.query", text)
+
+    def test_unknown_shape_keeps_the_conservative_warning(self):
+        text = harness_adapter._frame_failed_partial("", None)
+        self.assertIn("may have already run", text)

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1451,12 +1451,8 @@ class ChatErrorClassificationTests(unittest.TestCase):
         )
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestFailedPartialNamesSideEffects(unittest.TestCase):
-    """"Some steps may have already run" is unactionable — name them.
+    """Name the side effects instead of the vague "some steps may have run".
 
     A principal told only that something *may* have happened cannot tell whether
     a doc was created, an event booked, or nothing at all. The harness records
@@ -1479,6 +1475,8 @@ class TestFailedPartialNamesSideEffects(unittest.TestCase):
     def test_says_retry_is_safe_when_nothing_ran(self):
         text = harness_adapter._frame_failed_partial("", [])
         self.assertIn("safe to retry", text)
+        # Must not also tell them to go check — that was contradictory.
+        self.assertNotIn("check before retrying", text)
 
     def test_ignores_tools_still_in_flight(self):
         # A started-but-unfinished call is not a known side effect.
@@ -1486,6 +1484,37 @@ class TestFailedPartialNamesSideEffects(unittest.TestCase):
             "", [{"name": "docs.create", "status": "running"}]
         )
         self.assertIn("safe to retry", text)
+
+    def test_an_unrecognized_terminal_status_still_counts_as_run(self):
+        # The legacy tool_result stream does not normalize `status`, so a real
+        # completion can arrive as "completed"/"ok". Treating that as "did not
+        # run" would claim a safe retry after a Doc was already created.
+        text = harness_adapter._frame_failed_partial(
+            "", [{"name": "docs.create", "status": "completed"}]
+        )
+        self.assertIn("docs.create", text)
+        self.assertNotIn("safe to retry", text)
+
+    def test_an_unreadable_record_suppresses_the_safe_retry_claim(self):
+        for calls in (
+            [{"status": "success"}],           # terminal, but no usable name
+            [{"name": "unknown", "status": "success"}],
+            ["not-a-dict"],
+        ):
+            text = harness_adapter._frame_failed_partial("", calls)
+            self.assertNotIn("safe to retry", text, calls)
+            self.assertIn("may have already run", text, calls)
+
+    def test_named_and_unreadable_together_flags_the_uncertainty(self):
+        text = harness_adapter._frame_failed_partial(
+            "",
+            [
+                {"name": "docs.create", "status": "success"},
+                {"status": "success"},
+            ],
+        )
+        self.assertIn("docs.create", text)
+        self.assertIn("possibly others", text)
 
     def test_dedupes_and_caps_a_long_tool_list(self):
         calls = [{"name": f"tool{i}", "status": "success"} for i in range(9)]
@@ -1504,3 +1533,7 @@ class TestFailedPartialNamesSideEffects(unittest.TestCase):
     def test_unknown_shape_keeps_the_conservative_warning(self):
         text = harness_adapter._frame_failed_partial("", None)
         self.assertIn("may have already run", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -494,8 +494,15 @@ function validateAccessProposalResolve(argv: readonly string[]): void {
   if (!action || !ACCESS_PROPOSAL_ACTIONS.has(action)) throw new Error(refuse)
   if (action === "deny") return
   // Drive takes the accepted role as either a string or a single-element list.
-  const rawRole = Array.isArray(resource.role) ? resource.role[0] : resource.role
-  const role = typeof rawRole === "string" ? rawRole.toLowerCase() : null
+  // Validate the WHOLE list, not just index 0: `["reader","owner"]` would
+  // otherwise pass on its first element while `executeWorkspaceCommand` forwards
+  // the original argv — the full, unvalidated JSON — to `gws` verbatim, so
+  // nothing downstream re-reads the array. That is exactly the ceiling this
+  // check exists to hold.
+  const rawRole = resource.role
+  const roles = Array.isArray(rawRole) ? rawRole : [rawRole]
+  if (roles.length !== 1) throw new Error(refuse)
+  const role = typeof roles[0] === "string" ? roles[0].toLowerCase() : null
   if (!role || !PERMISSION_ROLES_NAMED.has(role)) throw new Error(refuse)
 }
 

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -482,8 +482,17 @@ const ACCESS_PROPOSAL_ACTIONS = new Set(["accept", "deny"])
  */
 function validateAccessProposalResolve(argv: readonly string[]): void {
   const refuse = "Access proposals resolve to reader, commenter or writer only"
-  const resource = jsonResource(argv) ?? parseObjectArgument(argv, "--params")
-  if (!resource) throw new Error(refuse)
+  // The IDs address the endpoint and ride --params; action/role are the body
+  // and ride --json. Validate the UNION so neither flag can carry a field the
+  // other is being judged on, and so an unrecognized key is caught wherever it
+  // was placed.
+  const resource = {
+    ...(parseObjectArgument(argv, "--params") ?? {}),
+    ...(jsonResource(argv) ?? {}),
+  }
+  if (!jsonResource(argv) && !parseObjectArgument(argv, "--params")) {
+    throw new Error(refuse)
+  }
   const keys = Object.keys(resource)
   if (keys.length === 0) throw new Error(refuse)
   if (!keys.every((key) => ACCESS_PROPOSAL_FIELDS.has(key.toLowerCase()))) {
@@ -493,17 +502,22 @@ function validateAccessProposalResolve(argv: readonly string[]): void {
     typeof resource.action === "string" ? resource.action.toLowerCase() : null
   if (!action || !ACCESS_PROPOSAL_ACTIONS.has(action)) throw new Error(refuse)
   if (action === "deny") return
-  // Drive takes the accepted role as either a string or a single-element list.
-  // Validate the WHOLE list, not just index 0: `["reader","owner"]` would
-  // otherwise pass on its first element while `executeWorkspaceCommand` forwards
-  // the original argv — the full, unvalidated JSON — to `gws` verbatim, so
-  // nothing downstream re-reads the array. That is exactly the ceiling this
-  // check exists to hold.
-  const rawRole = resource.role
+  if (!isSingleNamedRole(resource.role)) throw new Error(refuse)
+}
+
+/**
+ * Drive takes the accepted role as either a string or a single-element list.
+ * Validate the WHOLE list, not just index 0: `["reader","owner"]` would
+ * otherwise pass on its first element while `executeWorkspaceCommand` forwards
+ * the original argv — the full, unvalidated JSON — to `gws` verbatim, so
+ * nothing downstream re-reads the array. That is exactly the ceiling this
+ * check exists to hold.
+ */
+function isSingleNamedRole(rawRole: unknown): boolean {
   const roles = Array.isArray(rawRole) ? rawRole : [rawRole]
-  if (roles.length !== 1) throw new Error(refuse)
+  if (roles.length !== 1) return false
   const role = typeof roles[0] === "string" ? roles[0].toLowerCase() : null
-  if (!role || !PERMISSION_ROLES_NAMED.has(role)) throw new Error(refuse)
+  return !!role && PERMISSION_ROLES_NAMED.has(role)
 }
 
 function validateGmailModify(argv: readonly string[]): void {

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -72,6 +72,12 @@ const ALLOWED_WRITES = new Set([
   "drive files copy",
   "drive files create",
   "drive permissions create",
+  // Resolving a Drive access request is the same act as a share, reached from
+  // the other direction: the USER asked for access to an agent-owned file and
+  // the agent grants it. It was absent from this list, so the one path a user
+  // had to recover from the sharing outage was refused too
+  // (agent_failures 1986). Held to the same in-district shape rules below.
+  "drive accessproposals resolve",
   // The `+draft` helper is the form psd-workspace/SKILL.md actually documents
   // for composing a draft (it is the worked example in two places), and it is
   // how the model reaches drafting in practice. Only the canonical
@@ -128,6 +134,7 @@ const AGENT_ONLY_WRITES = new Set([
   "drive files copy",
   "drive files create",
   "drive permissions create",
+  "drive accessproposals resolve",
   "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
   "sheets spreadsheets values append",
@@ -452,6 +459,46 @@ function isDocumentedShareShape(
   return false
 }
 
+// Fields on a Drive accessProposals.resolve call. The proposal itself carries
+// the requester and the file, so the only things we choose here are whether to
+// accept and at what role.
+const ACCESS_PROPOSAL_FIELDS = new Set([
+  "fileid",
+  "proposalid",
+  "action",
+  "role",
+  "view",
+  "sendnotification",
+])
+const ACCESS_PROPOSAL_ACTIONS = new Set(["accept", "deny"])
+
+/**
+ * Resolving an access proposal grants the REQUESTER access, so it is held to
+ * the same role ceiling as a named-person share: reader, commenter or writer,
+ * never owner. `deny` needs no role at all.
+ *
+ * Allowlist, fails closed — an unparseable payload or an unrecognized key
+ * refuses the call.
+ */
+function validateAccessProposalResolve(argv: readonly string[]): void {
+  const refuse = "Access proposals resolve to reader, commenter or writer only"
+  const resource = jsonResource(argv) ?? parseObjectArgument(argv, "--params")
+  if (!resource) throw new Error(refuse)
+  const keys = Object.keys(resource)
+  if (keys.length === 0) throw new Error(refuse)
+  if (!keys.every((key) => ACCESS_PROPOSAL_FIELDS.has(key.toLowerCase()))) {
+    throw new Error(refuse)
+  }
+  const action =
+    typeof resource.action === "string" ? resource.action.toLowerCase() : null
+  if (!action || !ACCESS_PROPOSAL_ACTIONS.has(action)) throw new Error(refuse)
+  if (action === "deny") return
+  // Drive takes the accepted role as either a string or a single-element list.
+  const rawRole = Array.isArray(resource.role) ? resource.role[0] : resource.role
+  const role = typeof rawRole === "string" ? rawRole.toLowerCase() : null
+  if (!role || !PERMISSION_ROLES_NAMED.has(role)) throw new Error(refuse)
+}
+
 function validateGmailModify(argv: readonly string[]): void {
   const payload = parseObjectArgument(argv, "--json")
   if (!payload) throw new Error("Gmail modify requires a valid --json object")
@@ -551,6 +598,9 @@ function validateWorkspaceMutation(
   if (operation === "gmail users messages modify") validateGmailModify(argv)
   if (operation === "drive permissions create") {
     validateDriveShareShape(argv, ownerEmail)
+  }
+  if (operation === "drive accessproposals resolve") {
+    validateAccessProposalResolve(argv)
   }
 }
 

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -899,3 +899,64 @@ describe("Drive shares back to the requesting user", () => {
     ).toThrow(/limited to/)
   })
 })
+
+// Resolving an access request is a share reached from the other direction: the
+// user asked, the agent grants. It was missing from the allowlist entirely, so
+// the one recovery path users had during the sharing outage was refused too
+// (agent_failures 1986).
+describe("Drive access proposals", () => {
+  const resolve = (resource: Record<string, unknown>) =>
+    validateWorkspaceCommand({
+      scope: "agent",
+      argv: ["drive", "accessproposals", "resolve", "--json", JSON.stringify(resource)],
+    })
+
+  it.each([["reader"], ["commenter"], ["writer"]])("accepts at role %s", (role) => {
+    expect(() =>
+      resolve({ fileId: "f", proposalId: "p", action: "accept", role })
+    ).not.toThrow()
+  })
+
+  it("accepts a role passed as a single-element list", () => {
+    expect(() =>
+      resolve({ fileId: "f", proposalId: "p", action: "accept", role: ["writer"] })
+    ).not.toThrow()
+  })
+
+  it("allows a denial without a role", () => {
+    expect(() =>
+      resolve({ fileId: "f", proposalId: "p", action: "deny" })
+    ).not.toThrow()
+  })
+
+  it.each([
+    ["owner role", { fileId: "f", proposalId: "p", action: "accept", role: "owner" }],
+    ["organizer role", { fileId: "f", proposalId: "p", action: "accept", role: "organizer" }],
+    ["accept with no role", { fileId: "f", proposalId: "p", action: "accept" }],
+    ["unknown action", { fileId: "f", proposalId: "p", action: "escalate", role: "writer" }],
+    ["unknown key", { fileId: "f", proposalId: "p", action: "accept", role: "writer", extra: 1 }],
+  ])("refuses %s", (_name, resource) => {
+    expect(() => resolve(resource)).toThrow(/reader, commenter or writer/)
+  })
+
+  it("refuses an unparseable payload", () => {
+    expect(() =>
+      validateWorkspaceCommand({
+        scope: "agent",
+        argv: ["drive", "accessproposals", "resolve"],
+      })
+    ).toThrow(/reader, commenter or writer/)
+  })
+
+  it("stays off the user slot", () => {
+    expect(() =>
+      validateWorkspaceCommand({
+        scope: "user",
+        argv: [
+          "drive", "accessproposals", "resolve",
+          "--json", '{"fileId":"f","proposalId":"p","action":"accept","role":"writer"}',
+        ],
+      })
+    ).toThrow(/agent-owned/)
+  })
+})

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -945,6 +945,46 @@ describe("Drive access proposals", () => {
     expect(() => resolve(resource)).toThrow(/reader, commenter or writer/)
   })
 
+  // The documented shape splits IDs into --params and the body into --json;
+  // that exact argv must validate, or the SKILL.md example is broken.
+  it("accepts the documented --params/--json split", () => {
+    expect(() =>
+      validateWorkspaceCommand({
+        scope: "agent",
+        argv: [
+          "drive", "accessproposals", "resolve",
+          "--params", '{"fileId":"f","proposalId":"p"}',
+          "--json", '{"action":"accept","role":"writer"}',
+        ],
+      })
+    ).not.toThrow()
+  })
+
+  it("judges the union of --params and --json", () => {
+    // An unrecognized key is caught wherever it was placed.
+    expect(() =>
+      validateWorkspaceCommand({
+        scope: "agent",
+        argv: [
+          "drive", "accessproposals", "resolve",
+          "--params", '{"fileId":"f","proposalId":"p","sneaky":1}',
+          "--json", '{"action":"accept","role":"writer"}',
+        ],
+      })
+    ).toThrow(/reader, commenter or writer/)
+    // And a bad role in the body is still caught with IDs in params.
+    expect(() =>
+      validateWorkspaceCommand({
+        scope: "agent",
+        argv: [
+          "drive", "accessproposals", "resolve",
+          "--params", '{"fileId":"f","proposalId":"p"}',
+          "--json", '{"action":"accept","role":["reader","owner"]}',
+        ],
+      })
+    ).toThrow(/reader, commenter or writer/)
+  })
+
   it("refuses an unparseable payload", () => {
     expect(() =>
       validateWorkspaceCommand({

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -935,6 +935,12 @@ describe("Drive access proposals", () => {
     ["accept with no role", { fileId: "f", proposalId: "p", action: "accept" }],
     ["unknown action", { fileId: "f", proposalId: "p", action: "escalate", role: "writer" }],
     ["unknown key", { fileId: "f", proposalId: "p", action: "accept", role: "writer", extra: 1 }],
+    // Only role[0] used to be validated, so a list smuggled a second role past
+    // the ceiling — and executeWorkspaceCommand forwards the original argv to
+    // gws verbatim, so nothing downstream re-reads the array.
+    ["multi-element role list", { fileId: "f", proposalId: "p", action: "accept", role: ["reader", "owner"] }],
+    ["empty role list", { fileId: "f", proposalId: "p", action: "accept", role: [] }],
+    ["non-string role element", { fileId: "f", proposalId: "p", action: "accept", role: [{ role: "writer" }] }],
   ])("refuses %s", (_name, resource) => {
     expect(() => resolve(resource)).toThrow(/reader, commenter or writer/)
   })


### PR DESCRIPTION
## Description

The last two fixable items from the 2026-08-03..05 prod failure analysis (#1607). Both were things I previously handed back as "needs you" — neither actually needed you.

**1 · A failed turn now names the actions that already ran** — 11 rows / 7 users

`OpenClawIncompleteToolTurn` told the user only *"some tool actions may have already been executed — please verify before retrying."* A principal reading that can't tell whether a doc was created, a calendar event booked, or nothing at all happened, so the only safe response is to check everything by hand.

An automatic retry stays out, and that part is a real constraint rather than caution: by the time this class is raised the OpenClaw host has already attempted its one tools-disabled finalization, so replaying could repeat effects that landed. But the harness records every completed tool call, so it can name them — and now does, across this and the other failed-partial paths.

The most valuable case is the empty one: **when nothing completed, the message says so and tells the user it's safe to retry**, instead of sending them hunting for side effects that don't exist. Names are deduplicated and capped at five so a turn that looped over forty files doesn't paste forty entries into Chat; an unrecognized tool-call shape falls back to today's conservative wording rather than claiming nothing ran.

**2 · `drive accessproposals resolve` is allowlisted** — agent_failures 1986

While Drive sharing was broken, a user submitted a Drive access request for an agent-owned doc and the agent tried to accept it — the one recovery path available from the other direction. That operation wasn't in the broker allowlist at all, so it was refused too, and the user was left with no route to the file.

Resolving a proposal grants the requester access, so it's held to the same ceiling as a named-person share: **reader, commenter or writer, never owner**. `deny` needs no role. Drive accepts the role as a bare string or a single-element list; both are handled. Agent slot only, allowlisted keys, fails closed on an unparseable payload.

## Not fixable in this repo

**`students_demographics` timeouts** (opeln — 5 attempts, 15–100s, including a bare `SELECT COUNT(*)`). `psd-data` queries execute against an external `psd-data-mcp` server backed by Redshift. That table, its row-level-security predicate, and any sort/dist-key tuning live outside this repository — there is no schema here to change. A bare `COUNT(*)` timing out points squarely at the RLS predicate on that table, which is a warehouse-side fix.

The shared-calendar item (olearyd) is a Google sharing change — the agent account needs write access to the HRMS Staff Calendar. Not code, and confirmed as user-side.

## Verification

- Full unit suite: **571 suites / 5,374 tests passing**
- Complete agent-image Python suite exactly as CI invokes it (all 20 files, `unittest`, Python 3.12): **702 tests, OK**
- **E2E: 319 passed** via the pre-push gate
- `bun run lint` clean at `--max-warnings 0`; `bun run typecheck` clean

New coverage: six cases on the failed-turn message (names completed tools, declares a safe retry when none ran, ignores in-flight calls, dedupes and caps, preserves the partial answer, keeps conservative wording on an unknown shape) and eleven on access proposals (each allowed role, list-form role, denial without a role, plus owner/organizer/no-role/unknown-action/unknown-key/unparseable/user-slot refusals).

## Housekeeping

Closed **#1596**, which #1607 left dangling: #1606 carried the `Closes #1596` keyword but was closed in favour of #1607 rather than merged, so GitHub never fired the auto-close, and #1607's description didn't repeat it. Verified the work is on `dev` (`render_local.js` present, `render_local.py` removed) before closing.

## Checklist

- [x] No `console.*` in production code — agent skills are CLIs outside the Next.js runtime
- [x] Lint passes at `--max-warnings 0`
- [x] Typecheck passes
- [x] All tests pass — unit, agent-image Python, and E2E
- [x] No `any` types; no new type assertions
- [x] No secrets or environment variables added
- [ ] Code reviewed and approved — pending
