### PR TITLE
fix(agent): multi-series charts, four allowlist gaps, and the silent-failure paths behind them

### DIFF
--- a/infra/agent-image/skills/chat-chart/SKILL.md
+++ b/infra/agent-image/skills/chat-chart/SKILL.md
@@ -100,13 +100,15 @@ node /opt/psd-skills/chat-chart/run.js \
 
 **Data shape.**
 - `bar`, `line`, `pie`: `[{ "label": string, "value": number }, ...]`
+- `bar`, `line` (multi-series): `[{ "label": string, "values": { "<series>": number, ... } }, ...]`
 - `scatter`: `[{ "x": number, "y": number }, ...]`
 
-Multi-series and custom colors aren't supported in v1 — keep it to one series for now.
+Multiple series are supported — see "Comparing several series in one chart"
+above. Custom colours are not; the palette is assigned per series.
 
 `--user` is optional. The workspace broker derives the storage path from the calling agent's identity, so the email is provenance only — pass it verbatim from the `[caller: Name <email>]` header of the user turn when you have it.
 
-**Rendering limits.** Up to 50 points per chart; one series; labels are drawn with a built-in 5x7 ASCII font, so non-ASCII characters (accents, em dashes, curly quotes) render as `?` and long category labels are truncated to fit their slot. Prefer short, ASCII labels.
+**Rendering limits.** Up to 50 points per series; labels are drawn with a built-in 5x7 ASCII font, so non-ASCII characters (accents, em dashes, curly quotes) render as `?` and long category labels are truncated to fit their slot. Prefer short, ASCII labels.
 
 The 50-point cap is enforced by the local renderer, so it binds on `auto` and `local` — i.e. every chart unless you explicitly ask for `--engine quickchart`. That path has no point-count check of its own and is bounded only by argv size and the ~16KB practical spec-URL ceiling noted above; a large explicit-quickchart payload fails as a broken URL rather than a clean exit 3. Not a reason to send one — it's a reason not to reach for `--engine quickchart` to escape the cap.
 

--- a/infra/agent-image/skills/chat-chart/SKILL.md
+++ b/infra/agent-image/skills/chat-chart/SKILL.md
@@ -31,6 +31,30 @@ For "chart this data for me" style requests:
 
 Do NOT pick one or the other when the user wants a chart with surrounding context — pair them.
 
+## Comparing several series in one chart
+
+Give each point a `values` object instead of a single `value`, and every named
+series becomes its own dataset — grouped bars for `bar`, one line each for
+`line`, with a legend naming them:
+
+```bash
+node /opt/psd-skills/chat-chart/run.js \
+  --user hagelk@psd401.net --type bar \
+  --title 'DES i-Ready by grade - Spring 2026' \
+  --data-json '[
+    {"label":"Grade 1","values":{"Math":412,"Reading":398}},
+    {"label":"Grade 2","values":{"Math":441,"Reading":430}}
+  ]'
+```
+
+Prefer this over emitting two separate charts when the user asks to compare
+subjects, years, or schools — one chart is what they asked for. Every series
+must supply a value at every label; a gap is refused rather than drawn as zero.
+`pie` takes a single series only (a pie divides one whole), so use `bar` to
+compare.
+
+The flat `{"label":…,"value":…}` shape is unchanged for single-series charts.
+
 ## Engine selection
 
 | Engine     | Speed | Data leaves AWS? | When |
@@ -94,6 +118,21 @@ Prints two things to stdout in order:
 2. A `PSD_AGENT_RICH_V1` envelope wrapping a cardsV2 entry whose section contains an `image` widget pointing at the chart.
 
 **Include the envelope verbatim in your reply** so the Router renders the card. Add a sentence of prose above or below it if the chart needs context — that text becomes the fallback `text` of the message.
+
+**Every delivery surface renders this envelope — Google Chat and the AI Studio
+web chat alike.** The Router owns rendering, not the client, so there is no
+surface where emitting the envelope is wrong. Never strip it, summarise the
+chart in prose instead of showing it, or withhold the image because you think
+the caller's client cannot display a card. Observed 2026-08-06: an agent assumed
+web chat could not render the envelope, sent a title-only card with no image,
+and repeated that across several turns while the user told it the chart was
+missing — the assumption was invented, not read anywhere, and it took a
+screenshot of a working chart to dislodge it.
+
+If a user says the image did not appear, do NOT theorise about their client.
+Resend the envelope exactly as `run.js` emitted it, and log it with
+`psd-failure-report` — a chart the user cannot see is a failure whatever the
+cause.
 
 ## Examples
 

--- a/infra/agent-image/skills/chat-chart/SKILL.md
+++ b/infra/agent-image/skills/chat-chart/SKILL.md
@@ -134,6 +134,15 @@ Resend the envelope exactly as `run.js` emitted it, and log it with
 `psd-failure-report` — a chart the user cannot see is a failure whatever the
 cause.
 
+**What already reports itself.** A non-zero exit files its own `agent_failures`
+row: `ChartInputInvalid` for a bad flag, malformed `--data-json` or a series
+missing a value, `ChartRenderFailed` for a renderer fault. Do not also call
+`psd-failure-report` for those — it would file the same failure twice. The one
+exception is the `--engine quickchart` sensitivity refusal (exit 3), which is
+the gate working as designed and is deliberately not recorded. The case above —
+the command *succeeded* and the user still saw no image — is the one that needs
+reporting by hand, because `run.js` has no way to know.
+
 ## Examples
 
 ### Any district data — the default (on-host) engine

--- a/infra/agent-image/skills/chat-chart/render_local.js
+++ b/infra/agent-image/skills/chat-chart/render_local.js
@@ -90,6 +90,14 @@ const PIE_LEGEND_MIN_ROW = 26;
 // The 1/2/5 step rule yields 5-10 divisions; this is a safety net, not a
 // design parameter.
 const MAX_TICKS = 24;
+// Series-legend geometry. Two rows is what fits between the category labels
+// and the bottom of the canvas at MARGIN.bottom.
+const LEGEND_SWATCH_GAP = 10;
+const LEGEND_ENTRY_SPACING = 34;
+const LEGEND_ROW_GAP = 8;
+const LEGEND_MAX_ROWS = 2;
+// A label short enough to fit but long enough to tell two series apart.
+const LEGEND_READABLE_CHARS = 16;
 
 /**
  * 5x7 bitmap font, ASCII 32..126. Each glyph is five columns; each column
@@ -598,59 +606,153 @@ function categorySlots(area, count) {
   };
 }
 
-function drawBarChart(canvas, labels, values, area) {
-  const { min, max } = valueRange(values, { includeZero: true });
+/**
+ * Series legend for multi-dataset charts. Without it a grouped bar or a
+ * second line is an unlabelled colour, which is why single-series charts do
+ * not get one — the title already says what the data is.
+ *
+ * Drawn inside the plot area's top-right. Long labels are truncated rather
+ * than allowed to run off the canvas (the same failure the pie legend had).
+ */
+/**
+ * Lay the series legend out into rows that fit the plot width.
+ *
+ * Exported for tests. One row is preferred; with many series a single row
+ * forces every label down to the same truncated stub ("Very Long." six times
+ * identifies nothing), so entries wrap and each row's share of the width grows.
+ */
+function seriesLegendPlan(labelCount, areaWidth, scale) {
+  const swatch = FONT_HEIGHT * scale;
+  // Largest label length whose row PROVABLY fits, measured rather than
+  // estimated — an arithmetic approximation overflowed the right edge, the
+  // same way the pie legend used to.
+  const widestThatFits = (perRow) => {
+    for (let chars = 40; chars >= 4; chars--) {
+      const entry = swatch + LEGEND_SWATCH_GAP + textWidth('M'.repeat(chars), scale);
+      const total = entry * perRow + LEGEND_ENTRY_SPACING * (perRow - 1);
+      if (total <= areaWidth) return chars;
+    }
+    return 4;
+  };
+  for (let rows = 1; rows <= LEGEND_MAX_ROWS; rows++) {
+    const perRow = Math.ceil(labelCount / rows);
+    const maxChars = widestThatFits(perRow);
+    // Enough room for a label worth reading, or we are out of rows anyway.
+    // The bar is deliberately generous: at ~8 characters six series all render
+    // as the same stub ("Very Long." six times), which identifies nothing.
+    if (maxChars >= LEGEND_READABLE_CHARS || rows === LEGEND_MAX_ROWS) {
+      return { rows, perRow, maxChars };
+    }
+  }
+  return { rows: 1, perRow: labelCount, maxChars: 4 };
+}
+
+function drawSeriesLegend(canvas, seriesList, area) {
+  const scale = TICK_SCALE;
+  const swatch = FONT_HEIGHT * scale;
+  const { perRow, maxChars } = seriesLegendPlan(seriesList.length, area.width, scale);
+  const entries = seriesList.map((entry, index) => {
+    const text = truncateLabel(toAsciiLabel(entry.label), maxChars);
+    return {
+      text,
+      colour: PALETTE[index % PALETTE.length],
+      width: swatch + LEGEND_SWATCH_GAP + textWidth(text, scale),
+    };
+  });
+  // Below the category labels, not inside the plot: a legend in the top-right
+  // collided with the value labels of the tallest group (observed while
+  // testing the grouped-bar work), and no in-plot corner is safe for every
+  // dataset.
+  const firstRowY = area.bottom + 24 + FONT_HEIGHT * LABEL_SCALE + 26;
+  for (let row = 0; row * perRow < entries.length; row++) {
+    const slice = entries.slice(row * perRow, (row + 1) * perRow);
+    const total =
+      slice.reduce((sum, e) => sum + e.width, 0) +
+      LEGEND_ENTRY_SPACING * (slice.length - 1);
+    let x = area.left + Math.max(0, (area.width - total) / 2);
+    const y = firstRowY + row * (swatch + LEGEND_ROW_GAP);
+    for (const entry of slice) {
+      fillRect(canvas, { x, y, width: swatch, height: swatch }, entry.colour);
+      drawText(canvas, entry.text, { x: x + swatch + LEGEND_SWATCH_GAP, y, scale, align: 'left' }, TEXT);
+      x += entry.width + LEGEND_ENTRY_SPACING;
+    }
+  }
+}
+
+function drawBarChart(canvas, labels, seriesList, area) {
+  const all = seriesList.flatMap(entry => entry.data);
+  const { min, max } = valueRange(all, { includeZero: true });
   const ticks = niceTicks(min, max);
   const toY = drawValueAxis(canvas, area, ticks);
-  const { slot, centres } = categorySlots(area, values.length);
-  const barWidth = slot * 0.62;
+  const categories = Math.max(...seriesList.map(entry => entry.data.length));
+  const { slot, centres } = categorySlots(area, categories);
+  const multi = seriesList.length > 1;
+  // One series keeps the per-category palette it has always had. Multiple
+  // series colour by SERIES instead — the colour is what ties a bar to its
+  // legend entry, so it cannot also encode the category.
+  const groupWidth = slot * 0.62;
+  const barWidth = multi ? groupWidth / seriesList.length : groupWidth;
   const zeroY = toY(0);
-  for (const [index, value] of values.entries()) {
+  for (const [seriesIndex, entry] of seriesList.entries()) {
+  for (const [index, value] of entry.data.entries()) {
     const y = toY(value);
     const top = Math.min(y, zeroY);
     const height = Math.max(Math.abs(y - zeroY), 2);
-    const colour = PALETTE[index % PALETTE.length];
+    const colour = multi
+      ? PALETTE[seriesIndex % PALETTE.length]
+      : PALETTE[index % PALETTE.length];
+    const x = multi
+      ? centres[index] - groupWidth / 2 + barWidth * (seriesIndex + 0.5)
+      : centres[index];
     fillRect(
       canvas,
-      { x: centres[index] - barWidth / 2, y: top, width: barWidth, height },
+      { x: x - barWidth / 2, y: top, width: barWidth, height },
       colour,
     );
     // Value labels are a bonus, not the chart. Drop them rather than let
     // neighbouring bars' numbers overprint each other, and put a negative
     // bar's label under it so the text never sits on top of the bar.
-    if (textWidth(formatNumber(value), TICK_SCALE) <= slot) {
+    if (textWidth(formatNumber(value), TICK_SCALE) <= barWidth) {
       drawText(canvas, formatNumber(value), {
-        x: centres[index],
+        x,
         y: value < 0 ? top + height + 10 : top - FONT_HEIGHT * TICK_SCALE - 10,
         scale: TICK_SCALE,
         align: 'center',
       }, TEXT);
     }
   }
+  }
   drawCategoryLabels(canvas, labels, area, slot, centres);
+  if (multi) drawSeriesLegend(canvas, seriesList, area);
 }
 
-function drawLineChart(canvas, labels, values, area) {
-  const { min, max } = valueRange(values, { includeZero: false });
+function drawLineChart(canvas, labels, seriesList, area) {
+  const all = seriesList.flatMap(entry => entry.data);
+  const { min, max } = valueRange(all, { includeZero: false });
   const ticks = niceTicks(min, max);
   const toY = drawValueAxis(canvas, area, ticks);
-  const { slot, centres } = categorySlots(area, values.length);
-  const colour = PALETTE[0];
-  for (const [index, value] of values.entries()) {
-    if (index > 0) {
-      drawLineSegment(
-        canvas,
-        { x: centres[index - 1], y: toY(values[index - 1]) },
-        { x: centres[index], y: toY(value) },
-        colour,
-        6,
-      );
+  const categories = Math.max(...seriesList.map(entry => entry.data.length));
+  const { slot, centres } = categorySlots(area, categories);
+  for (const [seriesIndex, entry] of seriesList.entries()) {
+    const colour = PALETTE[seriesIndex % PALETTE.length];
+    const values = entry.data;
+    for (const [index, value] of values.entries()) {
+      if (index > 0) {
+        drawLineSegment(
+          canvas,
+          { x: centres[index - 1], y: toY(values[index - 1]) },
+          { x: centres[index], y: toY(value) },
+          colour,
+          6,
+        );
+      }
+    }
+    for (const [index, value] of values.entries()) {
+      fillCircle(canvas, centres[index], toY(value), 8, colour);
     }
   }
-  for (const [index, value] of values.entries()) {
-    fillCircle(canvas, centres[index], toY(value), 8, colour);
-  }
   drawCategoryLabels(canvas, labels, area, slot, centres);
+  if (seriesList.length > 1) drawSeriesLegend(canvas, seriesList, area);
 }
 
 function drawScatterChart(canvas, points, area) {
@@ -775,16 +877,34 @@ function drawPieChart(canvas, labels, values, area) {
   drawPieLegend(canvas, labels, bounds, cx + radius + 60, area);
 }
 
-function readSeries(config) {
+/**
+ * Read EVERY dataset, not just the first.
+ *
+ * Until 2026-08-06 this returned `datasets[0].data` and the rest were silently
+ * discarded, so "chart Reading and Math by grade" drew Math alone with a
+ * plausible-looking axis and no indication a series was missing. Half the data
+ * presented as if it were all of it is worse than a refusal — a principal
+ * reading it has no way to know.
+ */
+function readSeriesList(config) {
   const data = config?.data ?? {};
   const datasets = Array.isArray(data.datasets) ? data.datasets : [];
   if (datasets.length === 0) throw new Error('config.data.datasets is empty');
-  const series = Array.isArray(datasets[0].data) ? datasets[0].data : [];
-  if (series.length === 0) throw new Error('config.data.datasets[0].data is empty');
-  if (series.length > MAX_POINTS) {
-    throw new Error(`too many data points (${series.length} > ${MAX_POINTS})`);
+  const list = datasets.map((dataset, index) => {
+    const values = Array.isArray(dataset?.data) ? dataset.data : [];
+    if (values.length === 0) {
+      throw new Error(`config.data.datasets[${index}].data is empty`);
+    }
+    const label = typeof dataset?.label === 'string' && dataset.label.trim()
+      ? dataset.label.trim()
+      : `Series ${index + 1}`;
+    return { label, data: values };
+  });
+  const longest = Math.max(...list.map(entry => entry.data.length));
+  if (longest > MAX_POINTS) {
+    throw new Error(`too many data points (${longest} > ${MAX_POINTS})`);
   }
-  return series;
+  return list;
 }
 
 function readLabels(data, count) {
@@ -819,17 +939,35 @@ function readPoints(series) {
 }
 
 function drawChart(canvas, config, area) {
-  const series = readSeries(config);
+  const seriesList = readSeriesList(config);
   const type = config?.type;
   if (type === 'scatter') {
-    drawScatterChart(canvas, readPoints(series), area);
+    // Scatter keeps its own x/y reading; multiple point series are drawn in
+    // sequence so each gets its own colour.
+    drawScatterChart(canvas, readPoints(seriesList[0].data), area);
     return;
   }
-  const values = readNumbers(series);
-  const labels = readLabels(config.data, values.length);
-  if (type === 'bar') drawBarChart(canvas, labels, values, area);
-  else if (type === 'line') drawLineChart(canvas, labels, values, area);
-  else if (type === 'pie') drawPieChart(canvas, labels, values, area);
+  if (type === 'pie') {
+    // A pie shows one whole divided into parts, so a second dataset has no
+    // meaning — say that instead of silently drawing only the first.
+    if (seriesList.length > 1) {
+      throw new Error(
+        'a pie chart takes exactly one dataset; use a bar chart to compare ' +
+        `${seriesList.length} series`,
+      );
+    }
+    const values = readNumbers(seriesList[0].data);
+    drawPieChart(canvas, readLabels(config.data, values.length), values, area);
+    return;
+  }
+  const drawn = seriesList.map(entry => ({
+    label: entry.label,
+    data: readNumbers(entry.data),
+  }));
+  const categories = Math.max(...drawn.map(entry => entry.data.length));
+  const labels = readLabels(config.data, categories);
+  if (type === 'bar') drawBarChart(canvas, labels, drawn, area);
+  else if (type === 'line') drawLineChart(canvas, labels, drawn, area);
   else throw new Error(`unsupported chart type: ${JSON.stringify(type)}`);
 }
 
@@ -852,6 +990,7 @@ module.exports = {
   // Exported for unit tests.
   categoryLabelPlan,
   pieLegendPlan,
+  seriesLegendPlan,
   formatNumber,
   niceTicks,
   toAsciiLabel,

--- a/infra/agent-image/skills/chat-chart/render_local.js
+++ b/infra/agent-image/skills/chat-chart/render_local.js
@@ -710,40 +710,40 @@ function drawBarChart(canvas, labels, seriesList, area) {
   const barWidth = multi ? groupWidth / seriesList.length : groupWidth;
   const zeroY = toY(0);
   for (const [seriesIndex, entry] of seriesList.entries()) {
-  for (const [index, value] of entry.data.entries()) {
-    const y = toY(value);
-    const top = Math.min(y, zeroY);
-    const height = Math.max(Math.abs(y - zeroY), 2);
-    const colour = multi
-      ? PALETTE[seriesIndex % PALETTE.length]
-      : PALETTE[index % PALETTE.length];
-    const x = multi
-      ? centres[index] - groupWidth / 2 + barWidth * (seriesIndex + 0.5)
-      : centres[index];
-    fillRect(
-      canvas,
-      { x: x - barWidth / 2, y: top, width: barWidth, height },
-      colour,
-    );
-    // Value labels are a bonus, not the chart. Drop them rather than let
-    // neighbouring bars' numbers overprint each other, and put a negative
-    // bar's label under it so the text never sits on top of the bar.
-    //
-    // What counts as room depends on what the neighbour is. A single series
-    // owns its whole category slot — the next bar is a slot away, so a label
-    // wider than the bar still has nowhere to collide, which is why this has
-    // always been measured against `slot`. Grouped bars sit shoulder to
-    // shoulder inside one slot, so there a label may only claim its own bar.
-    const labelBudget = multi ? barWidth : slot;
-    if (textWidth(formatNumber(value), TICK_SCALE) <= labelBudget) {
-      drawText(canvas, formatNumber(value), {
-        x,
-        y: value < 0 ? top + height + 10 : top - FONT_HEIGHT * TICK_SCALE - 10,
-        scale: TICK_SCALE,
-        align: 'center',
-      }, TEXT);
+    for (const [index, value] of entry.data.entries()) {
+      const y = toY(value);
+      const top = Math.min(y, zeroY);
+      const height = Math.max(Math.abs(y - zeroY), 2);
+      const colour = multi
+        ? PALETTE[seriesIndex % PALETTE.length]
+        : PALETTE[index % PALETTE.length];
+      const x = multi
+        ? centres[index] - groupWidth / 2 + barWidth * (seriesIndex + 0.5)
+        : centres[index];
+      fillRect(
+        canvas,
+        { x: x - barWidth / 2, y: top, width: barWidth, height },
+        colour,
+      );
+      // Value labels are a bonus, not the chart. Drop them rather than let
+      // neighbouring bars' numbers overprint each other, and put a negative
+      // bar's label under it so the text never sits on top of the bar.
+      //
+      // What counts as room depends on what the neighbour is. A single series
+      // owns its whole category slot — the next bar is a slot away, so a label
+      // wider than the bar still has nowhere to collide, which is why this has
+      // always been measured against `slot`. Grouped bars sit shoulder to
+      // shoulder inside one slot, so there a label may only claim its own bar.
+      const labelBudget = multi ? barWidth : slot;
+      if (textWidth(formatNumber(value), TICK_SCALE) <= labelBudget) {
+        drawText(canvas, formatNumber(value), {
+          x,
+          y: value < 0 ? top + height + 10 : top - FONT_HEIGHT * TICK_SCALE - 10,
+          scale: TICK_SCALE,
+          align: 'center',
+        }, TEXT);
+      }
     }
-  }
   }
   drawCategoryLabels(canvas, labels, area, slot, centres);
   if (multi) drawSeriesLegend(canvas, seriesList, area);
@@ -935,6 +935,24 @@ function readSeriesList(config) {
   const longest = Math.max(...list.map(entry => entry.data.length));
   if (longest > MAX_POINTS) {
     throw new Error(`too many data points (${longest} > ${MAX_POINTS})`);
+  }
+  // On a CATEGORY chart every series must span the same categories. Those draw
+  // functions zip each series against one `centres` array sized to the longest,
+  // so a short series lands against the wrong labels — Reading's Grade 3 number
+  // sitting under Grade 4 — with no gap to see that it happened. Same "looks
+  // complete, isn't" failure as drawing datasets[0] alone, which is what this
+  // renderer was just fixed for. run.js refuses a gap before it reaches here;
+  // this guards the other callers of the exported drawChart/renderChartPng.
+  //
+  // Scatter is exempt and must stay so: its series are independent x/y point
+  // sets sharing only the axes, so 12 points against 30 is an ordinary chart,
+  // not a misalignment.
+  const shortest = Math.min(...list.map(entry => entry.data.length));
+  if (config?.type !== 'scatter' && shortest !== longest) {
+    throw new Error(
+      `series lengths differ (${list.map(entry => entry.data.length).join(', ')}) — ` +
+        'every series needs a value at every category',
+    );
   }
   return list;
 }

--- a/infra/agent-image/skills/chat-chart/render_local.js
+++ b/infra/agent-image/skills/chat-chart/render_local.js
@@ -96,6 +96,9 @@ const LEGEND_SWATCH_GAP = 10;
 const LEGEND_ENTRY_SPACING = 34;
 const LEGEND_ROW_GAP = 8;
 const LEGEND_MAX_ROWS = 2;
+// Shortest label worth drawing a legend entry for. Below this an entry is a
+// swatch and noise, and the row no longer fits regardless.
+const LEGEND_MIN_CHARS = 4;
 // A label short enough to fit but long enough to tell two series apart.
 const LEGEND_READABLE_CHARS = 16;
 
@@ -620,6 +623,9 @@ function categorySlots(area, count) {
  * Exported for tests. One row is preferred; with many series a single row
  * forces every label down to the same truncated stub ("Very Long." six times
  * identifies nothing), so entries wrap and each row's share of the width grows.
+ *
+ * `maxChars: 0` means the legend does NOT fit at any label length the rows
+ * allow — the caller must refuse rather than draw. See seriesLegendFits.
  */
 function seriesLegendPlan(labelCount, areaWidth, scale) {
   const swatch = FONT_HEIGHT * scale;
@@ -627,12 +633,17 @@ function seriesLegendPlan(labelCount, areaWidth, scale) {
   // estimated — an arithmetic approximation overflowed the right edge, the
   // same way the pie legend used to.
   const widestThatFits = (perRow) => {
-    for (let chars = 40; chars >= 4; chars--) {
+    for (let chars = 40; chars >= LEGEND_MIN_CHARS; chars--) {
       const entry = swatch + LEGEND_SWATCH_GAP + textWidth('M'.repeat(chars), scale);
       const total = entry * perRow + LEGEND_ENTRY_SPACING * (perRow - 1);
       if (total <= areaWidth) return chars;
     }
-    return 4;
+    // 0, not LEGEND_MIN_CHARS. Returning the minimum as though it fit is what
+    // let an over-full row run past the right edge: at 21 series the plan
+    // claimed 11 four-character entries per row, which measures 1440px in a
+    // 1350px plot, so the last series was drawn off-canvas and could not be
+    // identified at all.
+    return 0;
   };
   for (let rows = 1; rows <= LEGEND_MAX_ROWS; rows++) {
     const perRow = Math.ceil(labelCount / rows);
@@ -644,7 +655,12 @@ function seriesLegendPlan(labelCount, areaWidth, scale) {
       return { rows, perRow, maxChars };
     }
   }
-  return { rows: 1, perRow: labelCount, maxChars: 4 };
+  return { rows: 1, perRow: labelCount, maxChars: 0 };
+}
+
+/** Whether a series legend of this size can be drawn inside the plot width. */
+function seriesLegendFits(labelCount, areaWidth, scale) {
+  return seriesLegendPlan(labelCount, areaWidth, scale).maxChars > 0;
 }
 
 function drawSeriesLegend(canvas, seriesList, area) {
@@ -959,6 +975,18 @@ function drawChart(canvas, config, area) {
     const values = readNumbers(seriesList[0].data);
     drawPieChart(canvas, readLabels(config.data, values.length), values, area);
     return;
+  }
+  // A series the legend cannot name is an unidentifiable colour on the canvas,
+  // which is the same class of problem as drawing only datasets[0]: the chart
+  // looks complete and isn't. Refuse instead, before anything is drawn, and say
+  // how many series would fit.
+  if (seriesList.length > 1 && !seriesLegendFits(seriesList.length, area.width, TICK_SCALE)) {
+    let fits = seriesList.length - 1;
+    while (fits > 1 && !seriesLegendFits(fits, area.width, TICK_SCALE)) fits--;
+    throw new Error(
+      `too many series to label (${seriesList.length}); the legend holds at most ` +
+      `${fits} — chart fewer series, or split them across charts`,
+    );
   }
   const drawn = seriesList.map(entry => ({
     label: entry.label,

--- a/infra/agent-image/skills/chat-chart/render_local.js
+++ b/infra/agent-image/skills/chat-chart/render_local.js
@@ -67,8 +67,10 @@ const TEXT = [33, 33, 33];
 const AXIS = [90, 90, 90];
 const GRID = [219, 219, 219];
 
-// Categorical palette (tab10-derived). Series colour cycles through it for
-// bar/pie; line/scatter use the first entry.
+// Categorical palette (tab10-derived). Colour encodes SERIES on every
+// multi-series chart (grouped bar, line, scatter), so it matches the legend
+// entry. A single-series bar or a pie has no legend, so there colour cycles
+// per category/slice instead.
 const PALETTE = [
   [31, 119, 180],
   [214, 39, 40],
@@ -610,15 +612,13 @@ function categorySlots(area, count) {
 }
 
 /**
- * Series legend for multi-dataset charts. Without it a grouped bar or a
- * second line is an unlabelled colour, which is why single-series charts do
- * not get one — the title already says what the data is.
- *
- * Drawn inside the plot area's top-right. Long labels are truncated rather
- * than allowed to run off the canvas (the same failure the pie legend had).
- */
-/**
  * Lay the series legend out into rows that fit the plot width.
+ *
+ * The legend exists for multi-dataset charts only: without it a grouped bar or
+ * a second line is an unlabelled colour, while on a single-series chart the
+ * title already says what the data is. For where it is drawn and why, see
+ * drawSeriesLegend below — an earlier design put it in the plot's top-right,
+ * which collided with value labels.
  *
  * Exported for tests. One row is preferred; with many series a single row
  * forces every label down to the same truncated stub ("Very Long." six times
@@ -728,7 +728,14 @@ function drawBarChart(canvas, labels, seriesList, area) {
     // Value labels are a bonus, not the chart. Drop them rather than let
     // neighbouring bars' numbers overprint each other, and put a negative
     // bar's label under it so the text never sits on top of the bar.
-    if (textWidth(formatNumber(value), TICK_SCALE) <= barWidth) {
+    //
+    // What counts as room depends on what the neighbour is. A single series
+    // owns its whole category slot — the next bar is a slot away, so a label
+    // wider than the bar still has nowhere to collide, which is why this has
+    // always been measured against `slot`. Grouped bars sit shoulder to
+    // shoulder inside one slot, so there a label may only claim its own bar.
+    const labelBudget = multi ? barWidth : slot;
+    if (textWidth(formatNumber(value), TICK_SCALE) <= labelBudget) {
       drawText(canvas, formatNumber(value), {
         x,
         y: value < 0 ? top + height + 10 : top - FONT_HEIGHT * TICK_SCALE - 10,
@@ -771,9 +778,14 @@ function drawLineChart(canvas, labels, seriesList, area) {
   if (seriesList.length > 1) drawSeriesLegend(canvas, seriesList, area);
 }
 
-function drawScatterChart(canvas, points, area) {
-  const xs = points.map(p => p.x);
-  const ys = points.map(p => p.y);
+function drawScatterChart(canvas, seriesList, area) {
+  // Every series shares one pair of axes, so the ranges are taken across all
+  // of them. Reading only the first series' extent would push later points off
+  // the plot — the same "looks complete, isn't" failure as drawing datasets[0]
+  // alone, just expressed as clipping instead of omission.
+  const all = seriesList.flatMap(entry => entry.data);
+  const xs = all.map(p => p.x);
+  const ys = all.map(p => p.y);
   const yTicks = niceTicks(Math.min(...ys), Math.max(...ys));
   const toY = drawValueAxis(canvas, area, yTicks);
   const xTicks = niceTicks(Math.min(...xs), Math.max(...xs));
@@ -791,9 +803,13 @@ function drawScatterChart(canvas, points, area) {
     }, TEXT);
   }
   fillRect(canvas, { x: area.left, y: area.bottom, width: area.width, height: 2 }, AXIS);
-  for (const point of points) {
-    fillCircle(canvas, toX(point.x), toY(point.y), 9, PALETTE[0]);
+  for (const [seriesIndex, entry] of seriesList.entries()) {
+    const colour = PALETTE[seriesIndex % PALETTE.length];
+    for (const point of entry.data) {
+      fillCircle(canvas, toX(point.x), toY(point.y), 9, colour);
+    }
   }
+  if (seriesList.length > 1) drawSeriesLegend(canvas, seriesList, area);
 }
 
 function wedgeColour(dx, dy, radius, bounds) {
@@ -957,12 +973,6 @@ function readPoints(series) {
 function drawChart(canvas, config, area) {
   const seriesList = readSeriesList(config);
   const type = config?.type;
-  if (type === 'scatter') {
-    // Scatter keeps its own x/y reading; multiple point series are drawn in
-    // sequence so each gets its own colour.
-    drawScatterChart(canvas, readPoints(seriesList[0].data), area);
-    return;
-  }
   if (type === 'pie') {
     // A pie shows one whole divided into parts, so a second dataset has no
     // meaning — say that instead of silently drawing only the first.
@@ -987,6 +997,18 @@ function drawChart(canvas, config, area) {
       `too many series to label (${seriesList.length}); the legend holds at most ` +
       `${fits} — chart fewer series, or split them across charts`,
     );
+  }
+  if (type === 'scatter') {
+    // Scatter reads x/y pairs rather than category values, but is otherwise a
+    // multi-series chart like the rest: one point set per dataset, coloured and
+    // named by the same legend. It used to draw seriesList[0] alone under a
+    // comment claiming otherwise, so a second point set vanished silently.
+    drawScatterChart(
+      canvas,
+      seriesList.map(entry => ({ label: entry.label, data: readPoints(entry.data) })),
+      area,
+    );
+    return;
   }
   const drawn = seriesList.map(entry => ({
     label: entry.label,

--- a/infra/agent-image/skills/chat-chart/run.js
+++ b/infra/agent-image/skills/chat-chart/run.js
@@ -77,6 +77,24 @@ function fail(message, code = 2) {
   process.exit(code);
 }
 
+/**
+ * A failure that has to reach reportChartFailure before the process ends.
+ *
+ * `fail()` calls process.exit synchronously, so anything raised through it is
+ * dead before main()'s rejection handler can record a thing — which is how a
+ * renderer failure, the exact class this skill's new telemetry exists to
+ * capture, emitted neither AGENT_FAILURE_RECORD nor the broker write. Failures
+ * worth recording travel as a rejection instead; `exitCode` preserves the
+ * process contract that the direct `fail()` call had.
+ */
+class ChartFailure extends Error {
+  constructor(message, exitCode = 3) {
+    super(message);
+    this.name = 'ChartFailure';
+    this.exitCode = exitCode;
+  }
+}
+
 function parseArgs(argv) {
   const known = new Set([
     '--user',
@@ -293,7 +311,9 @@ async function renderLocal(config) {
   try {
     bytes = renderChartPng(config);
   } catch (err) {
-    fail(`local renderer failed: ${err && err.message ? err.message : err}`, 3);
+    // Thrown, not `fail()`ed: this is the failure the reporting path below was
+    // added for, and exiting here would skip it.
+    throw new ChartFailure(`local renderer failed: ${err && err.message ? err.message : err}`);
   }
   const published = await publishArtifact(bytes, '.png', 'image/png');
   return published.url;
@@ -433,9 +453,13 @@ if (require.main === module) {
     try { return parseArgs(process.argv); } catch { return {}; }
   })();
   main().catch(async err => {
-    process.stderr.write(`chat-chart: unexpected error: ${err && err.message ? err.message : err}\n`);
+    // A ChartFailure is a diagnosed failure with its own wording and exit code;
+    // anything else genuinely is unexpected. Both get recorded.
+    const expected = err instanceof ChartFailure;
+    const detail = err && err.message ? err.message : err;
+    process.stderr.write(`chat-chart: ${expected ? '' : 'unexpected error: '}${detail}\n`);
     await reportChartFailure(err, argsForReport);
-    process.exit(1);
+    process.exit(expected ? err.exitCode : 1);
   });
 }
 

--- a/infra/agent-image/skills/chat-chart/run.js
+++ b/infra/agent-image/skills/chat-chart/run.js
@@ -72,26 +72,51 @@ const PII_PATTERNS = [
   { name: 'psd-student-id', re: /\b2\d{6}\b/ },
 ];
 
+/**
+ * A caller mistake: a bad flag, a malformed --data-json, a series missing a
+ * value at one label.
+ *
+ * Raised rather than exited. `process.exit()` is synchronous, so a direct exit
+ * here outran main()'s handler and recorded nothing — and an authoring mistake
+ * is the *likelier* way an agent ends a turn with no chart than a renderer bug
+ * is, so leaving this class unreported left the bigger half of "the user asked
+ * for a chart and got nothing" invisible in `agent_failures`. Exit code and
+ * stderr wording are unchanged; only the reporting differs.
+ */
 function fail(message, code = 2) {
-  process.stderr.write(`chat-chart: ${message}\n`);
-  process.exit(code);
+  throw new ChartFailure(message, code, { errorClass: 'ChartInputInvalid' });
+}
+
+/**
+ * A refusal: the policy gate declining to render, not a failure to render.
+ *
+ * Deliberately NOT reported. `--engine quickchart` over PII or `--sensitive`
+ * data is REV-INFRA-002 working exactly as designed, and filing it as a chart
+ * failure would misclassify a correct refusal as a defect — noise in the one
+ * table someone reads to find real breakage. If these ever do want recording
+ * they want their own `error_class`, not this one.
+ */
+function refuse(reason) {
+  throw new ChartFailure(reason, 3, { report: false });
 }
 
 /**
  * A failure that has to reach reportChartFailure before the process ends.
  *
- * `fail()` calls process.exit synchronously, so anything raised through it is
- * dead before main()'s rejection handler can record a thing — which is how a
- * renderer failure, the exact class this skill's new telemetry exists to
- * capture, emitted neither AGENT_FAILURE_RECORD nor the broker write. Failures
- * worth recording travel as a rejection instead; `exitCode` preserves the
- * process contract that the direct `fail()` call had.
+ * Everything that ends a chart travels as a rejection so a single handler owns
+ * the stderr line, the telemetry, and the exit code. `exitCode` preserves the
+ * process contract each call site had; `errorClass` keeps an authoring mistake
+ * (`ChartInputInvalid`) distinguishable from a renderer bug
+ * (`ChartRenderFailed`) in `agent_failures`, since they need different fixes;
+ * `report: false` marks the paths that are working as intended.
  */
 class ChartFailure extends Error {
-  constructor(message, exitCode = 3) {
+  constructor(message, exitCode = 3, { errorClass = 'ChartRenderFailed', report = true } = {}) {
     super(message);
     this.name = 'ChartFailure';
     this.exitCode = exitCode;
+    this.errorClass = errorClass;
+    this.report = report;
   }
 }
 
@@ -384,7 +409,7 @@ async function main() {
     // PII data off-district (REV-INFRA-002), and we do not silently downgrade
     // to the local engine either — the caller named an engine, so tell them
     // why it was not used. Non-zero exit so the agent sees no chart was made.
-    fail(reason, 3);
+    refuse(reason);
   }
   process.stderr.write(`chat-chart: engine=${engine} (${reason})\n`);
 
@@ -410,12 +435,17 @@ async function main() {
  * turns were invisible in agent_failures. The one that prompted this was found
  * only because a human was watching the Chat window.
  *
+ * Covers every way a chart ends without an image: `ChartInputInvalid` for a
+ * caller mistake, `ChartRenderFailed` for a renderer fault or an unexpected
+ * rejection. Policy refusals are the one deliberate exclusion — see refuse().
+ *
  * Best-effort by design: the CloudWatch line is written first so the failure
  * survives even when the broker write does not, and any error here is swallowed
  * so telemetry can never turn a chart failure into a worse one.
  */
 async function reportChartFailure(err, args) {
   const errorMessage = `chat-chart failed: ${err && err.message ? err.message : String(err)}`;
+  const errorClass = err?.errorClass ?? 'ChartRenderFailed';
   const context = {
     tool: 'chat-chart',
     type: args?.['--type'] ?? null,
@@ -428,7 +458,7 @@ async function reportChartFailure(err, args) {
       JSON.stringify({
         source: 'tool',
         severity: 'error',
-        error_class: 'ChartRenderFailed',
+        error_class: errorClass,
         error_message: errorMessage,
         context,
       }) +
@@ -439,7 +469,7 @@ async function reportChartFailure(err, args) {
     await requestAgentBroker('/api/agent/failures', {
       source: 'tool',
       severity: 'error',
-      errorClass: 'ChartRenderFailed',
+      errorClass,
       errorMessage,
       context,
     });
@@ -449,16 +479,21 @@ async function reportChartFailure(err, args) {
 }
 
 if (require.main === module) {
+  // Parsed up front purely to give the failure report its context. A parse
+  // that throws leaves nothing to describe the run with, so the report goes out
+  // with an empty context rather than not at all — main() raises the same
+  // failure a moment later and that is what gets recorded.
   const argsForReport = (() => {
     try { return parseArgs(process.argv); } catch { return {}; }
   })();
   main().catch(async err => {
     // A ChartFailure is a diagnosed failure with its own wording and exit code;
-    // anything else genuinely is unexpected. Both get recorded.
+    // anything else genuinely is unexpected. Everything is recorded except the
+    // paths that opt out by design (refusals).
     const expected = err instanceof ChartFailure;
     const detail = err && err.message ? err.message : err;
     process.stderr.write(`chat-chart: ${expected ? '' : 'unexpected error: '}${detail}\n`);
-    await reportChartFailure(err, argsForReport);
+    if (!expected || err.report) await reportChartFailure(err, argsForReport);
     process.exit(expected ? err.exitCode : 1);
   });
 }

--- a/infra/agent-image/skills/chat-chart/run.js
+++ b/infra/agent-image/skills/chat-chart/run.js
@@ -205,21 +205,75 @@ function buildChartJsConfig(type, data, title) {
   }
 
   // bar / line / pie
-  for (const point of data) {
-    if (typeof point.label !== 'string' || !Number.isFinite(point.value)) {
-      fail(`${type} data points need string \`label\` and finite numeric \`value\` fields`);
+  //
+  // Two accepted shapes. The flat one is unchanged:
+  //     [{"label":"Grade 1","value":412}, …]
+  // The multi-series one carries a value PER SERIES, so "Reading and Math by
+  // grade" is one chart rather than two:
+  //     [{"label":"Grade 1","values":{"Math":412,"Reading":398}}, …]
+  // Before 2026-08-06 only the flat shape existed and the renderer drew only
+  // datasets[0], so a combined chart silently showed half its data.
+  const multi = data.some(point => point && typeof point.values === 'object' && point.values !== null);
+  if (!multi) {
+    for (const point of data) {
+      if (typeof point.label !== 'string' || !Number.isFinite(point.value)) {
+        fail(`${type} data points need string \`label\` and finite numeric \`value\` fields`);
+      }
     }
+    return {
+      type,
+      data: {
+        labels: data.map(p => p.label),
+        datasets: [{ label: seriesLabel, data: data.map(p => p.value) }],
+      },
+      options,
+    };
   }
-  const labels = data.map(p => p.label);
-  const values = data.map(p => p.value);
+
+  if (type === 'pie') {
+    fail('a pie chart shows one series; use --type bar to compare several', 2);
+  }
   return {
     type,
-    data: {
-      labels,
-      datasets: [{ label: seriesLabel, data: values }],
-    },
+    data: { labels: data.map(p => p.label), datasets: buildSeriesDatasets(data) },
     options,
   };
+}
+
+/**
+ * Turn `[{label, values:{Math, Reading}}, …]` into one dataset per series.
+ *
+ * Series order follows the first point that names them, so the legend reads in
+ * the order the caller wrote rather than by object-key chance. Every series
+ * must supply a finite value at every label — a gap is refused rather than
+ * drawn as zero, which would understate a grade with no data as a grade
+ * scoring nothing.
+ */
+function buildSeriesDatasets(data) {
+  const seriesNames = [];
+  for (const point of data) {
+    if (typeof point.label !== 'string') {
+      fail('data points need a string `label` field');
+    }
+    if (!point.values || typeof point.values !== 'object') {
+      fail('every point needs a `values` object when any point uses one');
+    }
+    for (const name of Object.keys(point.values)) {
+      if (!seriesNames.includes(name)) seriesNames.push(name);
+    }
+  }
+  if (seriesNames.length === 0) fail('`values` objects are empty — nothing to chart');
+  for (const point of data) {
+    for (const name of seriesNames) {
+      if (!Number.isFinite(point.values[name])) {
+        fail(`series "${name}" is missing a finite value at "${point.label}"`);
+      }
+    }
+  }
+  return seriesNames.map(name => ({
+    label: name,
+    data: data.map(p => p.values[name]),
+  }));
 }
 
 function renderQuickChart(config) {
@@ -328,9 +382,59 @@ async function main() {
   process.stdout.write(emitEnvelope(imageUrl, args['--title'], args['--text-fallback'], type));
 }
 
+/**
+ * Record a chart that could not be produced.
+ *
+ * A chart is the whole deliverable — when it fails the user gets nothing, but
+ * until 2026-08-06 this skill had no failure-reporting path at all, so those
+ * turns were invisible in agent_failures. The one that prompted this was found
+ * only because a human was watching the Chat window.
+ *
+ * Best-effort by design: the CloudWatch line is written first so the failure
+ * survives even when the broker write does not, and any error here is swallowed
+ * so telemetry can never turn a chart failure into a worse one.
+ */
+async function reportChartFailure(err, args) {
+  const errorMessage = `chat-chart failed: ${err && err.message ? err.message : String(err)}`;
+  const context = {
+    tool: 'chat-chart',
+    type: args?.['--type'] ?? null,
+    engine: args?.['--engine'] ?? 'auto',
+    sensitive: Boolean(args?.['--sensitive']),
+    user_facing: true,
+  };
+  process.stderr.write(
+    'AGENT_FAILURE_RECORD ' +
+      JSON.stringify({
+        source: 'tool',
+        severity: 'error',
+        error_class: 'ChartRenderFailed',
+        error_message: errorMessage,
+        context,
+      }) +
+      '\n',
+  );
+  try {
+    const { requestAgentBroker } = require('../_shared/agent-broker');
+    await requestAgentBroker('/api/agent/failures', {
+      source: 'tool',
+      severity: 'error',
+      errorClass: 'ChartRenderFailed',
+      errorMessage,
+      context,
+    });
+  } catch {
+    // Best-effort: the CloudWatch line above is the durable record.
+  }
+}
+
 if (require.main === module) {
-  main().catch(err => {
+  const argsForReport = (() => {
+    try { return parseArgs(process.argv); } catch { return {}; }
+  })();
+  main().catch(async err => {
     process.stderr.write(`chat-chart: unexpected error: ${err && err.message ? err.message : err}\n`);
+    await reportChartFailure(err, argsForReport);
     process.exit(1);
   });
 }

--- a/infra/agent-image/skills/chat-chart/run.test.js
+++ b/infra/agent-image/skills/chat-chart/run.test.js
@@ -1231,3 +1231,63 @@ test('the legend wraps rather than truncating every label to the same stub', () 
   assert.strictEqual(many.rows, 2);
   assert.ok(many.maxChars >= 16, `wrapped labels still only ${many.maxChars} chars`);
 });
+
+test('an authoring mistake is reported, not just exited on', () => {
+  // The likelier way an agent ends a turn with no chart: asking for Math and
+  // Reading by grade and forgetting one grade's Reading score. Every fail()
+  // call site used to process.exit() straight past the reporter, so this whole
+  // class — bad flags, malformed --data-json, a gap in a series — left nothing
+  // in agent_failures however many times a user said the chart never arrived.
+  const gap = JSON.stringify([
+    { label: 'Grade 3', values: { Math: 412, Reading: 398 } },
+    { label: 'Grade 4', values: { Math: 430 } },
+  ]);
+  const result = runCli(['--type', 'bar', '--data-json', gap]);
+
+  assert.match(result.stderr, /AGENT_FAILURE_RECORD/);
+  const record = JSON.parse(
+    result.stderr.slice(result.stderr.indexOf('AGENT_FAILURE_RECORD ') + 'AGENT_FAILURE_RECORD '.length)
+      .split('\n')[0],
+  );
+  // A distinct class from ChartRenderFailed: a caller mistake and a renderer
+  // bug want different fixes, so they must be told apart in agent_failures.
+  assert.strictEqual(record.error_class, 'ChartInputInvalid');
+  assert.match(record.error_message, /series "Reading" is missing a finite value at "Grade 4"/);
+  assert.strictEqual(record.context.type, 'bar');
+  assert.strictEqual(record.context.user_facing, true);
+  // Exit code and wording are the contract fail() already had.
+  assert.strictEqual(result.status, 2, result.stderr);
+  assert.doesNotMatch(result.stderr, /unexpected error/);
+});
+
+test('an unparseable argv is still reported, with an empty context', () => {
+  // parseArgs runs before there is anything to describe the run with. The
+  // report goes out with a bare context rather than not at all.
+  const result = runCli(['--type', 'bar', '--data-json', '[{"label":"A"']);
+
+  assert.strictEqual(result.status, 2, result.stderr);
+  assert.match(result.stderr, /AGENT_FAILURE_RECORD/);
+  const record = JSON.parse(
+    result.stderr.slice(result.stderr.indexOf('AGENT_FAILURE_RECORD ') + 'AGENT_FAILURE_RECORD '.length)
+      .split('\n')[0],
+  );
+  assert.strictEqual(record.error_class, 'ChartInputInvalid');
+  assert.match(record.error_message, /not valid JSON/);
+});
+
+test('a policy refusal is NOT reported as a chart failure', () => {
+  // REV-INFRA-002 declining to ship PII to quickchart.io is the gate working,
+  // not a defect. Filing it in agent_failures would put correct refusals in the
+  // one table read to find real breakage. If these ever want recording they
+  // want their own error_class, so this exclusion is asserted rather than left
+  // to be re-derived from the absence of a test.
+  const result = runCli([
+    '--engine', 'quickchart',
+    '--type', 'bar',
+    '--data-json', '[{"label":"jsmith@psd401.net","value":1}]',
+  ]);
+
+  assert.strictEqual(result.status, 3, result.stderr);
+  assert.doesNotMatch(result.stderr, /AGENT_FAILURE_RECORD/);
+  assert.doesNotMatch(result.stderr, /unexpected error/);
+});

--- a/infra/agent-image/skills/chat-chart/run.test.js
+++ b/infra/agent-image/skills/chat-chart/run.test.js
@@ -156,21 +156,25 @@ test('genuinely public data still reaches quickchart when asked for by name', ()
   assert.match(result.stdout, /PSD_AGENT_RICH_V1/);
 });
 
-test('Infinity is rejected at the CLI boundary, whatever the engine', () => {
+test('Infinity is rejected at the CLI boundary, whatever the engine', async () => {
   // JSON.parse('1e999') is Infinity, which is typeof 'number' — it used to
   // pass validation and serialise into the QuickChart URL as `null`.
-  const result = runCli(['--type', 'bar', '--data-json', '[{"label":"A","value":1e999}]']);
+  const { result } = await withStubBroker(async () => ({
+    result: await runCliAsync(['--type', 'bar', '--data-json', '[{"label":"A","value":1e999}]']),
+  }));
   assert.notStrictEqual(result.status, 0);
   assert.match(result.stderr, /finite/);
 });
 
-test('a malformed --user is rejected on every engine, as documented', () => {
-  const result = runCli([
-    '--type', 'bar',
-    '--engine', 'quickchart',
-    '--data-json', '[{"label":"A","value":1}]',
-    '--user', 'not an email',
-  ]);
+test('a malformed --user is rejected on every engine, as documented', async () => {
+  const { result } = await withStubBroker(async () => ({
+    result: await runCliAsync([
+      '--type', 'bar',
+      '--engine', 'quickchart',
+      '--data-json', '[{"label":"A","value":1}]',
+      '--user', 'not an email',
+    ]),
+  }));
   assert.notStrictEqual(result.status, 0);
   assert.match(result.stderr, /--user/);
 });
@@ -1004,11 +1008,13 @@ test('the single-series shape is unchanged', () => {
   assert.deepEqual(cfg.data.datasets[0].data, [1]);
 });
 
-test('a series missing a value at one point is rejected, not silently zeroed', () => {
-  const result = runCli([
-    '--type', 'bar',
-    '--data-json', '[{"label":"G1","values":{"Math":1,"Reading":2}},{"label":"G2","values":{"Math":3}}]',
-  ]);
+test('a series missing a value at one point is rejected, not silently zeroed', async () => {
+  const { result } = await withStubBroker(async () => ({
+    result: await runCliAsync([
+      '--type', 'bar',
+      '--data-json', '[{"label":"G1","values":{"Math":1,"Reading":2}},{"label":"G2","values":{"Math":3}}]',
+    ]),
+  }));
   assert.notStrictEqual(result.status, 0);
   assert.match(result.stderr, /Reading/);
 });
@@ -1037,14 +1043,21 @@ test('a legend that cannot fit is refused, not clipped off the canvas', () => {
   assert.ok(renderChartPng(series(20)).length > 0);
 });
 
-test('a renderer failure is reported, not just exited on', () => {
+test('a renderer failure is reported, not just exited on', async () => {
   // renderLocal used to call the synchronous fail(), which process.exit()s
   // before main()'s rejection handler can run — so the one failure class this
   // skill's telemetry was added for emitted no AGENT_FAILURE_RECORD at all.
+  //
+  // Runs under the stub even though only stderr is asserted: this spawn files a
+  // failure report, and the broker port is fixed, so left unserialised it posts
+  // into a concurrently-bound neighbour's brokerCalls and breaks that test by
+  // index instead of this one.
   const oversized = JSON.stringify(
     Array.from({ length: 51 }, (_, i) => ({ label: `L${i}`, value: i })),
   );
-  const result = runCli(['--type', 'bar', '--data-json', oversized]);
+  const { result } = await withStubBroker(async () => ({
+    result: await runCliAsync(['--type', 'bar', '--data-json', oversized]),
+  }));
 
   assert.match(result.stderr, /AGENT_FAILURE_RECORD/);
   const record = JSON.parse(
@@ -1232,7 +1245,18 @@ test('the legend wraps rather than truncating every label to the same stub', () 
   assert.ok(many.maxChars >= 16, `wrapped labels still only ${many.maxChars} chars`);
 });
 
-test('an authoring mistake is reported, not just exited on', () => {
+// Every test below runs its CLI under withStubBroker even where the broker
+// response is irrelevant. The broker port is fixed, so a subprocess that files
+// a failure report posts into whatever stub is currently bound — and bun runs
+// this file's async tests concurrently. Before reporting reached fail(), these
+// argv/validation failures made no broker call at all and were safe to spawn
+// synchronously; now they do, and an unserialised one lands in a neighbouring
+// test's brokerCalls ahead of that test's own traffic, breaking it by index.
+// Same fixed-port hazard as the EADDRINUSE race above, arriving from the other
+// direction: not two stubs racing to bind, but one stub receiving traffic from
+// a test that never meant to talk to it.
+
+test('an authoring mistake is reported, not just exited on', async () => {
   // The likelier way an agent ends a turn with no chart: asking for Math and
   // Reading by grade and forgetting one grade's Reading score. Every fail()
   // call site used to process.exit() straight past the reporter, so this whole
@@ -1242,7 +1266,10 @@ test('an authoring mistake is reported, not just exited on', () => {
     { label: 'Grade 3', values: { Math: 412, Reading: 398 } },
     { label: 'Grade 4', values: { Math: 430 } },
   ]);
-  const result = runCli(['--type', 'bar', '--data-json', gap]);
+  const { result, brokerCalls } = await withStubBroker(async ctx => ({
+    result: await runCliAsync(['--type', 'bar', '--data-json', gap]),
+    brokerCalls: ctx.brokerCalls,
+  }));
 
   assert.match(result.stderr, /AGENT_FAILURE_RECORD/);
   const record = JSON.parse(
@@ -1255,41 +1282,55 @@ test('an authoring mistake is reported, not just exited on', () => {
   assert.match(record.error_message, /series "Reading" is missing a finite value at "Grade 4"/);
   assert.strictEqual(record.context.type, 'bar');
   assert.strictEqual(record.context.user_facing, true);
+  // The POST too, not just the stderr line — the broker call is swallowed by
+  // design, so a wrong route or class would otherwise fail silently. The chart
+  // is refused before any upload, so this is the only traffic expected.
+  assert.strictEqual(brokerCalls.length, 1, `unexpected broker traffic: ${JSON.stringify(brokerCalls)}`);
+  assert.strictEqual(brokerCalls[0].url, '/agent-broker/api/agent/failures');
+  assert.strictEqual(brokerCalls[0].payload.errorClass, 'ChartInputInvalid');
   // Exit code and wording are the contract fail() already had.
   assert.strictEqual(result.status, 2, result.stderr);
   assert.doesNotMatch(result.stderr, /unexpected error/);
 });
 
-test('an unparseable argv is still reported, with an empty context', () => {
+test('an unparseable argv is still reported, with an empty context', async () => {
   // parseArgs runs before there is anything to describe the run with. The
   // report goes out with a bare context rather than not at all.
-  const result = runCli(['--type', 'bar', '--data-json', '[{"label":"A"']);
+  const { result, brokerCalls } = await withStubBroker(async ctx => ({
+    result: await runCliAsync(['--type', 'bar', '--data-json', '[{"label":"A"']),
+    brokerCalls: ctx.brokerCalls,
+  }));
 
   assert.strictEqual(result.status, 2, result.stderr);
-  assert.match(result.stderr, /AGENT_FAILURE_RECORD/);
-  const record = JSON.parse(
-    result.stderr.slice(result.stderr.indexOf('AGENT_FAILURE_RECORD ') + 'AGENT_FAILURE_RECORD '.length)
-      .split('\n')[0],
-  );
-  assert.strictEqual(record.error_class, 'ChartInputInvalid');
-  assert.match(record.error_message, /not valid JSON/);
+  assert.strictEqual(brokerCalls.length, 1, `unexpected broker traffic: ${JSON.stringify(brokerCalls)}`);
+  assert.strictEqual(brokerCalls[0].payload.errorClass, 'ChartInputInvalid');
+  assert.match(brokerCalls[0].payload.errorMessage, /not valid JSON/);
+  // --type parsed fine, so context still carries it; a flag-level parse failure
+  // is the case that reports with nothing.
+  assert.strictEqual(brokerCalls[0].payload.context.type, 'bar');
 });
 
-test('a policy refusal is NOT reported as a chart failure', () => {
+test('a policy refusal is NOT reported as a chart failure', async () => {
   // REV-INFRA-002 declining to ship PII to quickchart.io is the gate working,
   // not a defect. Filing it in agent_failures would put correct refusals in the
   // one table read to find real breakage. If these ever want recording they
   // want their own error_class, so this exclusion is asserted rather than left
   // to be re-derived from the absence of a test.
-  const result = runCli([
-    '--engine', 'quickchart',
-    '--type', 'bar',
-    '--data-json', '[{"label":"jsmith@psd401.net","value":1}]',
-  ]);
+  const { result, brokerCalls } = await withStubBroker(async ctx => ({
+    result: await runCliAsync([
+      '--engine', 'quickchart',
+      '--type', 'bar',
+      '--data-json', '[{"label":"jsmith@psd401.net","value":1}]',
+    ]),
+    brokerCalls: ctx.brokerCalls,
+  }));
 
   assert.strictEqual(result.status, 3, result.stderr);
   assert.doesNotMatch(result.stderr, /AGENT_FAILURE_RECORD/);
   assert.doesNotMatch(result.stderr, /unexpected error/);
+  // Nothing filed anywhere — a stronger claim than the stderr line's absence,
+  // since it covers the broker path the stderr assertion cannot see.
+  assert.strictEqual(brokerCalls.length, 0, `a refusal filed: ${JSON.stringify(brokerCalls)}`);
 });
 
 test('category series of unequal length are refused, not misaligned', () => {

--- a/infra/agent-image/skills/chat-chart/run.test.js
+++ b/infra/agent-image/skills/chat-chart/run.test.js
@@ -1013,6 +1013,30 @@ test('a series missing a value at one point is rejected, not silently zeroed', (
   assert.match(result.stderr, /Reading/);
 });
 
+test('a legend that cannot fit is refused, not clipped off the canvas', () => {
+  // widestThatFits used to bottom out at 4 characters and report that as a
+  // valid plan even when it did not fit: 21 series became 11 entries per row,
+  // measuring 1440px inside a 1350px plot, so the last series was drawn past
+  // the right edge and could not be identified.
+  const series = (n) => ({
+    type: 'bar',
+    data: {
+      labels: ['A', 'B'],
+      datasets: Array.from({ length: n }, (_, i) => ({ label: `Srs${i}`, data: [i + 1, i + 2] })),
+    },
+    options: {},
+  });
+
+  assert.strictEqual(seriesLegendPlan(21, 1350, 3).maxChars, 0, 'an unfittable plan must not claim a width');
+  assert.ok(seriesLegendPlan(20, 1350, 3).maxChars > 0);
+
+  assert.throws(() => renderChartPng(series(21)), /too many series to label \(21\)/);
+  // The refusal names a number the caller can act on rather than just refusing.
+  assert.throws(() => renderChartPng(series(21)), /at most 20/);
+  // And the boundary still renders — the guard must not cost a legal chart.
+  assert.ok(renderChartPng(series(20)).length > 0);
+});
+
 test('a renderer failure is reported, not just exited on', () => {
   // renderLocal used to call the synchronous fail(), which process.exit()s
   // before main()'s rejection handler can run — so the one failure class this

--- a/infra/agent-image/skills/chat-chart/run.test.js
+++ b/infra/agent-image/skills/chat-chart/run.test.js
@@ -26,6 +26,7 @@ const {
   pieLegendPlan,
   formatNumber,
   niceTicks,
+  seriesLegendPlan,
   toAsciiLabel,
   truncateLabel,
   OUT_WIDTH,
@@ -203,11 +204,36 @@ const RICH_OPEN = '<<<PSD_AGENT_RICH_V1>>>';
 const RICH_CLOSE = '<<<END_PSD_AGENT_RICH_V1>>>';
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
 
+// The broker port is fixed in agent-broker.js, so only ONE stub can be bound
+// at a time. `node --test` runs this file's tests sequentially and never
+// noticed; `bun test` runs async tests concurrently, so two of them raced to
+// listen and the loser died with EADDRINUSE. That surfaced the moment the file
+// grew more broker-using tests — it was latent, not new. Serialise on a promise
+// chain so every stub gets the port to itself regardless of runner.
+let brokerLock = Promise.resolve();
+
 /** Stub of the agent broker's workspace-storage publish/upload/complete contract. */
-async function withStubBroker(run) {
+function withStubBroker(run, options = {}) {
+  const result = brokerLock.then(() => withStubBrokerExclusive(run, options));
+  // Keep the chain alive even when a test fails, or one rejection wedges the
+  // rest of the file behind it.
+  brokerLock = result.then(() => undefined, () => undefined);
+  return result;
+}
+
+async function withStubBrokerExclusive(run, { failPublish = false } = {}) {
   const uploads = [];
   const brokerCalls = [];
   const server = http.createServer((req, res) => {
+    if (failPublish) {
+      // Simulate a broker that is up but refuses. Asserting on the ABSENCE of
+      // a listener instead was racy: bun runs this file's async tests
+      // concurrently, so a neighbouring test's stub was often already bound to
+      // the fixed port and the publish succeeded.
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'broker unavailable' }));
+      return;
+    }
     const chunks = [];
     req.on('data', chunk => chunks.push(chunk));
     req.on('end', () => {
@@ -272,6 +298,21 @@ function parseEnvelope(stdout) {
   assert.ok(start !== -1 && end > start, `no rich envelope in stdout:\n${stdout}`);
   return JSON.parse(stdout.slice(start + RICH_OPEN.length, end).trim());
 }
+
+test('a broker failure on the local path exits non-zero rather than printing a card', async () => {
+  // The broker is UP and refusing, rather than absent. Testing absence meant
+  // testing that no other test happened to be holding the fixed port, which
+  // bun's concurrent scheduling made a coin flip.
+  const result = await withStubBroker(
+    async () => runCliAsync([
+      '--type', 'bar',
+      '--data-json', '[{"label":"A","value":1}]',
+    ]),
+    { failPublish: true },
+  );
+  assert.notStrictEqual(result.status, 0);
+  assert.doesNotMatch(result.stdout, /PSD_AGENT_RICH_V1/);
+});
 
 test('the default engine renders, uploads and emits a card without naming an engine', async () => {
   const { result, uploads, brokerCalls } = await withStubBroker(async ctx => ({
@@ -338,16 +379,6 @@ test('issue #1596: --sensitive student data charts instead of exiting 3', async 
   assert.doesNotMatch(result.stderr, /quickchart/);
   assert.strictEqual(uploads.length, 1, 'the chart was never uploaded');
   assert.deepStrictEqual(uploads[0].bytes.subarray(0, 8), PNG_SIGNATURE);
-});
-
-test('a broker failure on the local path exits non-zero rather than printing a card', async () => {
-  // No stub broker listening: publishArtifact's fetch is refused.
-  const result = await runCliAsync([
-    '--type', 'bar',
-    '--data-json', '[{"label":"A","value":1}]',
-  ]);
-  assert.notStrictEqual(result.status, 0);
-  assert.doesNotMatch(result.stdout, /PSD_AGENT_RICH_V1/);
 });
 
 // ---------------------------------------------------------------------------
@@ -946,4 +977,115 @@ test('a flat series still produces a usable axis', () => {
   const ticks = niceTicks(5, 5);
   assert.ok(ticks.length >= 2);
   assert.ok(ticks.at(-1) > ticks[0]);
+});
+
+// ---------------------------------------------------------------------------
+// Multi-series (2026-08-06)
+//
+// The renderer read only datasets[0], so "chart Reading and Math by grade"
+// drew Math alone with a plausible axis and no sign a series was missing.
+// Half the data presented as all of it is worse than a refusal.
+// ---------------------------------------------------------------------------
+
+test('the CLI builds one dataset per named series, in the order given', () => {
+  const cfg = buildChartJsConfig('bar', [
+    { label: 'Grade 1', values: { Math: 412, Reading: 398 } },
+    { label: 'Grade 2', values: { Math: 441, Reading: 430 } },
+  ], 'i-Ready');
+  assert.deepEqual(cfg.data.datasets.map(d => d.label), ['Math', 'Reading']);
+  assert.deepEqual(cfg.data.datasets[0].data, [412, 441]);
+  assert.deepEqual(cfg.data.datasets[1].data, [398, 430]);
+  assert.deepEqual(cfg.data.labels, ['Grade 1', 'Grade 2']);
+});
+
+test('the single-series shape is unchanged', () => {
+  const cfg = buildChartJsConfig('bar', [{ label: 'A', value: 1 }], 't');
+  assert.strictEqual(cfg.data.datasets.length, 1);
+  assert.deepEqual(cfg.data.datasets[0].data, [1]);
+});
+
+test('a series missing a value at one point is rejected, not silently zeroed', () => {
+  const result = runCli([
+    '--type', 'bar',
+    '--data-json', '[{"label":"G1","values":{"Math":1,"Reading":2}},{"label":"G2","values":{"Math":3}}]',
+  ]);
+  assert.notStrictEqual(result.status, 0);
+  assert.match(result.stderr, /Reading/);
+});
+
+test('every dataset is drawn, not just the first', () => {
+  // Same categories, wildly different values: if only datasets[0] were drawn
+  // the axis could not span the second series' range.
+  const png = renderChartPng({
+    type: 'bar',
+    data: {
+      labels: ['A', 'B'],
+      datasets: [{ label: 'Low', data: [1, 2] }, { label: 'High', data: [900, 950] }],
+    },
+    options: {},
+  });
+  const pixels = decodePixels(png);
+  // The second series' palette colour must actually appear on the canvas.
+  assert.ok(extent(pixels, PALETTE_RED).count > 200, 'second series was not drawn');
+  assert.ok(countNonWhite(pixels) > 2000);
+});
+
+test('a multi-series line draws one line per dataset', () => {
+  const png = renderChartPng({
+    type: 'line',
+    data: {
+      labels: ['x', 'y', 'z'],
+      datasets: [{ label: 'One', data: [1, 2, 3] }, { label: 'Two', data: [3, 2, 1] }],
+    },
+    options: {},
+  });
+  const pixels = decodePixels(png);
+  assert.ok(extent(pixels, PALETTE_BLUE).count > 100, 'first line missing');
+  assert.ok(extent(pixels, PALETTE_RED).count > 100, 'second line missing');
+});
+
+test('a pie refuses a second dataset rather than drawing only the first', () => {
+  assert.throws(
+    () => renderChartPng({
+      type: 'pie',
+      data: { labels: ['a', 'b'], datasets: [{ data: [1, 2] }, { data: [3, 4] }] },
+      options: {},
+    }),
+    /exactly one dataset/,
+  );
+});
+
+test('the legend never runs off the canvas', () => {
+  // A legend that overflows takes those series' identities with it — the same
+  // failure the pie legend had. Asserted on PIXELS rather than by recomputing
+  // the layout arithmetic, so the test cannot drift from the renderer.
+  const EDGE = 6;
+  for (const count of [2, 3, 6, 10]) {
+    const png = renderChartPng({
+      type: 'bar',
+      data: {
+        labels: ['A', 'B'],
+        datasets: Array.from({ length: count }, (_, i) => ({
+          label: `Very Long Series Name Number ${i + 1}`,
+          data: [10 + i, 20 + i],
+        })),
+      },
+      options: {},
+    });
+    const pixels = decodePixels(png);
+    const left = { x0: 0, y0: 0, x1: EDGE, y1: OUT_HEIGHT };
+    const right = { x0: OUT_WIDTH - EDGE, y0: 0, x1: OUT_WIDTH, y1: OUT_HEIGHT };
+    assert.strictEqual(countNonWhite(pixels, left), 0, `${count} series: ran off the left`);
+    assert.strictEqual(countNonWhite(pixels, right), 0, `${count} series: ran off the right`);
+  }
+});
+
+test('the legend wraps rather than truncating every label to the same stub', () => {
+  // Six series on one row all render as "Very Long." — identical, identifying
+  // nothing. Wrapping buys each label real width.
+  const one = seriesLegendPlan(2, 1350, 3);
+  const many = seriesLegendPlan(6, 1350, 3);
+  assert.strictEqual(one.rows, 1);
+  assert.strictEqual(many.rows, 2);
+  assert.ok(many.maxChars >= 16, `wrapped labels still only ${many.maxChars} chars`);
 });

--- a/infra/agent-image/skills/chat-chart/run.test.js
+++ b/infra/agent-image/skills/chat-chart/run.test.js
@@ -1061,6 +1061,36 @@ test('a renderer failure is reported, not just exited on', () => {
   assert.doesNotMatch(result.stderr, /unexpected error/);
 });
 
+test('a renderer failure reaches the broker, not just stderr', async () => {
+  // reportChartFailure swallows every error from the broker call by design, so
+  // a wrong route or payload shape would fail silently and the stderr-only
+  // assertions above would still pass. That is the exact invisibility this
+  // reporting path exists to end, so the POST itself is asserted.
+  const oversized = JSON.stringify(
+    Array.from({ length: 51 }, (_, i) => ({ label: `L${i}`, value: i })),
+  );
+  const { result, brokerCalls } = await withStubBroker(async ctx => ({
+    result: await runCliAsync(['--type', 'bar', '--data-json', oversized]),
+    brokerCalls: ctx.brokerCalls,
+  }));
+
+  assert.strictEqual(result.status, 3, result.stderr);
+  // The render fails before publishArtifact, so the failure report is the only
+  // call the broker should see.
+  assert.strictEqual(brokerCalls.length, 1, `unexpected broker traffic: ${JSON.stringify(brokerCalls)}`);
+  const [failure] = brokerCalls;
+  assert.strictEqual(failure.url, '/agent-broker/api/agent/failures');
+  // camelCase on the wire, snake_case in the CloudWatch line — the split is the
+  // existing convention (psd-failure-report/report.js), and unverified until now.
+  assert.strictEqual(failure.payload.source, 'tool');
+  assert.strictEqual(failure.payload.severity, 'error');
+  assert.strictEqual(failure.payload.errorClass, 'ChartRenderFailed');
+  assert.match(failure.payload.errorMessage, /too many data points/);
+  assert.strictEqual(failure.payload.context.tool, 'chat-chart');
+  assert.strictEqual(failure.payload.context.type, 'bar');
+  assert.strictEqual(failure.payload.context.user_facing, true);
+});
+
 test('every dataset is drawn, not just the first', () => {
   // Same categories, wildly different values: if only datasets[0] were drawn
   // the axis could not span the second series' range.
@@ -1090,6 +1120,63 @@ test('a multi-series line draws one line per dataset', () => {
   const pixels = decodePixels(png);
   assert.ok(extent(pixels, PALETTE_BLUE).count > 100, 'first line missing');
   assert.ok(extent(pixels, PALETTE_RED).count > 100, 'second line missing');
+});
+
+test('a multi-series scatter draws every point set, not just the first', () => {
+  // drawScatterChart took a flat point array and painted PALETTE[0], while
+  // drawChart handed it seriesList[0] only — so a second point set vanished
+  // with no error, under a comment claiming each series got its own colour.
+  const png = renderChartPng({
+    type: 'scatter',
+    data: {
+      datasets: [
+        { label: 'Fall', data: [{ x: 1, y: 1 }, { x: 2, y: 2 }] },
+        { label: 'Spring', data: [{ x: 3, y: 30 }, { x: 4, y: 40 }] },
+      ],
+    },
+    options: {},
+  });
+  const pixels = decodePixels(png);
+  const first = extent(pixels, PALETTE_BLUE);
+  const second = extent(pixels, PALETTE_RED);
+  assert.ok(first.count > 80, `first series only ${first.count} px`);
+  assert.ok(second.count > 80, `second series missing (${second.count} px)`);
+  // Both axes span both series. Drawing series 0 alone and scaling to it would
+  // put Spring's y=30..40 far off the top of a 1..2 axis.
+  assert.ok(second.minY < first.minY, 'the second series is not plotted above the first');
+  assert.ok(second.minX > first.maxX, 'the second series is not plotted to the right');
+});
+
+test('a scatter refuses a legend it cannot fit, like bar and line', () => {
+  // The refusal used to sit after scatter's early return, so scatter alone
+  // could draw unnameable series past the canvas edge.
+  const datasets = Array.from({ length: 21 }, (_, i) => ({
+    label: `S${i + 1}`,
+    data: [{ x: i, y: i }],
+  }));
+  assert.throws(
+    () => renderChartPng({ type: 'scatter', data: { datasets }, options: {} }),
+    /too many series to label \(21\)/,
+  );
+  assert.ok(renderChartPng({ type: 'scatter', data: { datasets: datasets.slice(0, 20) }, options: {} }).length > 0);
+});
+
+test('a single series keeps the full-slot value-label budget it always had', () => {
+  // Grouped bars must measure a label against their own bar, but applying that
+  // to the single-series path silently dropped every label between 62% and
+  // 100% of the slot — a behaviour change the PR did not intend. 16 four-digit
+  // bars sit squarely in that band: the label measures 69px against a 52px bar
+  // in an 84px slot, so it is drawn under the historical rule and dropped under
+  // the grouped one.
+  const pixels = render(
+    'bar',
+    Array.from({ length: 16 }, (_, i) => ({ label: `W${i + 1}`, value: 1000 + i })),
+    'Wide',
+  );
+  assert.ok(
+    textInk(pixels, PLOT_BAND) > 30,
+    'single-series value labels that fit their slot must still be drawn',
+  );
 });
 
 test('a pie refuses a second dataset rather than drawing only the first', () => {
@@ -1123,8 +1210,15 @@ test('the legend never runs off the canvas', () => {
     const pixels = decodePixels(png);
     const left = { x0: 0, y0: 0, x1: EDGE, y1: OUT_HEIGHT };
     const right = { x0: OUT_WIDTH - EDGE, y0: 0, x1: OUT_WIDTH, y1: OUT_HEIGHT };
+    // The vertical direction is the one the horizontal fix did not cover. The
+    // legend wraps to LEGEND_MAX_ROWS *below* the axis, and "two rows is what
+    // fits at MARGIN.bottom" is an arithmetic claim about the same layout that
+    // already overflowed once sideways. 6 and 10 series wrap; 2 and 3 do not,
+    // so the loop covers both row counts.
+    const bottom = { x0: 0, y0: OUT_HEIGHT - EDGE, x1: OUT_WIDTH, y1: OUT_HEIGHT };
     assert.strictEqual(countNonWhite(pixels, left), 0, `${count} series: ran off the left`);
     assert.strictEqual(countNonWhite(pixels, right), 0, `${count} series: ran off the right`);
+    assert.strictEqual(countNonWhite(pixels, bottom), 0, `${count} series: ran off the bottom`);
   }
 });
 

--- a/infra/agent-image/skills/chat-chart/run.test.js
+++ b/infra/agent-image/skills/chat-chart/run.test.js
@@ -1013,6 +1013,30 @@ test('a series missing a value at one point is rejected, not silently zeroed', (
   assert.match(result.stderr, /Reading/);
 });
 
+test('a renderer failure is reported, not just exited on', () => {
+  // renderLocal used to call the synchronous fail(), which process.exit()s
+  // before main()'s rejection handler can run — so the one failure class this
+  // skill's telemetry was added for emitted no AGENT_FAILURE_RECORD at all.
+  const oversized = JSON.stringify(
+    Array.from({ length: 51 }, (_, i) => ({ label: `L${i}`, value: i })),
+  );
+  const result = runCli(['--type', 'bar', '--data-json', oversized]);
+
+  assert.match(result.stderr, /AGENT_FAILURE_RECORD/);
+  const record = JSON.parse(
+    result.stderr.slice(result.stderr.indexOf('AGENT_FAILURE_RECORD ') + 'AGENT_FAILURE_RECORD '.length)
+      .split('\n')[0],
+  );
+  assert.strictEqual(record.error_class, 'ChartRenderFailed');
+  assert.strictEqual(record.context.user_facing, true);
+  assert.match(record.error_message, /too many data points/);
+  // Diagnosed failure: the original wording and exit code both survive the
+  // move off fail(), so it is not relabelled as an unexpected error.
+  assert.strictEqual(result.status, 3, result.stderr);
+  assert.match(result.stderr, /chat-chart: local renderer failed:/);
+  assert.doesNotMatch(result.stderr, /unexpected error/);
+});
+
 test('every dataset is drawn, not just the first', () => {
   // Same categories, wildly different values: if only datasets[0] were drawn
   // the axis could not span the second series' range.

--- a/infra/agent-image/skills/chat-chart/run.test.js
+++ b/infra/agent-image/skills/chat-chart/run.test.js
@@ -1291,3 +1291,52 @@ test('a policy refusal is NOT reported as a chart failure', () => {
   assert.doesNotMatch(result.stderr, /AGENT_FAILURE_RECORD/);
   assert.doesNotMatch(result.stderr, /unexpected error/);
 });
+
+test('category series of unequal length are refused, not misaligned', () => {
+  // The draw functions zip every series against one `centres` array sized to
+  // the longest, so a short series silently lands under the wrong labels.
+  // run.js refuses a gap upstream; this guards the exported renderer, which is
+  // called directly here and is the reusable entry point.
+  assert.throws(
+    () =>
+      renderChartPng({
+        type: 'bar',
+        data: {
+          labels: ['A', 'B', 'C'],
+          datasets: [
+            { label: 'Math', data: [1, 2, 3] },
+            { label: 'Reading', data: [4, 5] },
+          ],
+        },
+      }),
+    /series lengths differ \(3, 2\)/,
+  );
+  // Equal lengths still render — the guard must not cost a legal chart.
+  assert.ok(
+    renderChartPng({
+      type: 'bar',
+      data: {
+        labels: ['A', 'B'],
+        datasets: [
+          { label: 'Math', data: [1, 2] },
+          { label: 'Reading', data: [3, 4] },
+        ],
+      },
+    }).length > 0,
+  );
+});
+
+test('scatter series of unequal length are legal and stay legal', () => {
+  // Scatter series share only the axes, so 3 points against 2 is an ordinary
+  // chart. The category guard above must not reach it.
+  const png = renderChartPng({
+    type: 'scatter',
+    data: {
+      datasets: [
+        { label: 'Fall', data: [{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }] },
+        { label: 'Spring', data: [{ x: 1, y: 4 }, { x: 2, y: 5 }] },
+      ],
+    },
+  });
+  assert.ok(png.length > 0);
+});

--- a/infra/agent-image/skills/psd-failure-report/SKILL.md
+++ b/infra/agent-image/skills/psd-failure-report/SKILL.md
@@ -20,6 +20,22 @@ Call `report` when ANY of the following is true:
 - The user's instruction was ambiguous and you had to guess (`reason: ambiguous_request`).
 - You started a task and did not finish it (`reason: task_incomplete`).
 - Anything else that means the user did not get what they asked for (`reason: other`).
+- **The user tells you something you produced did not work** — a chart with no
+  image, a document they cannot open, a link that 404s, an empty or truncated
+  reply, a file that never arrived (`reason: tool_error`, or `other` if no tool
+  is implicated). Report it even when every tool you called returned success.
+
+That last one is not optional, and it is the one most easily missed. Every
+trigger above it describes a failure *you* observed; this one describes a
+failure only the USER can observe. When a tool exits 0 and emits something
+malformed — a card whose image never loads, a URL that resolves to nothing —
+you have no way to detect it, so from your side the turn looks clean and no
+report gets written. The user telling you is the ONLY signal that exists.
+
+**Their report is the evidence. Your exit codes are not.** Do not argue that the
+tool succeeded, do not ask them to refresh first, and do not wait to reproduce
+it. Log it, then help them. If they mention it again, that is a second
+occurrence — log it again rather than assuming the first report covered it.
 
 If in doubt: **call it**. False positives are cheap; silent failures are expensive.
 

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -246,6 +246,33 @@ gws drive.permissions.create --scope agent --user hagelk@psd401.net \
   --json '{"fileId":"<id>","type":"domain","role":"reader","domain":"psd401.net"}'
 ```
 
+**Google Forms.** Create and populate a Form on the agent slot, then hand it
+over — transfer ownership to the caller, or share it, exactly as with a Doc:
+
+```bash
+gws forms.forms.create --scope agent --user hagelk@psd401.net \
+  --json '{"info":{"title":"TPEP Self-Assessment"}}'
+gws forms.forms.batchUpdate --scope agent --user hagelk@psd401.net \
+  --params '{"formId":"<id>"}' --json '{"requests":[…]}'
+```
+
+**Commenting on someone else's file.** Phase 1 blocks editing a doc the agent
+does not own, but a COMMENT is additive and attributed, so it is allowed on the
+agent slot — use it instead of asking the user to paste content:
+
+```bash
+gws drive.comments.create --scope agent --user hagelk@psd401.net \
+  --params '{"fileId":"<id>"}' --json '{"content":"Suggested reordering: …"}'
+```
+
+**Gmail labels.** Creating a label in the user's own mailbox is organizing, not
+authoring, so it stays on the user slot (`gmail.modify` covers it):
+
+```bash
+gws gmail.users.labels.create --scope user --user hagelk@psd401.net \
+  --json '{"name":"Digested"}'
+```
+
 **Granting a request someone already made.** When a user hits "request access" on an
 agent-owned file, Drive records an access proposal. List them with
 `drive accessproposals list` and grant one with `drive accessproposals resolve`

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -337,6 +337,14 @@ const USER_SCOPE_FORBIDDEN = [
     reason: 'creating a Google Sheet owned by the user (create as the agent and share explicitly instead)' },
   { pattern: /\bslides[\s.]+presentations[\s.]+create\b/i,
     reason: 'creating a Google Slides deck owned by the user (create as the agent and share explicitly instead)' },
+  // A Form is authored content like the three above, and its questions are
+  // written by a SEPARATE call (`forms.forms.batchUpdate`) rather than in the
+  // create body — so unlike Docs/Sheets/Slides the mutation needs its own entry
+  // here, or an agent-created Form could still be populated as the user.
+  { pattern: /\bforms[\s.]+forms[\s.]+create\b/i,
+    reason: 'creating a Google Form owned by the user (create as the agent and hand it over instead)' },
+  { pattern: /\bforms[\s.]+forms[\s.]+batchUpdate\b/i,
+    reason: 'writing questions into a Form as the user (build the Form as the agent and hand it over instead)' },
 ];
 
 // Structural mutations of existing content. These were previously refused here

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -183,6 +183,25 @@ describe('user-scope file creation is impersonation — hard blocked (2026-07-07
     }
   });
 
+  test('Form authoring is blocked on the user slot but allowed on the agent slot', () => {
+    // A Form's questions are written by a separate batchUpdate rather than in
+    // the create body, so both calls have to be held to the slot boundary —
+    // otherwise an agent-created Form could still be populated as the user.
+    for (const cmd of [
+      `forms forms create --json '{"info":{"title":"TPEP Self-Assessment"}}'`,
+      `forms forms batchUpdate --params '{"formId":"f1"}' --json '{"requests":[]}'`,
+      'forms.forms.create --json \'{"info":{"title":"x"}}\'',
+    ]) {
+      expect(enforcePhase1Gates(cmd, USER_CTX).allowed).toBe(false);
+    }
+    for (const cmd of [
+      `forms forms create --json '{"info":{"title":"TPEP Self-Assessment"}}'`,
+      `forms forms batchUpdate --params '{"formId":"f1"}' --json '{"requests":[]}'`,
+    ]) {
+      expect(enforcePhase1Gates(cmd, AGENT_CTX).allowed).toBe(true);
+    }
+  });
+
   test('missing/unknown scope fails closed to the user-slot rules', () => {
     expect(enforcePhase1Gates(`docs documents create --json '{"title":"x"}'`, undefined).allowed).toBe(false);
     expect(enforcePhase1Gates(`docs documents create --json '{"title":"x"}'`, { scope: 'weird' }).allowed).toBe(false);

--- a/infra/agent-image/skills/psd-workspace/run.js
+++ b/infra/agent-image/skills/psd-workspace/run.js
@@ -84,10 +84,19 @@ function emitForbiddenGate(gateCheck) {
   emit({
     status: 'phase1-forbidden',
     reason: gateCheck.reason,
+    // Do NOT point at a "confirmation flow" here. There isn't one, and saying
+    // so sent agents hunting for a tool that does not exist — observed live
+    // 2026-08-05 (agent_failures 2118), where the agent reported being told to
+    // route via a confirmation flow "but no such confirmation flow tool is
+    // exposed". Same failure shape as the provenance gate removed in 9c7ec8c5e:
+    // a refusal describing a remedy the codebase cannot provide wastes the turn
+    // and buries the real answer, which is that the user has to do this part.
     message:
       `Phase 1 forbids this operation: ${gateCheck.reason}. ` +
-      `If the user explicitly approved, route via the appropriate ` +
-      `confirmation flow rather than calling this skill directly.`,
+      `There is no override and no approval flow — user approval does not ` +
+      `unlock it. Tell the user plainly that you cannot do this, say what you ` +
+      `did instead (a draft, a link, the content in chat), and let them take ` +
+      `the final step themselves. Do not retry with a different shape.`,
   });
   process.exit(13);
 }

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -69,6 +69,7 @@ const ALLOWED_WRITES = new Set([
   "chat spaces messages create",
   "docs documents batchupdate",
   "docs documents create",
+  "drive comments create",
   "drive files copy",
   "drive files create",
   "drive permissions create",
@@ -86,9 +87,12 @@ const ALLOWED_WRITES = new Set([
   // mail at all. `chat +send` above establishes that helper verbs belong here.
   // Still a draft-only path: `+send`, `+reply`, `+reply-all` and `+forward`
   // remain absent, and the skill-side Phase 1 gate blocks them independently.
+  "forms forms batchupdate",
+  "forms forms create",
   "gmail +draft",
   "gmail users drafts create",
   "gmail users drafts update",
+  "gmail users labels create",
   "gmail users messages modify",
   "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
@@ -131,6 +135,7 @@ const AGENT_ONLY_WRITES = new Set([
   "calendar events update",
   "docs documents batchupdate",
   "docs documents create",
+  "drive comments create",
   "drive files copy",
   "drive files create",
   "drive permissions create",

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -140,6 +140,14 @@ const AGENT_ONLY_WRITES = new Set([
   "drive files create",
   "drive permissions create",
   "drive accessproposals resolve",
+  // A Form is authored content in exactly the sense a Doc, Sheet or Slides deck
+  // is, and psd-workspace/SKILL.md documents only the agent slot for it ("Create
+  // and populate a Form on the agent slot, then hand it over"). Allowlisting the
+  // two operations without this entry left `--scope user` — the default when the
+  // flag is omitted — authoring a Form under the caller's own identity, which is
+  // the impersonation boundary the create operations above are held to.
+  "forms forms batchupdate",
+  "forms forms create",
   "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
   "sheets spreadsheets values append",

--- a/tests/unit/lib/agent-workspace/allowlist-doc-drift.test.ts
+++ b/tests/unit/lib/agent-workspace/allowlist-doc-drift.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { validateWorkspaceCommand } from "@/lib/agent-workspace/command-executor"
+
+/**
+ * Every Workspace operation shown as a worked example in psd-workspace/SKILL.md
+ * must be reachable through the broker validator.
+ *
+ * Seven operations drifted out of the allowlist in the 2026-08-03..05 window
+ * alone — `drive permissions create`, the params-only move, `gmail +draft`,
+ * `drive accessproposals resolve`, `forms forms create`, `gmail users labels
+ * create` and `drive comments create`. Each was documented, or API-enabled, or
+ * both; each was refused with `operation_not_allowed`; and each surfaced only
+ * when a real user hit it, because nothing compared the docs to the allowlist.
+ *
+ * This closes that loop: the SKILL.md examples ARE the contract the model is
+ * taught, so a documented operation the broker refuses is a defect in one of
+ * the two, and the test fails until they agree.
+ */
+const SKILL_MD = join(
+  process.cwd(),
+  "infra/agent-image/skills/psd-workspace/SKILL.md"
+)
+
+/**
+ * Every `gws <service>.<resource>.<action>` invocation the doc shows.
+ *
+ * Deliberately one flat, bounded pattern: an earlier version nested quantifiers
+ * to parse space- and dot-separated forms together and tripped
+ * `security/detect-unsafe-regex`. The dotted form is what the examples use, and
+ * this only guards that the scrape still finds something.
+ */
+function documentedOperations(): string[] {
+  const md = readFileSync(SKILL_MD, "utf8")
+  const found = new Set<string>()
+  // One flat character run, split in JS. A `{1,20}` nested inside a `{1,3}`
+  // is star-height 2 and `security/detect-unsafe-regex` rejects it however
+  // tight the bounds — the same shape the chat-chart email pattern hit.
+  for (const match of md.matchAll(/gws ([a-z][a-z.]{1,60})/g)) {
+    const parts = match[1]!.split(".").filter(Boolean)
+    if (parts.length >= 2 && parts.length <= 4) {
+      found.add(parts.join(" ").toLowerCase())
+    }
+  }
+  return [...found]
+}
+
+describe("SKILL.md examples stay reachable through the broker", () => {
+  // Operations the skill documents with a concrete, copyable invocation. Kept
+  // explicit rather than scraped loosely: a scraper wide enough to catch every
+  // shape also catches prose, and a test that cries wolf gets muted.
+  const DOCUMENTED_WORKED_EXAMPLES: Array<{ argv: string[]; scope: "agent" | "user" }> = [
+    { scope: "user", argv: ["gmail", "+draft", "--to", "a@psd401.net", "--subject", "x"] },
+    { scope: "user", argv: ["gmail", "users", "labels", "create", "--json", '{"name":"Digested"}'] },
+    { scope: "user", argv: ["drive", "files", "update", "--params", '{"fileId":"f","addParents":"p"}'] },
+    { scope: "user", argv: ["drive", "files", "update", "--params", '{"fileId":"f"}', "--json", '{"name":"n"}'] },
+    { scope: "agent", argv: ["docs", "documents", "create", "--json", '{"title":"t"}'] },
+    { scope: "agent", argv: ["sheets", "spreadsheets", "create", "--json", "{}"] },
+    { scope: "agent", argv: ["slides", "presentations", "create", "--json", "{}"] },
+    { scope: "agent", argv: ["forms", "forms", "create", "--json", "{}"] },
+    { scope: "agent", argv: ["drive", "comments", "create", "--json", '{"content":"c"}'] },
+    {
+      scope: "agent",
+      argv: [
+        "drive", "permissions", "create",
+        "--json",
+        '{"fileId":"f","type":"user","role":"reader","emailAddress":"a@psd401.net"}',
+      ],
+    },
+    {
+      scope: "agent",
+      argv: [
+        "drive", "accessproposals", "resolve",
+        "--params", '{"fileId":"f","proposalId":"p"}',
+        "--json", '{"action":"accept","role":"writer"}',
+      ],
+    },
+  ]
+
+  it.each(DOCUMENTED_WORKED_EXAMPLES)(
+    "allows the documented $scope-slot example: $argv",
+    ({ argv, scope }) => {
+      expect(() =>
+        validateWorkspaceCommand({ scope, argv }, "a@psd401.net")
+      ).not.toThrow()
+    }
+  )
+
+  it("finds the documented operations it claims to cover", () => {
+    // Guards the guard: if SKILL.md is restructured so the scrape returns
+    // nothing, this suite would silently pass while covering zero operations.
+    const ops = documentedOperations()
+    // Named rather than counted: a count drifts silently as the doc is edited,
+    // and these are precisely the operations that were documented-but-refused.
+    for (const required of [
+      "drive permissions create",
+      "drive accessproposals resolve",
+      "drive comments create",
+      "forms forms create",
+      "gmail users labels create",
+    ]) {
+      expect(ops).toContain(required)
+    }
+  })
+
+  it("still refuses everything the docs describe as forbidden", () => {
+    for (const forbidden of [
+      ["gmail", "users", "messages", "send"],
+      ["gmail", "+send", "--to", "a@psd401.net"],
+      ["drive", "files", "delete", "--params", '{"fileId":"f"}'],
+      ["calendar", "events", "delete"],
+    ]) {
+      expect(() =>
+        validateWorkspaceCommand({ scope: "agent", argv: forbidden }, "a@psd401.net")
+      ).toThrow()
+    }
+  })
+})

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -456,6 +456,8 @@ function defineTrustedWorkspaceCommandPolicySuite1Part4() {
     ["calendar", "events", "update"],
     ["docs", "documents", "batchUpdate"],
     ["drive", "permissions", "create"],
+    ["forms", "forms", "create"],
+    ["forms", "forms", "batchUpdate"],
     ["sheets", "spreadsheets", "batchUpdate"],
     ["slides", "presentations", "batchUpdate"],
     ["tasks", "tasks", "patch"],
@@ -466,6 +468,17 @@ function defineTrustedWorkspaceCommandPolicySuite1Part4() {
     expect(() =>
       validateWorkspaceCommand({ scope: "user", argv })
     ).toThrow(/must use the agent-owned Workspace account/)
+  })
+
+  it.each([
+    ["forms", "forms", "create"],
+    ["forms", "forms", "batchUpdate"],
+  ])("still allows %s %s %s on the agent slot", (...argv) => {
+    // The slot restriction above must not have made the operation unreachable:
+    // the agent slot is the one psd-workspace/SKILL.md documents for Forms.
+    expect(() =>
+      validateWorkspaceCommand({ scope: "agent", argv })
+    ).not.toThrow()
   })
 }
 

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -455,6 +455,12 @@ function defineTrustedWorkspaceCommandPolicySuite1Part4() {
     ["calendar", "events", "patch"],
     ["calendar", "events", "update"],
     ["docs", "documents", "batchUpdate"],
+    // drive comments create was added to AGENT_ONLY_WRITES alongside the Forms
+    // operations but was the one addition with no user-slot case, so nothing
+    // would have gone red if it drifted back out — the exact failure mode
+    // allowlist-doc-drift.test.ts exists to prevent, since that test only
+    // asserts the agent slot is allowed.
+    ["drive", "comments", "create"],
     ["drive", "permissions", "create"],
     ["forms", "forms", "create"],
     ["forms", "forms", "batchUpdate"],


### PR DESCRIPTION
Closes #1609.

Everything still fixable from the 2026-08-06 prod baseline, plus both items in #1609.

## Charts

**Multi-series renders instead of silently dropping data.** `render_local.js` read only `datasets[0]`, so *"chart Reading and Math by grade"* drew Math alone under a plausible-looking axis with no sign a series was missing. Half the data presented as all of it is a correctness problem for assessment figures, not a cosmetic one.

Grouped bars, one line per series, axis spanning every series, legend naming them. A single series keeps the per-category palette it has always had — colour only encodes *series* when there's more than one, since that's what ties a bar to its legend entry.

**The CLI can express it.** A point may carry `values: {Math, Reading}` instead of a single `value`; the flat shape is unchanged. A series missing a value at any label is **refused rather than drawn as zero** — zero would report a grade with no data as a grade scoring nothing.

`pie` refuses a second dataset and says why (a pie divides one whole).

**Legend placement.** Below the axis: in the plot's top-right it collided with the tallest group's value labels, and no in-plot corner is safe for every dataset. It wraps to a second row rather than truncating every label to the same stub ("Very Long." six times identifies nothing), and the row width is **measured rather than estimated** — an arithmetic approximation overflowed the right edge, exactly as the pie legend once did.

**chat-chart records failures.** It had no reporting path at all, so a chart the user never saw left nothing in `agent_failures` — the reason the 2026-08-06 case was found only because a human was watching the Chat window. The CloudWatch line is written before the broker call so the record survives a broker outage.

## Four operations documented or API-enabled but refused by the broker

| Operation | Slot | Why it was blocking |
|---|---|---|
| `forms forms create` / `batchupdate` | agent | 2 users blocked building a TPEP self-assessment. `forms.googleapis.com` was **already enabled in terraform** — only the allowlist was missing. |
| `drive comments create` | agent | The Phase-1-safe way to contribute to a file the agent doesn't own; documented in `gws-drive`. |
| `gmail users labels create` | user (`gmail.modify` covers it) | Without it a Daily Digest schedule reprocessed the same 20 emails every run. |
| `drive accessproposals resolve` | agent | Gains its worked example in SKILL.md. |

Handing a Form over works via the ownership transfer added in #1607.

**All three new operations are documented as well as allowlisted.** Allowlisting without documenting leaves an operation inert — the model only emits commands the skill has told it about.

### The systemic fix

`tests/unit/lib/agent-workspace/allowlist-doc-drift.test.ts` asserts every documented worked example is reachable through the broker validator. **Seven operations drifted out of that allowlist in the 2026-08-03..05 window alone** — `permissions.create`, the params-only move, `gmail +draft`, `accessproposals resolve`, and these three — each surfacing only when a real user hit it.

## Two failures that logged nothing

- **`psd-failure-report` gains the trigger it was missing:** *the user telling you your output didn't work.* Every existing trigger describes a failure the **agent** observed, so a turn it believes succeeded produced no row however many times the user said otherwise.
- **`chat-chart` states that every delivery surface renders the rich envelope.** An agent invented the belief that web chat could not, sent a title-only card with no image, and repeated it across several turns. The assumption appears **nowhere in this repo** — it took a screenshot to dislodge.
- **The Phase 1 refusal no longer points at a "confirmation flow."** There isn't one, and saying so sent agents hunting for a tool that doesn't exist (`agent_failures` 2118) — the same shape as the provenance gate removed in `9c7ec8c5e`. It now says plainly that there is no override.

## Test-suite race found on the way

`withStubBroker` binds a fixed port, and **bun runs this file's async tests concurrently**, so two stubs raced to listen and the loser died `EADDRINUSE`. `node --test` never noticed because it runs them sequentially. Latent, not new — adding tests only changed the odds, and CI runs `bun test` on this file. Serialised on a promise chain, and the broker-failure test now uses a stub that **refuses** rather than asserting no stub is listening, which was testing scheduling luck.

## Verification

- Full unit suite: **571 suites / 5,392 tests**
- chat-chart: **56 under both `bun test` and `node --test`**, three consecutive bun runs, deterministic
- All 16 Bun skill suites CI runs
- `bun run lint` clean at `--max-warnings 0`; `bun run typecheck` clean
- agent-image bootstrap-budget and config-consistency gates passing

Charts rendered and visually inspected: two-series grouped bar, three-series line, and a six-series long-label case checked pixel-wise for canvas overflow.

## Not fixable here

`students_demographics` timeouts (opeln, two independent reports) — `psd-data` queries run against an external `psd-data-mcp`/Redshift. Hagel is raising it with the data engineer.

## Checklist

- [x] No `console.*` in production code — agent skills are CLIs outside the Next.js runtime
- [x] Lint passes at `--max-warnings 0`
- [x] Typecheck passes
- [x] All tests pass — unit, both chart runners, all 16 skill suites
- [x] No `any` types; no new type assertions
- [x] Documentation updated — psd-workspace and chat-chart SKILL.md
- [x] No secrets or environment variables added
- [ ] Code reviewed and approved — pending
