### PR TITLE
fix(agent): let the agent read its own schedule run history, and quiet routine contention

### DIFF
--- a/app/api/agent/schedules/route.ts
+++ b/app/api/agent/schedules/route.ts
@@ -76,13 +76,20 @@ async function executeScheduleOperation(
           enabled: body.enabled,
         }),
       })
+    case "runs":
+      return NextResponse.json({
+        runs: await service.runs(ownerEmail, {
+          scheduleId: body.scheduleId,
+          limit: body.limit,
+        }),
+      })
     case "delete":
       return NextResponse.json({
         deleted: await service.delete(ownerEmail, body.scheduleId),
       })
     default:
       return NextResponse.json(
-        { error: "operation must be create, list, update, or delete" },
+        { error: "operation must be create, list, runs, update, or delete" },
         { status: 400 }
       )
   }

--- a/infra/agent-image/skills/psd-schedules/SKILL.md
+++ b/infra/agent-image/skills/psd-schedules/SKILL.md
@@ -165,3 +165,23 @@ and confirm. Run `create`. Tell the user when the first fire will be.
   do not try to "fix" unrelated infrastructure (gateway pairing, device
   approval, etc.) — those are signs of a wrong tool choice, not a real
   problem to solve.
+
+## Diagnosing a failed run
+
+`list` reports each schedule's last status but never the reason. When a user
+asks why a scheduled job failed, read the run history — it carries the error
+message:
+
+```bash
+node /opt/psd-skills/psd-schedules/runs.js
+node /opt/psd-skills/psd-schedules/runs.js --schedule-id <id> --limit 10
+```
+
+Newest first, up to 50, scoped to the caller's own schedules. Each run reports
+`status`, `errorMessage`, `latencyMs` and `createdAt`.
+
+Do NOT tell the user you have no access to the scheduled job's logs — you do.
+Read the runs, quote the error, and say what you will change. Observed
+2026-08-06: a nightly filing job failed, the user asked how to fix it, and the
+agent replied that it had no way to see that job's run logs.
+

--- a/infra/agent-image/skills/psd-schedules/authority.test.js
+++ b/infra/agent-image/skills/psd-schedules/authority.test.js
@@ -7,7 +7,7 @@ const path = require('node:path');
 const skillDir = __dirname;
 
 describe('psd-schedules authority selectors', () => {
-  for (const script of ['create.js', 'list.js', 'update.js', 'delete.js']) {
+  for (const script of ['create.js', 'list.js', 'update.js', 'delete.js', 'runs.js']) {
     it(`${script} rejects the legacy --user selector before network access`, () => {
       const result = spawnSync(
         process.execPath,

--- a/infra/agent-image/skills/psd-schedules/runs.js
+++ b/infra/agent-image/skills/psd-schedules/runs.js
@@ -24,9 +24,15 @@ async function main() {
   }
   rejectLegacyAuthorityArgs(args);
 
+  const scheduleId = args['schedule-id'];
+  if (scheduleId === true) fail('--schedule-id requires a value');
+
   const limitArg = args.limit;
   let limit;
   if (limitArg !== undefined) {
+    // A valueless --limit parses as `true`, and Number(true) is 1 — without this
+    // guard a malformed invocation silently becomes `--limit 1`.
+    if (limitArg === true) fail('--limit requires a value');
     limit = Number(limitArg);
     if (!Number.isInteger(limit) || limit < 1 || limit > 50) {
       fail('--limit must be an integer between 1 and 50');
@@ -35,7 +41,7 @@ async function main() {
 
   const result = await requestScheduleOperation({
     operation: 'runs',
-    ...(args['schedule-id'] ? { scheduleId: args['schedule-id'] } : {}),
+    ...(scheduleId ? { scheduleId } : {}),
     ...(limit === undefined ? {} : { limit }),
   });
   emit(result);

--- a/infra/agent-image/skills/psd-schedules/runs.js
+++ b/infra/agent-image/skills/psd-schedules/runs.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const {
+  fail,
+  rejectLegacyAuthorityArgs,
+  parseArgs,
+  emit,
+  requestScheduleOperation,
+} = require('./common');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    process.stdout.write(
+      'Usage: runs.js [--schedule-id <id>] [--limit <1-50>]\n' +
+        '\n' +
+        'Recent runs for your schedules, newest first, with the error message\n' +
+        'for any that failed. Use this to answer "why did my scheduled job\n' +
+        'fail" — `list` reports a status but never the reason.\n',
+    );
+    return;
+  }
+  rejectLegacyAuthorityArgs(args);
+
+  const limitArg = args.limit;
+  let limit;
+  if (limitArg !== undefined) {
+    limit = Number(limitArg);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 50) {
+      fail('--limit must be an integer between 1 and 50');
+    }
+  }
+
+  const result = await requestScheduleOperation({
+    operation: 'runs',
+    ...(args['schedule-id'] ? { scheduleId: args['schedule-id'] } : {}),
+    ...(limit === undefined ? {} : { limit }),
+  });
+  emit(result);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    fail(error instanceof Error ? error.message : String(error));
+  });
+}

--- a/infra/lambdas/agent-cron/schedule-fire.ts
+++ b/infra/lambdas/agent-cron/schedule-fire.ts
@@ -172,7 +172,12 @@ export function resolveScheduleLockContention(
       fireClaim,
       failure: {
         ...failure,
-        severity: 'error',
+        // `warn`, for the same reason as the same-fire case above: every
+        // schedule for one owner shares the workspace lock, so two schedules
+        // firing close together contend BY DESIGN and the retry resolves it.
+        // Recording it at error severity put routine, self-healing contention
+        // in the operator feed next to real outages (prod 2026-08-06).
+        severity: 'warn',
         errorMessage:
           'Owner workspace is active for another schedule; retrying this fire',
       },

--- a/lib/agent-schedules/run-reader.ts
+++ b/lib/agent-schedules/run-reader.ts
@@ -8,11 +8,31 @@ export interface AgentScheduleLastRun {
   errorMessage: string | null;
 }
 
+/** One historical run, as the agent needs to see it to diagnose a failure. */
+export interface AgentScheduleRun {
+  scheduleId: string | null;
+  scheduleName: string | null;
+  createdAt: Date;
+  status: string;
+  errorMessage: string | null;
+  latencyMs: number;
+}
+
 export interface AgentScheduleRunReader {
   latestBySchedule(
     ownerEmail: string,
     scheduleIds: string[],
   ): Promise<Map<string, AgentScheduleLastRun>>;
+  /**
+   * Recent runs for the owner, newest first, optionally narrowed to one
+   * schedule. Carries `errorMessage` — the reason `list` alone was not enough:
+   * it reports a status but not WHY, so an agent asked "why did my nightly job
+   * fail" had nothing to answer with (prod 2026-08-06, agent_failures 2580).
+   */
+  recentForOwner(
+    ownerEmail: string,
+    options?: { scheduleId?: string; limit?: number },
+  ): Promise<AgentScheduleRun[]>;
 }
 
 export class DrizzleAgentScheduleRunReader
@@ -58,5 +78,43 @@ export class DrizzleAgentScheduleRunReader
       });
     }
     return latest;
+  }
+
+  async recentForOwner(
+    ownerEmail: string,
+    options: { scheduleId?: string; limit?: number } = {},
+  ): Promise<AgentScheduleRun[]> {
+    // Bounded: this lands in an agent's context window, and an owner with a
+    // five-minute schedule accumulates thousands of rows.
+    const limit = Math.min(Math.max(1, options.limit ?? 20), 50);
+    const conditions = [eq(agentScheduledRuns.userId, ownerEmail)];
+    if (options.scheduleId) {
+      conditions.push(eq(agentScheduledRuns.scheduleId, options.scheduleId));
+    }
+    const rows = await executeQuery(
+      (db) =>
+        db
+          .select({
+            scheduleId: agentScheduledRuns.scheduleId,
+            scheduleName: agentScheduledRuns.scheduleName,
+            createdAt: agentScheduledRuns.createdAt,
+            status: agentScheduledRuns.status,
+            errorMessage: agentScheduledRuns.errorMessage,
+            latencyMs: agentScheduledRuns.latencyMs,
+          })
+          .from(agentScheduledRuns)
+          .where(and(...conditions))
+          .orderBy(desc(agentScheduledRuns.createdAt), desc(agentScheduledRuns.id))
+          .limit(limit),
+      "getRecentAgentScheduleRuns",
+    );
+    return rows.map((row) => ({
+      scheduleId: row.scheduleId,
+      scheduleName: row.scheduleName,
+      createdAt: row.createdAt,
+      status: row.status,
+      errorMessage: row.errorMessage,
+      latencyMs: row.latencyMs,
+    }));
   }
 }

--- a/lib/agent-schedules/run-reader.ts
+++ b/lib/agent-schedules/run-reader.ts
@@ -86,7 +86,10 @@ export class DrizzleAgentScheduleRunReader
   ): Promise<AgentScheduleRun[]> {
     // Bounded: this lands in an agent's context window, and an owner with a
     // five-minute schedule accumulates thousands of rows.
-    const limit = Math.min(Math.max(1, options.limit ?? 20), 50);
+    // Floored as well as clamped: this is the last hop before Drizzle's
+    // `.limit()`, and a fraction reaching Postgres is a runtime error rather
+    // than a smaller page.
+    const limit = Math.floor(Math.min(Math.max(1, options.limit ?? 20), 50));
     const conditions = [eq(agentScheduledRuns.userId, ownerEmail)];
     if (options.scheduleId) {
       conditions.push(eq(agentScheduledRuns.scheduleId, options.scheduleId));

--- a/lib/agent-schedules/service.ts
+++ b/lib/agent-schedules/service.ts
@@ -32,6 +32,7 @@ import {
 import {
   DrizzleAgentScheduleRunReader,
   type AgentScheduleLastRun,
+  type AgentScheduleRun,
   type AgentScheduleRunReader,
 } from "@/lib/agent-schedules/run-reader";
 import {
@@ -854,6 +855,29 @@ export class AgentScheduleService {
             runEnrichmentAvailable,
           ),
     );
+  }
+
+  /**
+   * Recent runs for this owner, so the agent can answer "why did my scheduled
+   * job fail" instead of reporting that it cannot see its own history.
+   *
+   * Owner-scoped at the query, like every other operation here — a caller
+   * cannot read another owner's runs by passing their scheduleId.
+   */
+  async runs(
+    owner: string,
+    input: { scheduleId?: unknown; limit?: unknown } = {},
+  ): Promise<AgentScheduleRun[]> {
+    const ownerEmail = normalizeOwnerEmail(owner);
+    const scheduleId =
+      typeof input.scheduleId === "string" && input.scheduleId.trim()
+        ? input.scheduleId.trim()
+        : undefined;
+    const limit =
+      typeof input.limit === "number" && Number.isFinite(input.limit)
+        ? input.limit
+        : undefined;
+    return this.runReader.recentForOwner(ownerEmail, { scheduleId, limit });
   }
 
   async create(

--- a/lib/agent-schedules/service.ts
+++ b/lib/agent-schedules/service.ts
@@ -873,8 +873,12 @@ export class AgentScheduleService {
       typeof input.scheduleId === "string" && input.scheduleId.trim()
         ? input.scheduleId.trim()
         : undefined;
+    // Integer, not merely finite: a fractional `limit` such as 1.5 survives the
+    // reader's clamp and reaches Drizzle's `.limit()` as a fraction. The skill
+    // validates this too, but the broker route is reachable owner-mode without
+    // it, so the boundary that talks to the database enforces it as well.
     const limit =
-      typeof input.limit === "number" && Number.isFinite(input.limit)
+      typeof input.limit === "number" && Number.isInteger(input.limit)
         ? input.limit
         : undefined;
     return this.runReader.recentForOwner(ownerEmail, { scheduleId, limit });

--- a/tests/unit/agent-cron-schedule-fire.test.ts
+++ b/tests/unit/agent-cron-schedule-fire.test.ts
@@ -411,6 +411,8 @@ describe("agent-cron daily-session contention policy", () => {
         "schedule-fire#another-schedule#2026-07-28T14:55:00.000Z",
     }
 
+    // warn, not error: every schedule for one owner shares the workspace lock,
+    // so two firing close together contend by design and the retry resolves it.
     expect(
       resolveScheduleLockContention(otherScheduleContention, fireClaim),
     ).toEqual({
@@ -418,7 +420,7 @@ describe("agent-cron daily-session contention policy", () => {
       fireClaim,
       failure: {
         ...otherScheduleContention,
-        severity: "error",
+        severity: "warn",
         errorMessage:
           "Owner workspace is active for another schedule; retrying this fire",
       },

--- a/tests/unit/agent-schedules-service.test.ts
+++ b/tests/unit/agent-schedules-service.test.ts
@@ -100,13 +100,14 @@ function harness(
   const dynamoSend = jest.fn()
   const schedulerSend = jest.fn()
   const latestBySchedule = jest.fn().mockResolvedValue(latestRuns)
+  const recentForOwner = jest.fn().mockResolvedValue([])
   const service = new AgentScheduleService(
     config,
     { send: dynamoSend } as unknown as AgentScheduleDynamoClient,
     { send: schedulerSend } as unknown as SchedulerClient,
-    { latestBySchedule } as AgentScheduleRunReader,
+    { latestBySchedule, recentForOwner } as AgentScheduleRunReader,
   )
-  return { service, dynamoSend, schedulerSend, latestBySchedule }
+  return { service, dynamoSend, schedulerSend, latestBySchedule, recentForOwner }
 }
 
 function defineAgentScheduleServiceAuthorityBoundarySuite1Part1() {
@@ -517,7 +518,8 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part3() {it("repairs a
       { send: dynamoSend } as unknown as AgentScheduleDynamoClient,
       { send: schedulerSend } as unknown as SchedulerClient,
       {
-        latestBySchedule: jest.fn().mockResolvedValue(new Map()),
+        recentForOwner: jest.fn().mockResolvedValue([]),
+      latestBySchedule: jest.fn().mockResolvedValue(new Map()),
       },
     )
     await expect(service.delete(OWNER, SCHEDULE_ID)).resolves.toBe(SCHEDULE_ID)
@@ -643,3 +645,51 @@ const defineScheduleExpressionResourceGuardsSuite2 = () => {
 };
 
 describe("schedule expression resource guards", defineScheduleExpressionResourceGuardsSuite2)
+
+// `list` reports a status but never a reason, so an agent asked "why did my
+// nightly job fail" had nothing to answer with and told the user it could not
+// see that job's logs (prod 2026-08-06, agent_failures 2580).
+describe("schedule run history", () => {
+  it("returns the owner's recent runs, error messages included", async () => {
+    const { service, recentForOwner } = harness()
+    recentForOwner.mockResolvedValue([
+      {
+        scheduleId: "s1",
+        scheduleName: "Nightly inbox filing",
+        createdAt: new Date("2026-08-06T05:01:00Z"),
+        status: "error",
+        errorMessage: "exec was still running",
+        latencyMs: 1200,
+      },
+    ])
+    const runs = await service.runs("Owner@PSD401.net")
+    expect(runs).toHaveLength(1)
+    expect(runs[0].errorMessage).toBe("exec was still running")
+    // Owner is normalised before it reaches the reader, so a caller cannot
+    // reach another owner's rows by varying case.
+    expect(recentForOwner).toHaveBeenCalledWith("owner@psd401.net", {
+      scheduleId: undefined,
+      limit: undefined,
+    })
+  })
+
+  it("passes a narrowing scheduleId and limit through", async () => {
+    const { service, recentForOwner } = harness()
+    recentForOwner.mockResolvedValue([])
+    await service.runs("owner@psd401.net", { scheduleId: " s1 ", limit: 5 })
+    expect(recentForOwner).toHaveBeenCalledWith("owner@psd401.net", {
+      scheduleId: "s1",
+      limit: 5,
+    })
+  })
+
+  it("ignores non-string scheduleId and non-numeric limit", async () => {
+    const { service, recentForOwner } = harness()
+    recentForOwner.mockResolvedValue([])
+    await service.runs("owner@psd401.net", { scheduleId: 42, limit: "many" })
+    expect(recentForOwner).toHaveBeenCalledWith("owner@psd401.net", {
+      scheduleId: undefined,
+      limit: undefined,
+    })
+  })
+})

--- a/tests/unit/agent-schedules-service.test.ts
+++ b/tests/unit/agent-schedules-service.test.ts
@@ -693,3 +693,17 @@ describe("schedule run history", () => {
     })
   })
 })
+
+it("ignores a fractional limit rather than forwarding it to the database", async () => {
+  // 1.5 survives a finite-only check and the reader's clamp, reaching Drizzle's
+  // .limit() as a fraction — a runtime error, not a smaller page.
+  const { service, recentForOwner } = harness()
+  recentForOwner.mockResolvedValue([])
+  for (const bad of [1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    await service.runs("owner@psd401.net", { limit: bad })
+    expect(recentForOwner).toHaveBeenLastCalledWith("owner@psd401.net", {
+      scheduleId: undefined,
+      limit: undefined,
+    })
+  }
+})

--- a/tests/unit/agent-schedules-service.test.ts
+++ b/tests/unit/agent-schedules-service.test.ts
@@ -519,7 +519,7 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part3() {it("repairs a
       { send: schedulerSend } as unknown as SchedulerClient,
       {
         recentForOwner: jest.fn().mockResolvedValue([]),
-      latestBySchedule: jest.fn().mockResolvedValue(new Map()),
+        latestBySchedule: jest.fn().mockResolvedValue(new Map()),
       },
     )
     await expect(service.delete(OWNER, SCHEDULE_ID)).resolves.toBe(SCHEDULE_ID)
@@ -692,18 +692,18 @@ describe("schedule run history", () => {
       limit: undefined,
     })
   })
-})
 
-it("ignores a fractional limit rather than forwarding it to the database", async () => {
-  // 1.5 survives a finite-only check and the reader's clamp, reaching Drizzle's
-  // .limit() as a fraction — a runtime error, not a smaller page.
-  const { service, recentForOwner } = harness()
-  recentForOwner.mockResolvedValue([])
-  for (const bad of [1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
-    await service.runs("owner@psd401.net", { limit: bad })
-    expect(recentForOwner).toHaveBeenLastCalledWith("owner@psd401.net", {
-      scheduleId: undefined,
-      limit: undefined,
-    })
-  }
+  it("ignores a fractional limit rather than forwarding it to the database", async () => {
+    // 1.5 survives a finite-only check and the reader's clamp, reaching Drizzle's
+    // .limit() as a fraction — a runtime error, not a smaller page.
+    const { service, recentForOwner } = harness()
+    recentForOwner.mockResolvedValue([])
+    for (const bad of [1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      await service.runs("owner@psd401.net", { limit: bad })
+      expect(recentForOwner).toHaveBeenLastCalledWith("owner@psd401.net", {
+        scheduleId: undefined,
+        limit: undefined,
+      })
+    }
+  })
 })


### PR DESCRIPTION
Both items from the post-deploy prod review on 2026-08-06.

## 1. The agent can now diagnose its own scheduled-run failures

zarlingj's "Nightly inbox filing" failed, they asked the agent how to fix it, and it replied:

> *"This session has no direct access to that scheduled job's run logs to diagnose the specific error."* — `agent_failures` 2580

An ironic gap: the failed-turn message had just been made self-describing (*"I had already run: read, write, exec, edit… exec was still running and may or may not have completed"*), and the agent still couldn't read the history needed to act on it. The user got an apology instead of an answer.

`list` was the only window onto runs, and it reports a **status without a reason**. Added a `runs` operation end to end — reader → service → broker route → `runs.js` skill command — returning recent runs newest-first with `status`, `errorMessage`, `latencyMs` and `createdAt`, optionally narrowed to one schedule.

**Scoping:** owner-scoped at the query like every other operation on this service, so a caller can't read another owner's runs by passing their `scheduleId`. The owner email is normalised *before* it reaches the reader, so case can't be used to sidestep that. Bounded to 50 rows — this lands in an agent's context window, and an owner with a five-minute schedule accumulates thousands.

**Documented, not just built.** SKILL.md carries the instruction that actually matters:

> Do NOT tell the user you have no access to the scheduled job's logs — you do. Read the runs, quote the error, and say what you will change.

Allowlisting without documenting leaves a command inert; that lesson cost us a round on `accessproposals` in #1608.

## 2. Cross-schedule lock contention is `warn`, not `error`

Every schedule for one owner shares the workspace lock, so two firing close together contend **by design** and the retry resolves it. I downgraded only the *same-fire* case in #1607 — this is the sibling branch, still putting routine self-healing contention in the operator feed beside real outages.

## Verification

- Full unit suite: **571 suites / 5,421 tests passing**
- `bun run lint` clean at `--max-warnings 0`; `bun run typecheck` clean

Typecheck caught the two service test doubles that needed the new reader method — worth noting as evidence the interface is load-bearing rather than optional.

New coverage: error messages surface, owner normalisation reaches the reader, narrowing args pass through, and non-string `scheduleId` / non-numeric `limit` are ignored rather than forwarded.

## Context — where the prod baseline stands

After the two images shipped today, prod went from **119 failures / 35 users over three days** to **10 in ~17 hours**, with every top class at zero: `ChatDeadlineExpired*`, `phase1-forbidden` self-reports, Slides API, "no SIS data tool", and `ChatResponseDeliveryFailed`.

Still open and untouched, so they don't read as regressions here: `EmptyAgentResponse` (4 rows, 1 user, overnight), `OpenClawIncompleteToolTurn` / `OpenClawChatError` (message improved, frequency unchanged), and `students_demographics` timeouts (warehouse-side, with the data engineer).

## Checklist

- [x] No `console.*` in production code
- [x] Lint passes at `--max-warnings 0`
- [x] Typecheck passes
- [x] All tests pass
- [x] No `any` types; no new type assertions
- [x] Documentation updated — psd-schedules SKILL.md
- [x] No secrets or environment variables added
- [ ] Code reviewed and approved — pending
