### PR TITLE
fix(agent): retry a clean upstream failure, and detect when OpenClaw fixes toolConfig

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -383,6 +383,27 @@ COPY skills /opt/psd-skills
 # user invokes web_search.
 ARG BEDROCK_PLUGIN_VERSION=2026.7.2-beta.5
 ARG BEDROCK_PLUGIN_ASSERTION=claude-sonnet-5
+# UPSTREAM-BUG CANARY (2026-08-06) — this asserts a bug is STILL PRESENT.
+#
+# convertToolConfig returns undefined when tools are empty or toolChoice is
+# "none", so OpenClaw's tools-disabled "settled post-tool turn" finalization
+# sends a Converse request with no toolConfig while the message history still
+# carries toolUse/toolResult blocks. Bedrock rejects that combination
+# ("The toolConfig field must be defined when using toolUse and toolResult
+# content blocks"), so the recovery call cannot succeed and a turn that had
+# already run 1-2 tools fails outright. 9 occurrences across 8 users,
+# 2026-08-04..06, with an identical signature (response_chars=0, seq=19 at one
+# tool / seq=25 at two).
+#
+# It is NOT fixed upstream: 2026.7.2-beta.7's dist is byte-identical to
+# beta.5's. We chose to live with it rather than patch a vendored dependency
+# that runs on every turn.
+#
+# This canary is how we find out when that changes. The build FAILS the moment
+# upstream edits this line — which is the signal to re-test the finalization
+# path and delete this ARG. Without it we would carry a known-broken recovery
+# path indefinitely and never notice the fix landing.
+ARG BEDROCK_TOOLCONFIG_CANARY='if (!tools?.length || toolChoice === "none") return;'
 ARG PARALLEL_PLUGIN_VERSION=2026.7.2-beta.5
 ARG PARALLEL_PLUGIN_ENDPOINT=https://search.parallel.ai/mcp
 RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund && \
@@ -401,6 +422,8 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
     test -f /opt/openclaw-plugins/amazon-bedrock/openclaw.plugin.json && \
     grep -Fq -- "${BEDROCK_PLUGIN_ASSERTION}" \
       /opt/openclaw-plugins/amazon-bedrock/dist/bedrock-options.js && \
+    grep -Fq -- "${BEDROCK_TOOLCONFIG_CANARY}" \
+      /opt/openclaw-plugins/amazon-bedrock/dist/stream.runtime.js && \
     cd /opt/openclaw-plugins && \
     npm pack "@openclaw/parallel-plugin@${PARALLEL_PLUGIN_VERSION}" && \
     tar -xzf "openclaw-parallel-plugin-${PARALLEL_PLUGIN_VERSION}.tgz" && \

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -294,22 +294,31 @@ COPY ${OPENCLAW_CONFIG} /home/node/.openclaw/openclaw.json
 # visible to the LLM. Keep roadmap notes here in the Dockerfile instead.
 # TODO(phase-2): Add Google Calendar and Gmail read-only tool access to the agent.
 #
-# Tier-1 enforcement: SOUL.md alone is auto-loaded, but the rules in
-# psd-rules SKILL.md are NOT auto-injected by OpenClaw — the model only
-# sees a Tier-2 catalog stub for any skill it has not explicitly loaded.
-# That meant the "non-negotiable" rules were never actually present in
-# the system prompt and the agent ignored them (observed 2026-05-03).
-# At build time we strip psd-rules' YAML frontmatter and append the body
-# to SOUL.md so the rules ARE in the system prompt every turn. The
-# canonical edit point stays `skills/psd-rules/SKILL.md`.
+# Tier-1 enforcement: the rules in psd-rules SKILL.md are NOT auto-injected by
+# OpenClaw — the model only sees a Tier-2 catalog stub for any skill it has not
+# explicitly loaded. That meant the "non-negotiable" rules were never actually
+# present in the system prompt and the agent ignored them (observed 2026-05-03).
+# At build time we strip psd-rules' YAML frontmatter and write the body into a
+# bootstrap file so the rules ARE in the system prompt every turn. The canonical
+# edit point stays `skills/psd-rules/SKILL.md`.
+#
+# The rules go in AGENTS.md, NOT appended to SOUL.md (changed 2026-08-06).
+# OpenClaw budgets bootstrap files PER FILE (bootstrapMaxChars) as well as in
+# total (bootstrapTotalMaxChars), and it loads AGENTS.md, TOOLS.md, HEARTBEAT.md
+# and BOOTSTRAP.md alongside SOUL.md whenever they exist. Concatenating the
+# ~22k-char rules body onto SOUL.md spent one file's entire 32k budget while the
+# combined total sat at 35k of 80k — so we were out of room in one file while
+# 45k went unused, and every rule addition had to be paid for by deleting
+# another. Splitting also matches the documented roles: AGENTS.md is operational
+# rules and routing, SOUL.md is identity and voice.
 ARG SOUL_PREAMBLE=SOUL.md
 ARG PSD_RULES_SKILL=skills/psd-rules/SKILL.md
 COPY ${SOUL_PREAMBLE} /tmp/SOUL.preamble.md
 COPY ${PSD_RULES_SKILL} /tmp/psd-rules.SKILL.md
 RUN awk 'BEGIN{f=0} /^---[[:space:]]*$/{f++; next} f>=2{print}' /tmp/psd-rules.SKILL.md > /tmp/psd-rules.body.md && \
     cat /tmp/SOUL.preamble.md > /home/node/.openclaw/SOUL.md && \
-    printf '\n\n---\n\n# Operating Rules (from psd-rules)\n\n_The following rules are concatenated from `skills/psd-rules/SKILL.md` at container build time so they are guaranteed to appear in every turn\xe2\x80\x99s system prompt. Edit them in that file, not here._\n\n' >> /home/node/.openclaw/SOUL.md && \
-    cat /tmp/psd-rules.body.md >> /home/node/.openclaw/SOUL.md && \
+    printf '# Operating Rules (from psd-rules)\n\n_Concatenated from `skills/psd-rules/SKILL.md` at container build time so these rules appear in every turn\xe2\x80\x99s system prompt. Edit them in that file, not here._\n\n' > /home/node/.openclaw/AGENTS.md && \
+    cat /tmp/psd-rules.body.md >> /home/node/.openclaw/AGENTS.md && \
     rm -f /tmp/SOUL.preamble.md /tmp/psd-rules.SKILL.md /tmp/psd-rules.body.md
 # OpenClaw also auto-loads IDENTITY.md, USER.md, MEMORY.md (and AGENTS.md,
 # TOOLS.md, HEARTBEAT.md, BOOTSTRAP.md) when present. We seed empty stubs so

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -55,6 +55,23 @@ You can only do what your enabled skills allow. Today that is:
 - **Upstream `gws-*` skills** for per-API Google Workspace guidance (Gmail, Drive, Docs, Sheets, Slides, Calendar, Chat, etc.)
 - **District data (`psd-data`).** PowerSchool/SIS enrollment, attendance, grades, rosters, discipline, and Red Rover staff absences. Row-level filtered; run `tables --detailed`. Never say no SIS/data tool exists — a missing table is a permissions answer, not a capability one.
 
+**Never say a capability does not exist without searching first.** Run
+`psd-skills-meta` → `skills.search("<the user's own words>")` before telling
+anyone a tool, skill, workflow or data source is unavailable. Search their
+vocabulary, not yours: someone asking about a "classified eval" will not match
+a skill that only says "evaluations".
+
+This has been wrong four times in four days — the agent denied SIS data it had
+(`psd-data`), denied a classified-evaluation workflow it had (`psd-workflows`),
+invented a rule that web chat cannot render cards, and told a user it could not
+read its own scheduled-run history. Every one cost a real request. "I could not
+find a tool for that, here is what I searched" is always better than a
+confident no.
+
+The gateway roster in `psd-workflows` is dynamic — evaluations, requests,
+timesheets and more are added without changing any file here. Never answer a
+workflow question from this prompt alone; ask the roster.
+
 You do **not** have built-in access to email, calendar, files outside the workspace, the open internet, or any external API except via a skill. Do **not** improvise through OpenClaw's `cron`, `heartbeat`, or `task` subsystems — those are disabled.
 
 Atrium artifacts persist live data through `window.AtriumData`; load `psd-atrium`
@@ -62,7 +79,7 @@ for the contract. Never use Google Sheets, `fetch`, or browser storage instead.
 
 ## Skill tiers
 
-1. **Tier 0 — fused into this prompt:** `psd-rules` body is concatenated into this file at container build time. The full rules are below; you always have them.
+1. **Tier 0 — fused into this prompt:** the `psd-rules` body is written to **`AGENTS.md`** at container build time and injected every turn alongside this file. You always have the full rules; read `AGENTS.md`, not the end of this file.
 2. **Tier 2 — catalog stub:** Name + one-line summary for every skill not listed above. Use `psd-skills-meta` → `skills.search("keyword")`.
 3. **Tier 3 — on-demand:** Per Rule 9, read a skill's current SKILL.md before
    its first invocation in every user turn, even when you believe you remember

--- a/infra/agent-image/check_bootstrap_budget.py
+++ b/infra/agent-image/check_bootstrap_budget.py
@@ -18,9 +18,10 @@ tracks the real runtime limits (32k / 80k today) automatically when they change.
 Two entry modes (one source of truth for the file set + budgets):
 
   * --source-dir DIR  (build gate, host-side, no Docker/creds needed)
-      Reconstructs the EFFECTIVE SOUL.md the Dockerfile builds
-      (SOUL.md + the psd-rules SKILL.md body) and checks it alongside the other
-      repo-provided bootstrap files. This is what runs in build-and-push.sh.
+      Reconstructs the EFFECTIVE bootstrap set the Dockerfile builds — SOUL.md
+      as-is, plus an AGENTS.md synthesised from the psd-rules SKILL.md body —
+      and checks them alongside the other repo-provided files. This is what
+      runs in build-and-push.sh.
 
   * --runtime-dir DIR (in-container / runtime)
       Checks the already-built files as they sit in /home/node/.openclaw. The
@@ -53,14 +54,14 @@ BOOTSTRAP_FILES: Tuple[str, ...] = (
     "BOOTSTRAP.md",
 )
 
-# Separator the Dockerfile prints between SOUL.md and the psd-rules body. Kept
+# Header the Dockerfile prints at the top of the generated AGENTS.md. Kept
 # byte-identical (including the U+2019 right single quote in "turn's") so the
 # reconstructed effective size matches the built file. If the Dockerfile's
 # printf changes, change it here too.
-_PSD_RULES_SEPARATOR = (
-    "\n\n---\n\n# Operating Rules (from psd-rules)\n\n"
-    "_The following rules are concatenated from `skills/psd-rules/SKILL.md` at "
-    "container build time so they are guaranteed to appear in every turn’s "
+_PSD_RULES_HEADER = (
+    "# Operating Rules (from psd-rules)\n\n"
+    "_Concatenated from `skills/psd-rules/SKILL.md` at "
+    "container build time so these rules appear in every turn’s "
     "system prompt. Edit them in that file, not here._\n\n"
 )
 
@@ -132,9 +133,11 @@ def _read(path: str) -> str:
 def effective_bootstrap_sizes(source_dir: str) -> Dict[str, int]:
     """Reconstruct the EFFECTIVE bootstrap file sizes the image builds.
 
-    SOUL.md is rebuilt as `SOUL.md + separator + psd-rules body` exactly like the
-    Dockerfile does; the other repo-provided files are measured as-is. Files not
-    present in the repo (runtime-seeded empty stubs) contribute 0 and are
+    The psd-rules body becomes AGENTS.md, not a suffix on SOUL.md (2026-08-06).
+    Budgets are enforced per file as well as in total, so appending ~22k chars
+    of rules to SOUL.md consumed one file's entire allowance while the combined
+    total sat at 35k of 80k — out of room in one file with 45k unused. Files
+    not present in the repo (runtime-seeded empty stubs) contribute 0 and are
     omitted from the report.
     """
     sizes: Dict[str, int] = {}
@@ -142,10 +145,11 @@ def effective_bootstrap_sizes(source_dir: str) -> Dict[str, int]:
     soul_path = os.path.join(source_dir, "SOUL.md")
     rules_path = os.path.join(source_dir, "skills", "psd-rules", "SKILL.md")
     if os.path.isfile(soul_path):
-        soul = _read(soul_path)
-        if os.path.isfile(rules_path):
-            soul = soul + _PSD_RULES_SEPARATOR + _strip_frontmatter(_read(rules_path))
-        sizes["SOUL.md"] = len(soul)
+        sizes["SOUL.md"] = len(_read(soul_path))
+    if os.path.isfile(rules_path):
+        sizes["AGENTS.md"] = len(
+            _PSD_RULES_HEADER + _strip_frontmatter(_read(rules_path))
+        )
 
     for name in BOOTSTRAP_FILES:
         if name == "SOUL.md":

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -202,6 +202,14 @@ def _format_for_chat(text: str) -> str:
 CONTEXT_OVERFLOW_ERROR_CLASS = "ContextOverflow"
 INCOMPLETE_TOOL_TURN_ERROR_CLASS = "OpenClawIncompleteToolTurn"
 
+# Upstream-failure retry (2026-08-06 Bedrock 5xx incident). One retry only:
+# the point is to absorb a transient fault, not to hammer a provider that is
+# already unwell. The latency bound keeps the retry to turns that failed at
+# the model call — the incident's turns died in ~6s — rather than something
+# that collapsed late in real work.
+UPSTREAM_RETRY_DELAY_S = 2.0
+UPSTREAM_RETRY_MAX_LATENCY_MS = 30_000
+
 
 def _classify_chat_error(error_message: str) -> str:
     """Name the chat-error class from OpenClaw's message.
@@ -771,6 +779,75 @@ class OpenClawAdapter(HarnessAdapter):
         return {**totals, "capture_complete": False}
 
     def process(
+        self,
+        message: str,
+        session_id: str,
+        model_override: Optional[str] = None,
+        deadline_s: Optional[int] = None,
+        _is_nudge: bool = False,
+    ) -> TurnResult:
+        """Run one turn, retrying once when the UPSTREAM model call fails
+        before any work happened.
+
+        On 2026-08-06 Bedrock returned 5xx for ~25 minutes (CloudWatch
+        InvocationServerErrors peaked at 26/5min, InvocationThrottles stayed
+        at zero — a server fault, not our quota). It cost 27 turns across 9
+        users. Every one of them died in ~6 seconds having executed NOTHING:
+        no tool calls, no output. A transient upstream fault at that point is
+        the one failure a turn can safely repeat, because there is nothing to
+        repeat.
+
+        Deliberately narrow. `_should_retry_upstream` demands the turn be
+        provably side-effect-free, so this never re-runs work: a turn that
+        already created a Doc is not retried, whatever it failed with.
+        """
+        attempt = self._process_once(
+            message, session_id, model_override, deadline_s, _is_nudge
+        )
+        if not self._should_retry_upstream(attempt):
+            return attempt
+        logger.warning(
+            "retrying turn after a clean upstream failure: error_class=%s "
+            "latency_ms=%d",
+            attempt.error_class,
+            attempt.latency_ms,
+        )
+        time.sleep(UPSTREAM_RETRY_DELAY_S)
+        retried = self._process_once(
+            message, session_id, model_override, deadline_s, _is_nudge
+        )
+        if retried.failed:
+            # Keep the retry's result — it is the more recent evidence — but
+            # say plainly that a retry happened, so a two-failure turn is not
+            # read as a single blip.
+            logger.error(
+                "upstream retry also failed: first=%s second=%s",
+                attempt.error_class,
+                retried.error_class,
+            )
+            return retried
+        logger.info("upstream retry recovered the turn")
+        return retried
+
+    @staticmethod
+    def _should_retry_upstream(result: TurnResult) -> bool:
+        """True only when replaying the turn cannot repeat a side effect.
+
+        ALL must hold: the turn failed; it failed as a generic upstream chat
+        error (not a deadline, overflow, or the incomplete-tool-turn class,
+        each of which OpenClaw already handles its own way); no tool call was
+        recorded; and it died fast enough that the failure was the model call
+        itself rather than something that happened mid-work.
+        """
+        if not result.failed:
+            return False
+        if result.error_class != "OpenClawChatError":
+            return False
+        if result.tool_calls:
+            return False
+        return result.latency_ms <= UPSTREAM_RETRY_MAX_LATENCY_MS
+
+    def _process_once(
         self,
         message: str,
         session_id: str,

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -165,6 +165,15 @@ class TurnResult:
     latency_ms: int = 0
     messages: List[Dict[str, Any]] = dataclasses.field(default_factory=list)
     tool_calls: List[Dict[str, Any]] = dataclasses.field(default_factory=list)
+    # Tools that STARTED and never reported a terminal result — i.e. what was
+    # still in `tool_starts` when the turn ended. A started-but-unfinished call
+    # never lands in `tool_calls`, so without this an interrupted side effect
+    # (the request reached the broker and created the Doc, its result event
+    # simply never arrived) looks identical to a turn that ran nothing. It is
+    # the most dangerous case, not the safest: `_should_retry_upstream` treats
+    # a nonzero value as replay-UNSAFE, and `_frame_failed_partial` already
+    # tells the user the same thing in prose.
+    tools_in_flight: int = 0
     # Set True when this turn is an error/degraded return (session conflict,
     # deadline, empty response, WS failure) rather than a real answer. The
     # wrapper forwards this to the router (metadata.failed) so a 0-token error
@@ -209,6 +218,15 @@ INCOMPLETE_TOOL_TURN_ERROR_CLASS = "OpenClawIncompleteToolTurn"
 # that collapsed late in real work.
 UPSTREAM_RETRY_DELAY_S = 2.0
 UPSTREAM_RETRY_MAX_LATENCY_MS = 30_000
+# The retry runs inside the ORIGINAL turn's budget, not on a fresh one: the
+# 550s interactive deadline exists to reserve the rest of the Router Lambda's
+# 15-minute ceiling for workspace flushing and delivery, and a second full
+# deadline would blow straight through it. The second attempt therefore gets
+# only what is left after the first attempt and the backoff. Below this floor
+# there is not enough turn left to be worth the attempt — and it is also
+# `_resolve_deadline_s`'s own lower clamp, so a smaller remainder would be
+# silently rounded back UP into an overshoot.
+UPSTREAM_RETRY_MIN_REMAINING_S = 60
 
 
 def _classify_chat_error(error_message: str) -> str:
@@ -801,20 +819,37 @@ class OpenClawAdapter(HarnessAdapter):
         provably side-effect-free, so this never re-runs work: a turn that
         already created a Doc is not retried, whatever it failed with.
         """
+        started_at = time.monotonic()
         attempt = self._process_once(
             message, session_id, model_override, deadline_s, _is_nudge
         )
         if not self._should_retry_upstream(attempt):
             return attempt
+        # Wall clock, not attempt.latency_ms: latency is measured from
+        # chat.send and so misses connection setup, which the retry must also
+        # pay for a second time.
+        elapsed_s = time.monotonic() - started_at
+        remaining_s = int(
+            self._resolve_deadline_s(deadline_s) - elapsed_s - UPSTREAM_RETRY_DELAY_S
+        )
+        if remaining_s < UPSTREAM_RETRY_MIN_REMAINING_S:
+            logger.warning(
+                "skipping upstream retry — only %ds of the turn budget left: "
+                "error_class=%s",
+                remaining_s,
+                attempt.error_class,
+            )
+            return attempt
         logger.warning(
             "retrying turn after a clean upstream failure: error_class=%s "
-            "latency_ms=%d",
+            "latency_ms=%d retry_deadline_s=%d",
             attempt.error_class,
             attempt.latency_ms,
+            remaining_s,
         )
         time.sleep(UPSTREAM_RETRY_DELAY_S)
         retried = self._process_once(
-            message, session_id, model_override, deadline_s, _is_nudge
+            message, session_id, model_override, remaining_s, _is_nudge
         )
         if retried.failed:
             # Keep the retry's result — it is the more recent evidence — but
@@ -836,14 +871,21 @@ class OpenClawAdapter(HarnessAdapter):
         ALL must hold: the turn failed; it failed as a generic upstream chat
         error (not a deadline, overflow, or the incomplete-tool-turn class,
         each of which OpenClaw already handles its own way); no tool call was
-        recorded; and it died fast enough that the failure was the model call
-        itself rather than something that happened mid-work.
+        recorded AND none was still in flight; and it died fast enough that the
+        failure was the model call itself rather than something that happened
+        mid-work.
+
+        `tools_in_flight` is not redundant with `tool_calls`. A tool that
+        started and never reported a terminal result is dropped from
+        `tool_calls` entirely, so a turn that had already asked the broker to
+        create a Doc can present an EMPTY tool_calls list. Retrying that would
+        create the Doc twice.
         """
         if not result.failed:
             return False
         if result.error_class != "OpenClawChatError":
             return False
-        if result.tool_calls:
+        if result.tool_calls or result.tools_in_flight:
             return False
         return result.latency_ms <= UPSTREAM_RETRY_MAX_LATENCY_MS
 
@@ -1487,6 +1529,7 @@ class OpenClawAdapter(HarnessAdapter):
                                 latency_ms=int((time.time() - chat_send_at) * 1000),
                                 messages=messages_log,
                                 tool_calls=tool_calls,
+                                tools_in_flight=len(tool_starts),
                                 failed=True,
                                 error_class=err_class,
                             )
@@ -1595,6 +1638,7 @@ class OpenClawAdapter(HarnessAdapter):
                                 latency_ms=int((time.time() - chat_send_at) * 1000),
                                 messages=messages_log,
                                 tool_calls=tool_calls,
+                                tools_in_flight=len(tool_starts),
                                 failed=True,
                                 error_class="OpenClawChatSendError",
                             )
@@ -1642,6 +1686,7 @@ class OpenClawAdapter(HarnessAdapter):
                 model=observed_model,
                 messages=messages_log,
                 tool_calls=tool_calls,
+                tools_in_flight=len(tool_starts),
                 failed=True,
                 error_class="WebSocketError",
             )
@@ -1687,6 +1732,7 @@ class OpenClawAdapter(HarnessAdapter):
                 latency_ms=latency_ms,
                 messages=log,
                 tool_calls=tool_calls,
+                tools_in_flight=len(tool_starts),
                 failed=failed,
                 error_class=error_class,
                 nudged=nudged,
@@ -1883,6 +1929,7 @@ class OpenClawAdapter(HarnessAdapter):
                     latency_ms=int((time.time() - chat_send_at) * 1000),
                     messages=messages_log + nudged.messages,
                     tool_calls=merged_tools,
+                    tools_in_flight=len(tool_starts) + nudged.tools_in_flight,
                     failed=nudged.failed,
                     error_class=nudged.error_class,
                     # The nudge fired and recovered a reply — record it so the

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -25,6 +25,7 @@
       "model": {
         "primary": "amazon-bedrock/us.anthropic.claude-sonnet-5"
       },
+      "bootstrapPromptTruncationWarning": "always",
       "bootstrapMaxChars": 32000,
       "bootstrapTotalMaxChars": 80000,
       "params": {

--- a/infra/agent-image/skills/psd-workflows/SKILL.md
+++ b/infra/agent-image/skills/psd-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-workflows
-summary: Discover and conduct PSD gateway workflows conversationally, including evaluations, requests, and timesheets, with verified caller binding and explicit confirmation before submission.
-description: Use the live PSD Agent Gateway roster to conduct a supported workflow in chat. Discover tools, load the selected family's schema, follow its categories and validation guidance, confirm a complete summary, submit only after explicit approval, and return any signing or completion link.
+summary: Discover and conduct PSD gateway workflows conversationally — classified and certificated staff evaluations, requests, and timesheets — with verified caller binding and explicit confirmation before submission.
+description: Use the live PSD Agent Gateway roster to conduct a supported workflow in chat. Covers classified staff evaluation, certificated evaluation, and any other evaluation family the gateway exposes — check the roster before telling a user no evaluation tool exists. Discover tools, load the selected family's schema, follow its categories and validation guidance, confirm a complete summary, submit only after explicit approval, and return any signing or completion link.
 allowed-tools: Bash(node:*)
 ---
 

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -160,16 +160,33 @@ is no way to fix it with more quoting. **Never inline document/email/event
 body text in `--json` or `--body`.** Instead, write the payload to a file
 first and reference it:
 
+**Write the payload file with the `write` tool, not a shell heredoc.** `write`
+takes the content as a parameter, so quotes, newlines and emoji never touch the
+shell. A `cat <<'PAYLOAD'` heredoc has to survive `exec`'s quoting, and an
+unterminated one leaves the shell sitting at a `>` continuation prompt with the
+call never issued — observed 2026-08-06, where a Slides build was abandoned
+after repeated attempts to generate the payload through `python3` + heredoc and
+the batchUpdate was never sent at all.
+
 ```bash
-# 1. Write the payload to a file (any quotes/newlines/emoji are fine here)
-cat > /tmp/doc-payload.json <<'PAYLOAD'
-{"requests":[{"insertText":{"location":{"index":1},"text":"It's fine to use \"both\" quote kinds.\n\nNew paragraphs too."}}]}
-PAYLOAD
+# 1. write  →  /tmp/doc-payload.json
+#    {"requests":[{"insertText":{"location":{"index":1},
+#     "text":"It's fine to use \"both\" quote kinds.\n\nNew paragraphs too."}}]}
+#    (use the `write` TOOL for this step — do not cat/heredoc it)
 
 # 2. Reference it with --json-file (replaces --json)
 node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "docs documents batchUpdate --params '{\"documentId\":\"<id>\"}' --json-file /tmp/doc-payload.json"
+
+# Slides and Sheets take the SAME shape — the rule is not Docs-specific.
+node /opt/psd-skills/psd-workspace/run.js \
+  --user hagelk@psd401.net \
+  --command "slides presentations batchUpdate --params '{\"presentationId\":\"<id>\"}' --json-file /tmp/slides-payload.json"
+
+node /opt/psd-skills/psd-workspace/run.js \
+  --user hagelk@psd401.net \
+  --command "sheets spreadsheets batchUpdate --params '{\"spreadsheetId\":\"<id>\"}' --json-file /tmp/sheet-payload.json"
 
 # Plain-text bodies (e.g. +draft) use --body-file (replaces --body)
 node /opt/psd-skills/psd-workspace/run.js \

--- a/infra/agent-image/test_check_bootstrap_budget.py
+++ b/infra/agent-image/test_check_bootstrap_budget.py
@@ -74,7 +74,10 @@ class StripFrontmatterTests(unittest.TestCase):
 
 
 class EffectiveSizesTests(unittest.TestCase):
-    def test_soul_includes_psd_rules_body(self):
+    def test_rules_body_becomes_agents_not_soul(self):
+        # 2026-08-06: the rules moved out of SOUL.md into AGENTS.md. Budgets are
+        # per file as well as total, so appending ~22k of rules to SOUL.md spent
+        # one file's whole allowance while 45k of the total went unused.
         d = tempfile.mkdtemp()
         _write(os.path.join(d, "SOUL.md"), "SOUL")
         os.makedirs(os.path.join(d, "skills", "psd-rules"))
@@ -83,9 +86,17 @@ class EffectiveSizesTests(unittest.TestCase):
             "---\nname: x\n---\nRULES BODY",
         )
         sizes = cbb.effective_bootstrap_sizes(d)
-        # SOUL.md effective = "SOUL" + separator + "RULES BODY" (frontmatter stripped)
-        expected = len("SOUL") + len(cbb._PSD_RULES_SEPARATOR) + len("RULES BODY")
-        self.assertEqual(sizes["SOUL.md"], expected)
+        self.assertEqual(sizes["SOUL.md"], len("SOUL"))
+        self.assertEqual(
+            sizes["AGENTS.md"],
+            len(cbb._PSD_RULES_HEADER) + len("RULES BODY"),
+        )
+
+    def test_agents_is_absent_without_a_rules_skill(self):
+        d = tempfile.mkdtemp()
+        _write(os.path.join(d, "SOUL.md"), "SOUL")
+        sizes = cbb.effective_bootstrap_sizes(d)
+        self.assertNotIn("AGENTS.md", sizes)
 
     def test_omits_absent_files(self):
         d = tempfile.mkdtemp()

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1168,6 +1168,161 @@ class TestUpstreamRetry(unittest.TestCase):
         self.assertTrue(result.failed)
         self.assertEqual(result.error_class, "OpenClawChatError")
 
+    def test_never_retries_a_turn_with_a_tool_still_in_flight(self):
+        # The dangerous case tool_calls alone cannot see: the call STARTED,
+        # may already have created the Doc, and its result event never
+        # arrived — so it never landed in tool_calls at all.
+        self.assertFalse(
+            OpenClawAdapter._should_retry_upstream(
+                self._result(tool_calls=[], tools_in_flight=1)
+            )
+        )
+
+    def test_a_started_tool_with_no_result_blocks_the_retry_end_to_end(self):
+        # The gate above is only real if _process_once actually populates the
+        # field, so drive a real turn: a tool STARTS, never reports back, and
+        # the turn then dies as a generic upstream error inside the latency
+        # bound. tool_calls is empty — the old predicate would have replayed
+        # it and asked the broker to run `edit` a second time.
+        chat_id = None
+
+        class FakeWebSocket:
+            def __init__(self, messages):
+                self.messages = list(messages)
+                self.sent = []
+
+            def send(self, payload):
+                nonlocal chat_id
+                parsed = json.loads(payload)
+                self.sent.append(parsed)
+                if parsed.get("method") == "chat.send":
+                    chat_id = parsed["id"]
+
+            def recv(self):
+                message = self.messages.pop(0)
+                return message() if callable(message) else message
+
+            def settimeout(self, _timeout):
+                return None
+
+            def close(self):
+                return None
+
+        def envelope(**fields):
+            return json.dumps(fields)
+
+        def current_run_event(event, payload):
+            return envelope(
+                type="event",
+                event=event,
+                payload={"runId": chat_id, **payload},
+            )
+
+        messages = [
+            envelope(type="event", event="connect.challenge", payload={}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={"tools": []}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={}),
+            lambda: envelope(type="res", id=chat_id, ok=True,
+                             payload={"runId": chat_id, "status": "started"}),
+            # Starts, and never reports a terminal result.
+            lambda: current_run_event(
+                "agent",
+                {
+                    "stream": "item",
+                    "data": {
+                        "itemId": "tool-901",
+                        "phase": "start",
+                        "kind": "tool",
+                        "name": "edit",
+                    },
+                },
+            ),
+            lambda: current_run_event(
+                "chat",
+                {"seq": 7, "state": "error", "errorMessage": "upstream boom"},
+            ),
+        ]
+        socket = FakeWebSocket(messages)
+        fake_websocket_module = mock.Mock()
+        fake_websocket_module.create_connection.return_value = socket
+        fake_websocket_module.WebSocketTimeoutException = TimeoutError
+        empty_usage = {
+            "input": 0,
+            "output": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+            "model_calls": 0,
+            "capture_complete": False,
+        }
+        adapter = OpenClawAdapter()
+        adapter._ready = True
+
+        with (
+            mock.patch.dict(sys.modules, {"websocket": fake_websocket_module}),
+            mock.patch.object(adapter, "_read_turn_usage",
+                              return_value=empty_usage),
+            mock.patch("harness_adapter.record_failure"),
+            mock.patch("harness_adapter.time.time", return_value=100.0),
+        ):
+            result = adapter._process_once("edit the doc", "s1", deadline_s=600)
+
+        self.assertEqual(result.error_class, "OpenClawChatError")
+        self.assertEqual(result.tool_calls, [], "the start never completed")
+        self.assertEqual(result.tools_in_flight, 1)
+        self.assertFalse(OpenClawAdapter._should_retry_upstream(result))
+
+    def test_retry_runs_inside_the_remaining_turn_budget(self):
+        # A second FULL deadline would blow through the 550s ceiling that
+        # reserves the rest of the Router invocation for flush + delivery.
+        adapter = OpenClawAdapter()
+        deadlines = []
+
+        def fake_once(message, session_id, model_override=None,
+                      deadline_s=None, _is_nudge=False):
+            deadlines.append(deadline_s)
+            if len(deadlines) == 1:
+                return self._result()
+            return harness_adapter.TurnResult(text="recovered", failed=False)
+
+        clock = iter([0.0, 25.0])
+        with mock.patch.object(adapter, "_process_once", side_effect=fake_once), \
+                mock.patch.object(harness_adapter.time, "sleep"), \
+                mock.patch.object(
+                    harness_adapter.time, "monotonic", side_effect=lambda: next(clock)
+                ):
+            adapter.process("x", "s1", deadline_s=550)
+
+        self.assertEqual(deadlines[0], 550)
+        # 550 budget - 25s spent - 2s backoff.
+        self.assertEqual(deadlines[1], 523)
+        self.assertLess(deadlines[1], deadlines[0])
+
+    def test_skips_the_retry_when_too_little_budget_remains(self):
+        # Below the floor there is not enough turn left to be worth it — and
+        # _resolve_deadline_s would clamp a smaller remainder back UP to 60,
+        # turning the guard into the very overshoot it exists to prevent.
+        adapter = OpenClawAdapter()
+        calls = []
+
+        def fake_once(*_a, **_kw):
+            calls.append(1)
+            return self._result()
+
+        clock = iter([0.0, 45.0])
+        with mock.patch.object(adapter, "_process_once", side_effect=fake_once), \
+                mock.patch.object(harness_adapter.time, "sleep"), \
+                mock.patch.object(
+                    harness_adapter.time, "monotonic", side_effect=lambda: next(clock)
+                ):
+            result = adapter.process("x", "s1", deadline_s=60)
+
+        self.assertEqual(len(calls), 1, "no budget left — must not retry")
+        self.assertTrue(result.failed)
+
 
 class TestRecordItemToolEvent(unittest.TestCase):
     """Native-mode tool items must land in tool_calls telemetry (#1138 r12)."""

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1064,6 +1064,111 @@ class TestQuestionEventEndsTurn(unittest.TestCase):
         record_failure.assert_not_called()
 
 
+class TestUpstreamRetry(unittest.TestCase):
+    """A clean upstream failure is the one thing a turn can safely repeat.
+
+    2026-08-06: Bedrock returned 5xx for ~25 minutes and cost 27 turns across
+    9 users. Every one died in ~6s having executed nothing — no tool calls, no
+    output. CloudWatch showed InvocationServerErrors peaking at 26/5min with
+    InvocationThrottles flat at zero, so it was a server fault, not our quota.
+    """
+
+    @staticmethod
+    def _result(**kw):
+        defaults = dict(text="", failed=True, error_class="OpenClawChatError",
+                        latency_ms=6000)
+        defaults.update(kw)
+        return harness_adapter.TurnResult(**defaults)
+
+    def test_retries_a_clean_upstream_failure(self):
+        self.assertTrue(
+            OpenClawAdapter._should_retry_upstream(self._result())
+        )
+
+    def test_never_retries_a_turn_that_ran_tools(self):
+        # The whole safety argument. A turn that created a Doc must not repeat.
+        self.assertFalse(
+            OpenClawAdapter._should_retry_upstream(
+                self._result(tool_calls=[{"name": "docs.create"}])
+            )
+        )
+
+    def test_never_retries_a_successful_turn(self):
+        self.assertFalse(
+            OpenClawAdapter._should_retry_upstream(
+                self._result(failed=False, error_class=None)
+            )
+        )
+
+    def test_leaves_classes_openclaw_already_handles_alone(self):
+        # Deadlines promote to the job path, overflow restarts fresh, and an
+        # incomplete tool turn is explicitly replay-unsafe.
+        for cls in (
+            "ChatDeadlineExpired",
+            "ChatDeadlineExpiredPartial",
+            "ContextOverflow",
+            harness_adapter.INCOMPLETE_TOOL_TURN_ERROR_CLASS,
+        ):
+            self.assertFalse(
+                OpenClawAdapter._should_retry_upstream(
+                    self._result(error_class=cls)
+                ),
+                cls,
+            )
+
+    def test_does_not_retry_a_turn_that_died_late(self):
+        # A late collapse is not "the model call failed" — something happened
+        # during real work, so replay is not provably safe.
+        self.assertFalse(
+            OpenClawAdapter._should_retry_upstream(
+                self._result(latency_ms=120_000)
+            )
+        )
+
+    def test_process_retries_once_and_returns_the_recovery(self):
+        adapter = OpenClawAdapter()
+        calls = []
+
+        def fake_once(message, session_id, model_override=None,
+                      deadline_s=None, _is_nudge=False):
+            calls.append(message)
+            if len(calls) == 1:
+                return self._result()
+            return harness_adapter.TurnResult(text="recovered", failed=False)
+
+        with mock.patch.object(adapter, "_process_once", side_effect=fake_once), \
+                mock.patch.object(harness_adapter.time, "sleep"):
+            result = adapter.process("chart attendance", "s1")
+
+        self.assertEqual(len(calls), 2)
+        self.assertFalse(result.failed)
+        self.assertEqual(result.text, "recovered")
+
+    def test_process_does_not_retry_when_unsafe(self):
+        adapter = OpenClawAdapter()
+        calls = []
+
+        def fake_once(*_a, **_kw):
+            calls.append(1)
+            return self._result(tool_calls=[{"name": "write"}])
+
+        with mock.patch.object(adapter, "_process_once", side_effect=fake_once), \
+                mock.patch.object(harness_adapter.time, "sleep"):
+            result = adapter.process("do work", "s1")
+
+        self.assertEqual(len(calls), 1, "a tool-running turn must not repeat")
+        self.assertTrue(result.failed)
+
+    def test_a_second_failure_returns_the_retry_result(self):
+        adapter = OpenClawAdapter()
+        with mock.patch.object(
+            adapter, "_process_once", side_effect=lambda *a, **k: self._result()
+        ), mock.patch.object(harness_adapter.time, "sleep"):
+            result = adapter.process("x", "s1")
+        self.assertTrue(result.failed)
+        self.assertEqual(result.error_class, "OpenClawChatError")
+
+
 class TestRecordItemToolEvent(unittest.TestCase):
     """Native-mode tool items must land in tool_calls telemetry (#1138 r12)."""
 


### PR DESCRIPTION
## 1. One retry when the model call fails before any work happened

The 2026-08-06 Bedrock incident cost **27 turns across 9 users** in ~25 minutes. CloudWatch confirms the shape:

| Metric | Value |
|---|---|
| `InvocationServerErrors` | peaked **26 per 5 min** |
| `InvocationThrottles` | **flat at zero** |

A server fault, not our quota — nothing a limit increase would have prevented. And every one of those turns died in **~6 seconds having executed nothing**: no tool calls, no output.

That's the one failure a turn can safely repeat, because there is nothing to repeat.

`_should_retry_upstream` requires the turn be **provably side-effect-free** before retrying — it failed, as a generic `OpenClawChatError`, with no tool call recorded, inside 30s. A turn that already created a Doc is never retried, whatever it failed with. The classes OpenClaw handles its own way are left alone: deadlines promote to the job path, overflow restarts fresh, and an incomplete tool turn is explicitly `replaySafe=no`.

**One retry only** — the point is to absorb a transient fault, not to hammer a provider that is already unwell.

## 2. A canary for the upstream `toolConfig` bug

This answers "how will we know when OpenClaw fixes it, and how do we avoid colliding with their fix?"

**The bug.** `convertToolConfig` returns `undefined` when tools are empty or `toolChoice === "none"`:

```js
if (!tools?.length || toolChoice === "none") return;
```

So OpenClaw's tools-disabled *"settled post-tool turn"* finalization sends a Converse request with no `toolConfig` while the history still carries `toolUse`/`toolResult` blocks. Bedrock rejects that combination outright:

> `Validation error: The toolConfig field must be defined when using toolUse and toolResult content blocks.`

The recovery call **can never succeed**, so a turn that had already run 1–2 tools fails hard. Nine occurrences across eight users, 2026-08-04..06, with an identical signature — `response_chars=0`, `seq=19` at one tool, `seq=25` at two.

**The irony:** `check_config_consistency.py` pins `_SETTLED_TOOL_RECOVERY_MIN = "2026.7.2-beta.5"` *specifically to guarantee this finalization exists* (#1469). The recovery path we required is the one that's broken.

**Not fixed upstream.** I diffed `2026.7.2-beta.7` against `beta.5`: the `dist` directories are **byte-identical**. Upgrading changes nothing.

**The decision.** We chose to live with the bug rather than patch a vendored dependency that runs on every turn and can't be verified locally without a live Bedrock call.

**So this PR adds a canary instead of a patch.** `BEDROCK_TOOLCONFIG_CANARY` asserts the broken line is **still present**. The build fails the moment upstream edits it — which is the signal to re-test the finalization path and delete the ARG.

Two things it buys:
- Without it we'd carry a known-broken recovery path indefinitely and never notice the fix landing.
- If we ever *do* patch, the same canary is what stops our patch and theirs from silently colliding — the build breaks instead of double-fixing.

I verified the canary string matches the shipped `dist` of **both** beta.5 and beta.7, so it passes today and is a real assertion rather than a no-op.

## Verification

- agent-image Python suite exactly as CI invokes it (all 20 files, `unittest`, 3.12): **716 tests, OK**
- config-consistency and bootstrap-budget gates passing
- `bun run lint` clean at `--max-warnings 0`; `bun run typecheck` clean

Eight new retry tests cover the safety gate from both directions: it fires on a clean upstream failure, and refuses on a tool-running turn, a successful turn, a late collapse, and each class OpenClaw already recovers itself.

## Still open, deliberately

- **`EmptyAgentResponse`** — 10 rows / 2 users, and 8 are stittd's *overnight* runs (00:52, 03:34, 04:19, 04:45, 04:46, 05:42, 05:45). That pattern says scheduled runs, not chat. Two distinct context shapes, one of which is `{"event:chat": 1}` and nothing else. Wants its own diagnosis rather than a guess.
- **`psd-data` JOIN failures** — warehouse-side, with the data engineer.
- **hudacn's Drive auto-sort** — `drive.file` can't write to shared-with-me files; an OAuth scope decision, not a code fix.

## Checklist

- [x] No `console.*` in production code
- [x] Lint passes at `--max-warnings 0`
- [x] Typecheck passes
- [x] All tests pass
- [x] No `any` types; no new type assertions
- [x] No secrets or environment variables added
- [ ] Code reviewed and approved — pending
