### PR TITLE
fix(agent-image): drop bootstrapPromptTruncationWarning — not a key our host accepts

### DIFF
--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -25,7 +25,6 @@
       "model": {
         "primary": "amazon-bedrock/us.anthropic.claude-sonnet-5"
       },
-      "bootstrapPromptTruncationWarning": "always",
       "bootstrapMaxChars": 32000,
       "bootstrapTotalMaxChars": 80000,
       "params": {


### PR DESCRIPTION
Build fix for the image blocked on #1614.

The Docker build failed at `openclaw config validate`:

```
openclaw.json:24 — agents.defaults: Unrecognized key: "bootstrapPromptTruncationWarning"
```

The setting is documented upstream, but the host we pin (`2026.7.2-beta.5`) doesn't accept it — and an unrecognized key makes the **whole config invalid** rather than being ignored. I took it from the docs without checking it against the pinned version.

**Nothing is lost by removing it.** `check_bootstrap_budget.py` already fails the build when any bootstrap file is over budget, and `check_runtime_bootstrap()` emits a WARN plus a CloudWatch metric if a live image is ever over budget despite the gate. Truncation is still caught at both build and runtime — which is what the setting was meant to add.

**Worth noting the sequencing:** the `BEDROCK_TOOLCONFIG_CANARY` grep added in the same change **passed**. The build got past it to config validation, so the canary is matching the shipped dist as intended.

## Verification

- `check_config_consistency.py` and `check_bootstrap_budget.py` both pass
- agent-image config/budget/candidate-matrix suites pass
- E2E green via the pre-push gate

Bootstrap layout after #1614 is unchanged by this: SOUL.md 11,182 · AGENTS.md 21,767 · total 36,124 / 80,000.