### PR TITLE
fix(agent): exclude AGENTS.md from workspace sync so the rules survive cold start

### DIFF
--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -3331,11 +3331,27 @@ class ImageOwnedBootstrapExclusionTests(unittest.TestCase):
                 "stop the agent's own memory from persisting",
             )
 
-    def test_the_rules_file_the_dockerfile_writes_is_covered(self):
-        # Ties the exclusion to the Dockerfile rather than to a literal: if the
+    def test_every_bootstrap_file_the_dockerfile_generates_is_covered(self):
+        # Ties the exclusion to the Dockerfile rather than to a literal: if a
         # generated bootstrap filename changes, this fails instead of silently
-        # leaving the new name unexcluded.
+        # leaving the new name unprotected.
+        #
+        # EVERY redirect target, not the first. `re.search` returned SOUL.md —
+        # which is excluded — so the test passed while asserting nothing about
+        # AGENTS.md, the very file it was written to guard. Renaming AGENTS.md
+        # would not have failed it.
         dockerfile = pathlib.Path(__file__).with_name("Dockerfile").read_text()
-        match = re.search(r"> /home/node/\.openclaw/([A-Z]+\.md)", dockerfile)
-        self.assertIsNotNone(match, "no generated bootstrap file found in the Dockerfile")
-        self.assertIn(match.group(1), workspace_sync._SKIP_RELATIVE_PREFIXES)
+        generated = set(
+            re.findall(r"> /home/node/\.openclaw/([A-Za-z]+\.md)", dockerfile)
+        )
+        self.assertTrue(generated, "no generated bootstrap file found in the Dockerfile")
+        # Both files the image generates today; a new one must be added here
+        # AND to the policy, which is the point of the check.
+        self.assertEqual(generated, {"SOUL.md", "AGENTS.md"})
+        for name in sorted(generated):
+            self.assertIn(
+                name,
+                workspace_sync._SKIP_RELATIVE_PREFIXES,
+                f"the Dockerfile generates {name} but workspace sync would "
+                "overwrite it from S3 on cold start",
+            )

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -20,6 +20,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import re
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -3293,3 +3294,48 @@ class SQLitePersistenceTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ImageOwnedBootstrapExclusionTests(unittest.TestCase):
+    """Every image-owned bootstrap file must be excluded from workspace sync.
+
+    An image-owned file that is NOT excluded gets overwritten on cold-start by
+    each user's S3 workspace, which predates it. It then works perfectly for a
+    brand-new user and is silently absent for everyone else — which is exactly
+    how it hides. This happened to SOUL.md on 2026-04-22 and again to AGENTS.md
+    on 2026-08-07, when the operating rules moved into their own bootstrap file
+    and the agent reported having no rules in context.
+
+    IDENTITY/USER/MEMORY are deliberately NOT here: those are agent-written and
+    user-owned, and must round-trip.
+    """
+
+    IMAGE_OWNED = ("SOUL.md", "AGENTS.md")
+    USER_OWNED = ("IDENTITY.md", "USER.md", "MEMORY.md")
+
+    def test_image_owned_bootstrap_files_never_sync(self):
+        for name in self.IMAGE_OWNED:
+            self.assertIn(
+                name,
+                workspace_sync._SKIP_RELATIVE_PREFIXES,
+                f"{name} is image-owned and must be excluded from sync, or a "
+                "pre-existing user's S3 workspace will overwrite it on pull",
+            )
+
+    def test_user_owned_memory_files_still_round_trip(self):
+        for name in self.USER_OWNED:
+            self.assertNotIn(
+                name,
+                workspace_sync._SKIP_RELATIVE_PREFIXES,
+                f"{name} is agent-written and user-owned; excluding it would "
+                "stop the agent's own memory from persisting",
+            )
+
+    def test_the_rules_file_the_dockerfile_writes_is_covered(self):
+        # Ties the exclusion to the Dockerfile rather than to a literal: if the
+        # generated bootstrap filename changes, this fails instead of silently
+        # leaving the new name unexcluded.
+        dockerfile = pathlib.Path(__file__).with_name("Dockerfile").read_text()
+        match = re.search(r"> /home/node/\.openclaw/([A-Z]+\.md)", dockerfile)
+        self.assertIsNotNone(match, "no generated bootstrap file found in the Dockerfile")
+        self.assertIn(match.group(1), workspace_sync._SKIP_RELATIVE_PREFIXES)

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -684,6 +684,16 @@ def _materialize_empty_workspace_file(
 # intentionally NOT on this list — those are agent-written, user-owned,
 # and must round-trip.
 #
+# AGENTS.md joined this list on 2026-08-07 after the identical failure
+# recurred: the operating rules moved out of SOUL.md into their own bootstrap
+# file, every existing user's S3 workspace predated that file, and the
+# cold-start pull overwrote the workspace without it. The image wrote AGENTS.md
+# correctly and the host supports it — it simply was not present by the time the
+# prompt was built, so the agent reported having no rules in context. It worked
+# for a brand-new user and failed for everyone else, which is what made it look
+# like the split itself had failed. ANY image-owned bootstrap file has to be
+# added here the moment it is introduced.
+#
 # Exact paths and prefix paths are separate so retiring one generated control
 # file can never hide similarly named user content. The values live in
 # workspace_policy.json so the web checkpoint and image runtime cannot

--- a/lib/agent-workspace/workspace-policy.json
+++ b/lib/agent-workspace/workspace-policy.json
@@ -5,14 +5,38 @@
     "maxSegmentUtf8Bytes": 255,
     "maxDepth": 64,
     "rejectedCodePointRanges": [
-      [0, 31],
-      [92, 92],
-      [127, 159],
-      [1564, 1564],
-      [8206, 8207],
-      [8232, 8238],
-      [8294, 8297],
-      [55296, 57343]
+      [
+        0,
+        31
+      ],
+      [
+        92,
+        92
+      ],
+      [
+        127,
+        159
+      ],
+      [
+        1564,
+        1564
+      ],
+      [
+        8206,
+        8207
+      ],
+      [
+        8232,
+        8238
+      ],
+      [
+        8294,
+        8297
+      ],
+      [
+        55296,
+        57343
+      ]
     ]
   },
   "checkpointExclusions": {
@@ -27,6 +51,7 @@
       "logs/",
       "update-check.json",
       ".openclaw/",
+      "AGENTS.md",
       "SOUL.md",
       "skills/gws-",
       "skills/psd-brand-guidelines/",


### PR DESCRIPTION
Caught on dev immediately after deploying the bootstrap split in #1614. **The dev image currently ships with no operating rules in the system prompt.**

Asked to quote Rule 4 and Rule 9 without loading anything, the agent replied *"the psd-rules skill content isn't loaded into my context right now."*

## The split was fine — the file was being deleted

Verified in the built image:
- `/home/node/.openclaw/AGENTS.md` is written correctly — **21,915 bytes**
- The pinned host recognises the filename — **90 references** in `/app/dist`, more than `SOUL.md`'s 39

The file simply wasn't there by the time the prompt was assembled.

`workspace_sync` pulls each owner's workspace from S3 on cold start. Files owned by the **image** rather than the **user** must be excluded from that sync or the pull overwrites them. `SOUL.md` is on that list; `AGENTS.md` was not. Every existing user's S3 workspace predates `AGENTS.md`, so the pull replaced the workspace without it.

This is the same bug the exclusion list's own comment documents from **2026-04-22**, when an old `SOUL.md` in each user's workspace kept overwriting the image's fresh one and new rules *"never seemed to take"*. Identical shape, identical cause, one file later.

## Why it hid so well

An image-owned file that isn't excluded works **perfectly for a brand-new user** and is **silently absent for everyone else**. Two of the three post-deploy checks passed for exactly that reason — they don't depend on `AGENTS.md`. Only the check written specifically to detect this caught it.

## The fix

Add `AGENTS.md` to `checkpointExclusions.relativePrefixes` in `workspace-policy.json` — read by **both** the image runtime and the web checkpoint, so the two can't drift into different definitions of durable state.

Nothing moved. The rules stay in `AGENTS.md`; the sync layer now leaves them alone, exactly as it does for `SOUL.md`.

| Kind | Files | Behavior |
|---|---|---|
| Image-owned | `SOUL.md`, **`AGENTS.md`**, `openclaw.json` | Never synced — image copy always wins |
| User-owned | `IDENTITY.md`, `USER.md`, `MEMORY.md` | Must round-trip — agent-written |

`AGENTS.md` was in neither bucket. That's the whole bug.

## Tests — mutation-checked

Removing `AGENTS.md` from the policy fails two of the three:

- every image-owned bootstrap file is excluded from sync
- `IDENTITY`/`USER`/`MEMORY` are **not** excluded — those are agent-written and must round-trip; excluding them would stop the agent's memory persisting
- the generated bootstrap filename is read **out of the Dockerfile** rather than hardcoded, so renaming it fails the test instead of silently leaving the new name unprotected

## Verification

- Full unit suite; agent-image `workspace_sync` **84 tests**
- bootstrap-budget and config-consistency gates
- `bun run lint` clean at `--max-warnings 0`; `bun run typecheck` clean

## Checklist

- [x] No `console.*` in production code
- [x] Lint passes at `--max-warnings 0`
- [x] Typecheck passes
- [x] All tests pass
- [x] No secrets or environment variables added
- [ ] Code reviewed and approved — pending
