### PR TITLE
fix(agent): put the operating rules back in SOUL.md and raise the per-file cap

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -294,31 +294,22 @@ COPY ${OPENCLAW_CONFIG} /home/node/.openclaw/openclaw.json
 # visible to the LLM. Keep roadmap notes here in the Dockerfile instead.
 # TODO(phase-2): Add Google Calendar and Gmail read-only tool access to the agent.
 #
-# Tier-1 enforcement: the rules in psd-rules SKILL.md are NOT auto-injected by
-# OpenClaw — the model only sees a Tier-2 catalog stub for any skill it has not
-# explicitly loaded. That meant the "non-negotiable" rules were never actually
-# present in the system prompt and the agent ignored them (observed 2026-05-03).
-# At build time we strip psd-rules' YAML frontmatter and write the body into a
-# bootstrap file so the rules ARE in the system prompt every turn. The canonical
-# edit point stays `skills/psd-rules/SKILL.md`.
-#
-# The rules go in AGENTS.md, NOT appended to SOUL.md (changed 2026-08-06).
-# OpenClaw budgets bootstrap files PER FILE (bootstrapMaxChars) as well as in
-# total (bootstrapTotalMaxChars), and it loads AGENTS.md, TOOLS.md, HEARTBEAT.md
-# and BOOTSTRAP.md alongside SOUL.md whenever they exist. Concatenating the
-# ~22k-char rules body onto SOUL.md spent one file's entire 32k budget while the
-# combined total sat at 35k of 80k — so we were out of room in one file while
-# 45k went unused, and every rule addition had to be paid for by deleting
-# another. Splitting also matches the documented roles: AGENTS.md is operational
-# rules and routing, SOUL.md is identity and voice.
+# Tier-1 enforcement: SOUL.md alone is auto-loaded, but the rules in
+# psd-rules SKILL.md are NOT auto-injected by OpenClaw — the model only
+# sees a Tier-2 catalog stub for any skill it has not explicitly loaded.
+# That meant the "non-negotiable" rules were never actually present in
+# the system prompt and the agent ignored them (observed 2026-05-03).
+# At build time we strip psd-rules' YAML frontmatter and append the body
+# to SOUL.md so the rules ARE in the system prompt every turn. The
+# canonical edit point stays `skills/psd-rules/SKILL.md`.
 ARG SOUL_PREAMBLE=SOUL.md
 ARG PSD_RULES_SKILL=skills/psd-rules/SKILL.md
 COPY ${SOUL_PREAMBLE} /tmp/SOUL.preamble.md
 COPY ${PSD_RULES_SKILL} /tmp/psd-rules.SKILL.md
 RUN awk 'BEGIN{f=0} /^---[[:space:]]*$/{f++; next} f>=2{print}' /tmp/psd-rules.SKILL.md > /tmp/psd-rules.body.md && \
     cat /tmp/SOUL.preamble.md > /home/node/.openclaw/SOUL.md && \
-    printf '# Operating Rules (from psd-rules)\n\n_Concatenated from `skills/psd-rules/SKILL.md` at container build time so these rules appear in every turn\xe2\x80\x99s system prompt. Edit them in that file, not here._\n\n' > /home/node/.openclaw/AGENTS.md && \
-    cat /tmp/psd-rules.body.md >> /home/node/.openclaw/AGENTS.md && \
+    printf '\n\n---\n\n# Operating Rules (from psd-rules)\n\n_The following rules are concatenated from `skills/psd-rules/SKILL.md` at container build time so they are guaranteed to appear in every turn\xe2\x80\x99s system prompt. Edit them in that file, not here._\n\n' >> /home/node/.openclaw/SOUL.md && \
+    cat /tmp/psd-rules.body.md >> /home/node/.openclaw/SOUL.md && \
     rm -f /tmp/SOUL.preamble.md /tmp/psd-rules.SKILL.md /tmp/psd-rules.body.md
 # OpenClaw also auto-loads IDENTITY.md, USER.md, MEMORY.md (and AGENTS.md,
 # TOOLS.md, HEARTBEAT.md, BOOTSTRAP.md) when present. We seed empty stubs so

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -79,7 +79,7 @@ for the contract. Never use Google Sheets, `fetch`, or browser storage instead.
 
 ## Skill tiers
 
-1. **Tier 0 — fused into this prompt:** the `psd-rules` body is written to **`AGENTS.md`** at container build time and injected every turn alongside this file. You always have the full rules; read `AGENTS.md`, not the end of this file.
+1. **Tier 0 — fused into this prompt:** the `psd-rules` body is concatenated into this file at container build time. The full rules are below; you always have them.
 2. **Tier 2 — catalog stub:** Name + one-line summary for every skill not listed above. Use `psd-skills-meta` → `skills.search("keyword")`.
 3. **Tier 3 — on-demand:** Per Rule 9, read a skill's current SKILL.md before
    its first invocation in every user turn, even when you believe you remember

--- a/infra/agent-image/check_bootstrap_budget.py
+++ b/infra/agent-image/check_bootstrap_budget.py
@@ -18,10 +18,9 @@ tracks the real runtime limits (32k / 80k today) automatically when they change.
 Two entry modes (one source of truth for the file set + budgets):
 
   * --source-dir DIR  (build gate, host-side, no Docker/creds needed)
-      Reconstructs the EFFECTIVE bootstrap set the Dockerfile builds — SOUL.md
-      as-is, plus an AGENTS.md synthesised from the psd-rules SKILL.md body —
-      and checks them alongside the other repo-provided files. This is what
-      runs in build-and-push.sh.
+      Reconstructs the EFFECTIVE SOUL.md the Dockerfile builds
+      (SOUL.md + the psd-rules SKILL.md body) and checks it alongside the other
+      repo-provided bootstrap files. This is what runs in build-and-push.sh.
 
   * --runtime-dir DIR (in-container / runtime)
       Checks the already-built files as they sit in /home/node/.openclaw. The
@@ -54,14 +53,14 @@ BOOTSTRAP_FILES: Tuple[str, ...] = (
     "BOOTSTRAP.md",
 )
 
-# Header the Dockerfile prints at the top of the generated AGENTS.md. Kept
+# Separator the Dockerfile prints between SOUL.md and the psd-rules body. Kept
 # byte-identical (including the U+2019 right single quote in "turn's") so the
 # reconstructed effective size matches the built file. If the Dockerfile's
 # printf changes, change it here too.
-_PSD_RULES_HEADER = (
-    "# Operating Rules (from psd-rules)\n\n"
-    "_Concatenated from `skills/psd-rules/SKILL.md` at "
-    "container build time so these rules appear in every turn’s "
+_PSD_RULES_SEPARATOR = (
+    "\n\n---\n\n# Operating Rules (from psd-rules)\n\n"
+    "_The following rules are concatenated from `skills/psd-rules/SKILL.md` at "
+    "container build time so they are guaranteed to appear in every turn’s "
     "system prompt. Edit them in that file, not here._\n\n"
 )
 
@@ -133,11 +132,9 @@ def _read(path: str) -> str:
 def effective_bootstrap_sizes(source_dir: str) -> Dict[str, int]:
     """Reconstruct the EFFECTIVE bootstrap file sizes the image builds.
 
-    The psd-rules body becomes AGENTS.md, not a suffix on SOUL.md (2026-08-06).
-    Budgets are enforced per file as well as in total, so appending ~22k chars
-    of rules to SOUL.md consumed one file's entire allowance while the combined
-    total sat at 35k of 80k — out of room in one file with 45k unused. Files
-    not present in the repo (runtime-seeded empty stubs) contribute 0 and are
+    SOUL.md is rebuilt as `SOUL.md + separator + psd-rules body` exactly like the
+    Dockerfile does; the other repo-provided files are measured as-is. Files not
+    present in the repo (runtime-seeded empty stubs) contribute 0 and are
     omitted from the report.
     """
     sizes: Dict[str, int] = {}
@@ -145,11 +142,10 @@ def effective_bootstrap_sizes(source_dir: str) -> Dict[str, int]:
     soul_path = os.path.join(source_dir, "SOUL.md")
     rules_path = os.path.join(source_dir, "skills", "psd-rules", "SKILL.md")
     if os.path.isfile(soul_path):
-        sizes["SOUL.md"] = len(_read(soul_path))
-    if os.path.isfile(rules_path):
-        sizes["AGENTS.md"] = len(
-            _PSD_RULES_HEADER + _strip_frontmatter(_read(rules_path))
-        )
+        soul = _read(soul_path)
+        if os.path.isfile(rules_path):
+            soul = soul + _PSD_RULES_SEPARATOR + _strip_frontmatter(_read(rules_path))
+        sizes["SOUL.md"] = len(soul)
 
     for name in BOOTSTRAP_FILES:
         if name == "SOUL.md":

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -25,7 +25,7 @@
       "model": {
         "primary": "amazon-bedrock/us.anthropic.claude-sonnet-5"
       },
-      "bootstrapMaxChars": 32000,
+      "bootstrapMaxChars": 64000,
       "bootstrapTotalMaxChars": 80000,
       "params": {
         "cacheRetention": "long"

--- a/infra/agent-image/test_check_bootstrap_budget.py
+++ b/infra/agent-image/test_check_bootstrap_budget.py
@@ -8,6 +8,7 @@ import json
 import os
 import sys
 import tempfile
+import pathlib
 import unittest
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -74,10 +75,7 @@ class StripFrontmatterTests(unittest.TestCase):
 
 
 class EffectiveSizesTests(unittest.TestCase):
-    def test_rules_body_becomes_agents_not_soul(self):
-        # 2026-08-06: the rules moved out of SOUL.md into AGENTS.md. Budgets are
-        # per file as well as total, so appending ~22k of rules to SOUL.md spent
-        # one file's whole allowance while 45k of the total went unused.
+    def test_soul_includes_psd_rules_body(self):
         d = tempfile.mkdtemp()
         _write(os.path.join(d, "SOUL.md"), "SOUL")
         os.makedirs(os.path.join(d, "skills", "psd-rules"))
@@ -86,17 +84,9 @@ class EffectiveSizesTests(unittest.TestCase):
             "---\nname: x\n---\nRULES BODY",
         )
         sizes = cbb.effective_bootstrap_sizes(d)
-        self.assertEqual(sizes["SOUL.md"], len("SOUL"))
-        self.assertEqual(
-            sizes["AGENTS.md"],
-            len(cbb._PSD_RULES_HEADER) + len("RULES BODY"),
-        )
-
-    def test_agents_is_absent_without_a_rules_skill(self):
-        d = tempfile.mkdtemp()
-        _write(os.path.join(d, "SOUL.md"), "SOUL")
-        sizes = cbb.effective_bootstrap_sizes(d)
-        self.assertNotIn("AGENTS.md", sizes)
+        # SOUL.md effective = "SOUL" + separator + "RULES BODY" (frontmatter stripped)
+        expected = len("SOUL") + len(cbb._PSD_RULES_SEPARATOR) + len("RULES BODY")
+        self.assertEqual(sizes["SOUL.md"], expected)
 
     def test_omits_absent_files(self):
         d = tempfile.mkdtemp()
@@ -158,3 +148,52 @@ class MainCliTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class InjectedBootstrapSetTests(unittest.TestCase):
+    """The budget gate must model the files the host actually injects.
+
+    2026-08-07: operating rules were moved into AGENTS.md on the belief that it
+    was a bootstrap file. It is not, in the host we pin. `openclaw config
+    schema` enumerates the optional bootstrap files as SOUL/USER/IDENTITY/
+    HEARTBEAT, and this host uses AGENTS.md for post-compaction re-injection of
+    named sections instead. The rules were never injected, and the sync
+    exclusion added to "fix" it retired a path already in S3, which broke every
+    workspace restore on dev.
+
+    These assert the gate keeps measuring SOUL.md as the file that carries the
+    rules, so a future move cannot silently pass the budget check while the
+    prompt loses its rules.
+    """
+
+    def test_rules_are_measured_as_part_of_soul(self):
+        d = tempfile.mkdtemp()
+        _write(os.path.join(d, "SOUL.md"), "SOUL")
+        os.makedirs(os.path.join(d, "skills", "psd-rules"))
+        _write(
+            os.path.join(d, "skills", "psd-rules", "SKILL.md"),
+            "---\nname: x\n---\nRULES BODY",
+        )
+        sizes = cbb.effective_bootstrap_sizes(d)
+        self.assertGreater(
+            sizes["SOUL.md"],
+            len("SOUL") + len("RULES BODY"),
+            "the rules body must be measured inside SOUL.md",
+        )
+        self.assertNotIn(
+            "AGENTS.md",
+            sizes,
+            "AGENTS.md is not injected by this host — it must not be treated "
+            "as a bootstrap file",
+        )
+
+    def test_the_dockerfile_writes_the_rules_into_soul(self):
+        # Tied to the Dockerfile so moving the rules elsewhere fails here
+        # rather than silently removing them from the prompt.
+        dockerfile = pathlib.Path(__file__).with_name("Dockerfile").read_text()
+        self.assertRegex(
+            dockerfile,
+            r"psd-rules\.body\.md >> /home/node/\.openclaw/SOUL\.md",
+            "the psd-rules body must be appended to SOUL.md — the only file "
+            "this host injects that can carry it",
+        )

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -20,7 +20,6 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
-import re
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -3294,64 +3293,3 @@ class SQLitePersistenceTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-
-class ImageOwnedBootstrapExclusionTests(unittest.TestCase):
-    """Every image-owned bootstrap file must be excluded from workspace sync.
-
-    An image-owned file that is NOT excluded gets overwritten on cold-start by
-    each user's S3 workspace, which predates it. It then works perfectly for a
-    brand-new user and is silently absent for everyone else — which is exactly
-    how it hides. This happened to SOUL.md on 2026-04-22 and again to AGENTS.md
-    on 2026-08-07, when the operating rules moved into their own bootstrap file
-    and the agent reported having no rules in context.
-
-    IDENTITY/USER/MEMORY are deliberately NOT here: those are agent-written and
-    user-owned, and must round-trip.
-    """
-
-    IMAGE_OWNED = ("SOUL.md", "AGENTS.md")
-    USER_OWNED = ("IDENTITY.md", "USER.md", "MEMORY.md")
-
-    def test_image_owned_bootstrap_files_never_sync(self):
-        for name in self.IMAGE_OWNED:
-            self.assertIn(
-                name,
-                workspace_sync._SKIP_RELATIVE_PREFIXES,
-                f"{name} is image-owned and must be excluded from sync, or a "
-                "pre-existing user's S3 workspace will overwrite it on pull",
-            )
-
-    def test_user_owned_memory_files_still_round_trip(self):
-        for name in self.USER_OWNED:
-            self.assertNotIn(
-                name,
-                workspace_sync._SKIP_RELATIVE_PREFIXES,
-                f"{name} is agent-written and user-owned; excluding it would "
-                "stop the agent's own memory from persisting",
-            )
-
-    def test_every_bootstrap_file_the_dockerfile_generates_is_covered(self):
-        # Ties the exclusion to the Dockerfile rather than to a literal: if a
-        # generated bootstrap filename changes, this fails instead of silently
-        # leaving the new name unprotected.
-        #
-        # EVERY redirect target, not the first. `re.search` returned SOUL.md —
-        # which is excluded — so the test passed while asserting nothing about
-        # AGENTS.md, the very file it was written to guard. Renaming AGENTS.md
-        # would not have failed it.
-        dockerfile = pathlib.Path(__file__).with_name("Dockerfile").read_text()
-        generated = set(
-            re.findall(r"> /home/node/\.openclaw/([A-Za-z]+\.md)", dockerfile)
-        )
-        self.assertTrue(generated, "no generated bootstrap file found in the Dockerfile")
-        # Both files the image generates today; a new one must be added here
-        # AND to the policy, which is the point of the check.
-        self.assertEqual(generated, {"SOUL.md", "AGENTS.md"})
-        for name in sorted(generated):
-            self.assertIn(
-                name,
-                workspace_sync._SKIP_RELATIVE_PREFIXES,
-                f"the Dockerfile generates {name} but workspace sync would "
-                "overwrite it from S3 on cold start",
-            )

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -684,15 +684,31 @@ def _materialize_empty_workspace_file(
 # intentionally NOT on this list — those are agent-written, user-owned,
 # and must round-trip.
 #
-# AGENTS.md joined this list on 2026-08-07 after the identical failure
-# recurred: the operating rules moved out of SOUL.md into their own bootstrap
-# file, every existing user's S3 workspace predated that file, and the
-# cold-start pull overwrote the workspace without it. The image wrote AGENTS.md
-# correctly and the host supports it — it simply was not present by the time the
-# prompt was built, so the agent reported having no rules in context. It worked
-# for a brand-new user and failed for everyone else, which is what made it look
-# like the split itself had failed. ANY image-owned bootstrap file has to be
-# added here the moment it is introduced.
+# AGENTS.md is deliberately NOT on this list, and must not be added without
+# reading the next paragraph (2026-08-07).
+#
+# It was added here, then removed the same day. The reasoning that put it here
+# was wrong at the root: AGENTS.md is not a bootstrap file in the OpenClaw host
+# we pin. The injected set is IDENTITY.md / USER.md / SOUL.md (+ MEMORY.md) —
+# confirmed by `openclaw config schema`, whose `skipOptionalBootstrapFiles`
+# enumerates only SOUL/USER/IDENTITY/HEARTBEAT, and by the injected-file arrays
+# in /app/dist. This host uses AGENTS.md for POST-COMPACTION re-injection of
+# named sections (DEFAULT_POST_COMPACTION_SECTIONS = ["Session Startup",
+# "Red Lines"]), not as a per-turn system prompt.
+#
+# So operating rules placed in AGENTS.md were never injected at all, and
+# excluding it from sync fixed nothing while creating a retired-but-present
+# path — the broker then refused every restore with "Retired workspace host
+# state requires controlled migration" and dev could not start a turn.
+#
+# Two rules follow from this:
+#   1. Verify a file is actually injected (`openclaw config schema`) BEFORE
+#      building anything on it. A grep count in /app/dist proves the host
+#      mentions the name, not that it loads the file.
+#   2. Add the sync exclusion in the SAME release that first writes an
+#      image-owned file, never after. Excluding a path that is already in S3
+#      is a retired path and needs a controlled migration; excluding one that
+#      was never pushed is free.
 #
 # Exact paths and prefix paths are separate so retiring one generated control
 # file can never hide similarly named user content. The values live in

--- a/lib/agent-workspace/workspace-policy.json
+++ b/lib/agent-workspace/workspace-policy.json
@@ -51,7 +51,6 @@
       "logs/",
       "update-check.json",
       ".openclaw/",
-      "AGENTS.md",
       "SOUL.md",
       "skills/gws-",
       "skills/psd-brand-guidelines/",


### PR DESCRIPTION
Reverts the `AGENTS.md` split from #1614/#1616. **It was built on a wrong premise and left dev unable to restore a workspace.**

## AGENTS.md is not a bootstrap file in the host we pin

Verified three ways, all authoritative:

- `openclaw config schema` — `skipOptionalBootstrapFiles` enumerates **SOUL.md, USER.md, IDENTITY.md, HEARTBEAT.md**
- The injected-file arrays in `/app/dist` are `["SOUL.md"]` and `["IDENTITY.md","USER.md","SOUL.md"]`
- AGENTS.md is handled in `selection-*.js` under `DEFAULT_POST_COMPACTION_SECTIONS = ["Session Startup", "Red Lines"]`

This host uses AGENTS.md for **post-compaction re-injection of named sections**, not as a per-turn system prompt. Our rules file has no such sections, so **nothing was ever injected**.

## What actually broke

The rules were absent from the prompt the moment they moved. The sync exclusion added to "fix" that fixed nothing — it retired a path already present in S3, and the broker correctly refused every restore:

> `Retired workspace host state requires controlled migration`

Dev couldn't start a turn.

**The reasoning error:** I cited "90 references to AGENTS.md in `/app/dist`" as evidence it was supported. That proved only that the host *mentions the name*, for a different feature. The claim that AGENTS.md is an operational-rules bootstrap file came from a **blog post** and was never checked against the pinned host — the same mistake as `bootstrapPromptTruncationWarning` an hour earlier, which this host also rejects.

## The change

- **Dockerfile** appends the `psd-rules` body to `SOUL.md` again — a real bootstrap file, already sync-excluded, demonstrably works.
- **`workspace-policy.json`** drops the AGENTS.md exclusion. That *un-retires* the path, which is the direction needing **no controlled migration**, so dev recovers on an ordinary deploy. Diff is exactly one line.
- **`bootstrapMaxChars` 32000 → 64000.** SOUL.md is 32,991 with the rules plus the new capability-denial guidance, so the cap had to move. It's our own number, not a platform limit — the schema types it as a plain integer with a documented default of 20000. At ~33k chars SOUL.md is ~8,250 tokens, **~4.6% of our 180k `contextTokens`**, sitting in the cached prefix where `cacheRead` is **10× cheaper** than `input`. Total usage 36,166 / 80,000.
- **`workspace_sync.py`'s comment** now records what was learned rather than the wrong conclusion.

## Kept from the split

Capability-denial rule, `psd-workflows` classified/certificated vocabulary, Slides + Sheets `--json-file` examples, the upstream retry, and the toolConfig canary. Only the file layout is reverted.

## Two rules now written into the code

1. **Verify a file is actually injected** (`openclaw config schema`) before building on it. A grep count proves the host mentions a name, not that it loads the file.
2. **Add a sync exclusion in the SAME release that first writes an image-owned file** — excluding a path already in S3 is a retired path and needs a migration; excluding one never pushed is free.

## Tests — mutation-checked

Moving the rules out of SOUL.md fails both: the rules body is measured inside SOUL.md, AGENTS.md is never treated as a bootstrap file, and the Dockerfile is asserted to append the body to SOUL.md.

## Verification

- agent-image Python suite as CI invokes it — **722 tests**
- Full unit suite; bootstrap-budget and config-consistency gates
- `bun run lint` clean at `--max-warnings 0`; `bun run typecheck` clean
- E2E green via the pre-push gate

## Deploy

**Ordinary deploy — no cutover.** No change to `storage-broker.ts` or migration 171, and the `workspace_sync.py` edit is comment-only. Removing an exclusion is the safe direction.
