### PR TITLE
fix(agent-image): stop charging the prompt budget for files this host never injects

### DIFF
--- a/infra/agent-image/check_bootstrap_budget.py
+++ b/infra/agent-image/check_bootstrap_budget.py
@@ -39,18 +39,30 @@ import sys
 from typing import Dict, List, Optional, Tuple
 
 # The bootstrap files OpenClaw auto-loads when present (Dockerfile lines ~326-354
-# document SOUL/IDENTITY/USER/MEMORY as seeded, and AGENTS/TOOLS/HEARTBEAT/
-# BOOTSTRAP as also-auto-loaded when present). SOUL.md is the only one the image
-# builds by concatenation; the rest are copied/seeded as-is.
+# The files THIS host actually injects into the system prompt, verified against
+# `openclaw config schema` rather than documentation: skipOptionalBootstrapFiles
+# enumerates SOUL/USER/IDENTITY/HEARTBEAT, and the injected-file arrays in
+# /app/dist are ["SOUL.md"] and ["IDENTITY.md","USER.md","SOUL.md"]. SOUL.md is
+# the only one the image builds by concatenation; the rest are seeded as-is.
+#
+# AGENTS.md is deliberately ABSENT (2026-08-07). This host uses it for
+# post-compaction re-injection of named sections
+# (DEFAULT_POST_COMPACTION_SECTIONS = ["Session Startup", "Red Lines"]), not as
+# a per-turn bootstrap file. Counting it here charged the prompt budget for
+# something never injected — and because a stale AGENTS.md now exists in the S3
+# workspace of every user who ran the 2026-08-07 image, the runtime check would
+# have pulled ~22k of dead weight into the total and emitted BootTruncationWarn
+# and BOOT_TRUNCATION for a file with no effect on the prompt.
+#
+# TOOLS.md/BOOTSTRAP.md are listed by upstream docs but are not in this host's
+# injected set either; keep them out until `openclaw config schema` says
+# otherwise.
 BOOTSTRAP_FILES: Tuple[str, ...] = (
     "SOUL.md",
     "IDENTITY.md",
     "USER.md",
     "MEMORY.md",
-    "AGENTS.md",
-    "TOOLS.md",
     "HEARTBEAT.md",
-    "BOOTSTRAP.md",
 )
 
 # Separator the Dockerfile prints between SOUL.md and the psd-rules body. Kept

--- a/infra/agent-image/test_check_bootstrap_budget.py
+++ b/infra/agent-image/test_check_bootstrap_budget.py
@@ -166,6 +166,33 @@ class InjectedBootstrapSetTests(unittest.TestCase):
     prompt loses its rules.
     """
 
+    def test_a_stale_agents_md_is_ignored_at_runtime(self):
+        # The 2026-08-07 image pushed AGENTS.md into every user's S3 workspace.
+        # Un-excluding the path means it gets pulled back down, so the RUNTIME
+        # check will see it on disk. It must not be charged to the prompt
+        # budget: this host never injects it, and ~22k of dead weight would
+        # emit BootTruncationWarn/BOOT_TRUNCATION for no reason.
+        d = tempfile.mkdtemp()
+        _write(os.path.join(d, "SOUL.md"), "SOUL")
+        _write(os.path.join(d, "AGENTS.md"), "X" * 22_000)
+        sizes = cbb.runtime_bootstrap_sizes(d)
+        self.assertIn("SOUL.md", sizes)
+        self.assertNotIn(
+            "AGENTS.md",
+            sizes,
+            "a stale AGENTS.md must not count against the prompt budget",
+        )
+        self.assertEqual(sum(sizes.values()), len("SOUL"))
+
+    def test_runtime_set_matches_the_hosts_injected_files(self):
+        # Guards against re-adding a file on documentation alone. Verified via
+        # `openclaw config schema` (skipOptionalBootstrapFiles) and the
+        # injected-file arrays in /app/dist.
+        self.assertEqual(
+            set(cbb.BOOTSTRAP_FILES),
+            {"SOUL.md", "IDENTITY.md", "USER.md", "MEMORY.md", "HEARTBEAT.md"},
+        )
+
     def test_rules_are_measured_as_part_of_soul(self):
         d = tempfile.mkdtemp()
         _write(os.path.join(d, "SOUL.md"), "SOUL")


### PR DESCRIPTION
Codex P2 on #1619 — I merged that PR before reading this finding. It's a real consequence, not cosmetic.

## The problem

`BOOTSTRAP_FILES` drives **both** the build gate and the **runtime** check, and it listed `AGENTS.md`, `TOOLS.md` and `BOOTSTRAP.md` on the strength of upstream documentation. This host injects none of them — `openclaw config schema` enumerates the optional bootstrap files as SOUL/USER/IDENTITY/HEARTBEAT, and the injected-file arrays in `/app/dist` are `["SOUL.md"]` and `["IDENTITY.md","USER.md","SOUL.md"]`.

That became live as of #1619: the 2026-08-07 image pushed `AGENTS.md` into the S3 workspace of **every user who ran it**, and un-excluding the path means those copies get pulled back down. The runtime check would then find ~22k of dead weight on disk, charge it against the 80k total, and emit `BootTruncationWarn` + `BOOT_TRUNCATION` for a file with **no effect on the prompt at all**.

**Why my test missed it:** it only passed because the temporary directory happened to contain no `AGENTS.md`. It exercised the build path and never the runtime one — which is precisely where the stale file shows up.

## The fix

`BOOTSTRAP_FILES` is now the verified injected set: SOUL, IDENTITY, USER, MEMORY, HEARTBEAT.

Two tests, **mutation-checked** (re-adding `AGENTS.md` fails three):
- a 22,000-char stale `AGENTS.md` on disk is ignored by `runtime_bootstrap_sizes` and contributes nothing to the total
- the file set matches the host's injected list exactly, so nothing can be re-added on documentation alone

## Root cause, third time today

Trusting docs over `openclaw config schema`. Same error as `bootstrapPromptTruncationWarning` (host rejected the key) and the AGENTS.md split itself. The schema ships in the image and answers in seconds — the second test now encodes that so it can't drift back.

## Verification

- agent-image budget/config/wrapper/workspace/candidate suites — **236 tests**
- bootstrap-budget gate passing at **36,095 / 80,000**
- `bun run lint` clean at `--max-warnings 0`; `bun run typecheck` clean
- E2E green via the pre-push gate

Ordinary deploy — no cutover (no `storage-broker.ts`, no `workspace_sync.py`, no migration 171).