### PR TITLE
docs(agent-image): correct the AGENTS.md bootstrap comment — it IS injected

### DIFF
--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -684,31 +684,40 @@ def _materialize_empty_workspace_file(
 # intentionally NOT on this list — those are agent-written, user-owned,
 # and must round-trip.
 #
-# AGENTS.md is deliberately NOT on this list, and must not be added without
-# reading the next paragraph (2026-08-07).
+# AGENTS.md is NOT on this list today, but only because we are not currently
+# writing it — NOT because the host ignores it (2026-08-09).
 #
-# It was added here, then removed the same day. The reasoning that put it here
-# was wrong at the root: AGENTS.md is not a bootstrap file in the OpenClaw host
-# we pin. The injected set is IDENTITY.md / USER.md / SOUL.md (+ MEMORY.md) —
-# confirmed by `openclaw config schema`, whose `skipOptionalBootstrapFiles`
-# enumerates only SOUL/USER/IDENTITY/HEARTBEAT, and by the injected-file arrays
-# in /app/dist. This host uses AGENTS.md for POST-COMPACTION re-injection of
-# named sections (DEFAULT_POST_COMPACTION_SECTIONS = ["Session Startup",
-# "Red Lines"]), not as a per-turn system prompt.
+# AGENTS.md IS injected into the system prompt by the host we pin. Verified at
+# runtime, not inferred: boot the image with a distinct sentinel in AGENTS.md
+# and another in SOUL.md, point a stub `openai-completions` provider at a local
+# capture server, run one turn, and read the request body. Both sentinels appear
+# in the role=system message, AGENTS.md under its own
+# `## /home/node/.openclaw/AGENTS.md` header.
 #
-# So operating rules placed in AGENTS.md were never injected at all, and
-# excluding it from sync fixed nothing while creating a retired-but-present
-# path — the broker then refused every restore with "Retired workspace host
-# state requires controlled migration" and dev could not start a turn.
+# An earlier version of this comment claimed the opposite, citing
+# `skipOptionalBootstrapFiles` from `openclaw config schema`. That was wrong:
+# the key enumerates only the OPTIONAL bootstrap files, not the complete
+# injected set. The injected-file arrays in /app/dist are likewise
+# reduced-context allowlists, not the main-session loader. Static reading of a
+# minified bundle cannot settle this question — run the capture instead. Use the
+# SOUL.md sentinel as the positive control: it is definitively injected, so if
+# it does not appear, the method is broken and the result proves nothing.
 #
-# Two rules follow from this:
-#   1. Verify a file is actually injected (`openclaw config schema`) BEFORE
-#      building anything on it. A grep count in /app/dist proves the host
-#      mentions the name, not that it loads the file.
-#   2. Add the sync exclusion in the SAME release that first writes an
-#      image-owned file, never after. Excluding a path that is already in S3
-#      is a retired path and needs a controlled migration; excluding one that
-#      was never pushed is free.
+# So the original 2026-08-07 diagnosis was right — sync WAS overwriting
+# AGENTS.md and clobbering the rules. Excluding it was the correct fix. It
+# failed only on ordering: the first image pushed AGENTS.md to S3 before the
+# exclusion existed, which made it a retired-but-present path, and the broker
+# then refused every restore with "Retired workspace host state requires
+# controlled migration" until the exclusion was reverted.
+#
+# The rule that follows:
+#   Add the sync exclusion in the SAME release that first writes an image-owned
+#   file, never after. Excluding a path already in S3 creates a retired path and
+#   needs a controlled migration; excluding one that was never pushed is free.
+#
+# Operating rules currently live appended to SOUL.md, which is on this list and
+# works. Moving them into AGENTS.md is a viable optimization, not a fix — doing
+# it safely from here costs a workspace cutover, so it stays parked.
 #
 # Exact paths and prefix paths are separate so retiring one generated control
 # file can never hide similarly named user content. The values live in


### PR DESCRIPTION
## What

Comment-only correction to `infra/agent-image/workspace_sync.py`. No behavior change.

## Why

The comment above `CHECKPOINT_EXCLUSIONS` claimed AGENTS.md **is not** a bootstrap file in the OpenClaw host we pin, citing `skipOptionalBootstrapFiles` from `openclaw config schema`. That is wrong, and the comment was actively steering the next reader away from a correct approach.

## Evidence

Settled at runtime instead of by reading the minified bundle:

1. Distinct sentinel into `AGENTS.md`, another into `SOUL.md`
2. Stub provider in `openclaw.json` — `"api": "openai-completions"`, `"auth": "api-key"`, `baseUrl` → local capture server
3. `HOME=/home/node openclaw agent --local --agent main --model <stub>/<model> -m "hello"`
4. Read the captured request body

Both sentinels land in the `role=system` message:

```
## /home/node/.openclaw/AGENTS.md
# Rules

ZZAGENTSSENTINELZZ
```

The SOUL.md sentinel is the **positive control** — SOUL.md is definitively injected, so if it doesn't appear the method is broken. Two earlier attempts failed that control: `bedrock-converse-stream` rejects a plaintext stub with `Protocol error`, and `--log-level trace` doesn't contain the assembled prompt.

### Why the original reading was wrong

- `skipOptionalBootstrapFiles` enumerates only the **optional** bootstrap files, not the complete injected set
- The injected-file arrays in `/app/dist` are reduced-context allowlists, not the main-session prompt loader
- A grep hit in a minified bundle proves the host mentions a name, not that it loads the file

## Consequence

The original 2026-08-07 diagnosis was right: sync **was** overwriting AGENTS.md, and excluding it was the correct fix. It failed only on **ordering** — the first image pushed AGENTS.md to S3 before the exclusion existed, creating a retired-but-present path, after which the broker refused every restore with `Retired workspace host state requires controlled migration`.

The surviving rule, now stated without the bad reasoning attached:

> Add the sync exclusion in the **same release** that first writes an image-owned file, never after.

Rules currently live appended to `SOUL.md` (on the exclusion list, works). The AGENTS.md split is recorded as a **parked optimization**, not a pending fix — doing it safely now costs a workspace cutover.

## Verification

AST comparison against `origin/dev` — parsed module is **identical**. Comment-only, so the images already pushed (`2026-08-09-rules-restored`, `sha256:494a6ef9…`) do **not** need a rebuild.

Supersedes #1620, which was closed because its premise was this same wrong claim.