### PR TITLE
fix(agent): nudge an empty turn even when it ran no tools

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1898,6 +1898,21 @@ class OpenClawAdapter(HarnessAdapter):
         # skipping preserves the old behavior exactly rather than adding a new
         # risk. Tool work that DID complete keeps its original nudge, whose
         # wording already forbids re-running tools.
+        #
+        # The `has_tools or` short-circuit is deliberate, and asymmetric with
+        # _should_retry_upstream on purpose. A turn can hold BOTH a completed
+        # tool call and a second one still in flight; that shape takes the
+        # tools branch and nudges, guarded by EMPTY_TURN_NUDGE's "Do not
+        # re-run any tools" wording rather than by this gate.
+        # _should_retry_upstream is stricter because it replays the USER's
+        # original message verbatim — it has no wording of its own to lean
+        # on. The nudge sends a prompt this file controls, so the wording IS
+        # the guard, and only the no-tools variant (which cannot carry that
+        # sentence without asserting work that never happened) needs the hard
+        # gate. Tightening this to `not tools_in_flight_now` would also
+        # withdraw the nudge from mixed-shape turns that have had it since
+        # long before 2026-08-09 — out of scope for this fix. Pinned by
+        # test_completed_tool_plus_in_flight_still_gets_tools_nudge.
         has_tools = bool(tool_calls)
         tools_in_flight_now = bool(tool_starts)
         should_nudge = has_tools or not tools_in_flight_now

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1888,7 +1888,20 @@ class OpenClawAdapter(HarnessAdapter):
 
         if response_text.strip():
             return _result(_format_for_chat(response_text.strip()))
-        if not _is_nudge:
+        # A start with no terminal event is replay-unsafe: the call may have
+        # already created the Doc, and tool_starts is emptied by pop() the
+        # moment a terminal event lands, so a non-empty tool_starts means
+        # genuinely in flight. The no-tools wording does not forbid re-running
+        # tools, so nudging here could execute the side effect twice — the same
+        # hazard _should_retry_upstream refuses on tools_in_flight. Before
+        # 2026-08-09 this case got no nudge either (tool_calls was empty), so
+        # skipping preserves the old behavior exactly rather than adding a new
+        # risk. Tool work that DID complete keeps its original nudge, whose
+        # wording already forbids re-running tools.
+        has_tools = bool(tool_calls)
+        tools_in_flight_now = bool(tool_starts)
+        should_nudge = has_tools or not tools_in_flight_now
+        if not _is_nudge and should_nudge:
             # The turn produced no user-visible reply — nudge once instead of
             # sending the canned fallback (#1138, observed live on r12).
             # Recursion is bounded by _is_nudge; a short deadline is plenty at
@@ -1904,7 +1917,6 @@ class OpenClawAdapter(HarnessAdapter):
             # same one-shot recovery, with wording that does not assert tool
             # work that did not happen (that would invite a SOUL rule 4
             # violation: never fabricate outcomes).
-            has_tools = bool(tool_calls)
             logger.warning(
                 "empty final after %d tool calls — sending one nudge "
                 "(variant=%s)",
@@ -1930,7 +1942,17 @@ class OpenClawAdapter(HarnessAdapter):
                 deadline_s=180,
                 _is_nudge=True,
             )
-            if nudged.text.strip():
+            # A nudge leg that ALSO ends empty does not come back with empty
+            # text — it falls through to the canned fallback below and returns
+            # that, which is non-empty. Testing text alone therefore treats
+            # every failed nudge as a success, returns early, and skips the
+            # outer failure row entirely. Check the error class too, so a nudge
+            # that did not actually recover falls through to be recorded once,
+            # by this leg, with accurate nudge_* telemetry.
+            nudge_recovered = bool(nudged.text.strip()) and (
+                nudged.error_class != "EmptyAgentResponse"
+            )
+            if nudge_recovered:
                 merged_tools = tool_calls + nudged.tool_calls
                 return TurnResult(
                     text=nudged.text,
@@ -1957,6 +1979,18 @@ class OpenClawAdapter(HarnessAdapter):
                     # though it wrote no agent_failures row.
                     nudged=True,
                 )
+        if _is_nudge:
+            # The nudge leg is an internal recovery attempt, not a user turn.
+            # Recording here would write a SECOND row for the same turn, and it
+            # would be the misleading one: _is_nudge makes nudge_attempted read
+            # false on the very row that proves a nudge happened. Stay silent
+            # and let the outer leg record the single accurate row.
+            return _result(
+                "I processed your message but had no response.",
+                failed=True,
+                error_class="EmptyAgentResponse",
+                nudged=False,
+            )
         record_failure(
             source="harness",
             severity="empty_response",
@@ -1970,27 +2004,32 @@ class OpenClawAdapter(HarnessAdapter):
                 "last_state": last_state,
                 "event_counts": event_counts,
                 "first_events": first_event_types,
-                # Reaching here means the nudge did not rescue the turn. Record
-                # whether one was even attempted, and which wording — without
-                # this, a row that never got a nudge is indistinguishable from
-                # one where the nudge fired and the model stayed silent, which
-                # is exactly the ambiguity that made these rows hard to read.
-                "nudge_attempted": not _is_nudge,
+                # Reaching here means no nudge rescued the turn. Record whether
+                # one was even attempted, and which wording — without this, a
+                # row that never got a nudge is indistinguishable from one
+                # where the nudge fired and the model stayed silent — exactly
+                # the ambiguity that made these rows hard to read.
+                "nudge_attempted": should_nudge,
                 "nudge_variant": (
-                    None
-                    if _is_nudge
-                    else ("tools" if tool_calls else "no-tools")
+                    ("tools" if has_tools else "no-tools")
+                    if should_nudge
+                    else None
+                ),
+                # Set when the nudge was skipped because a tool call was still
+                # in flight and replaying it could double a side effect.
+                "nudge_skipped_tools_in_flight": (
+                    tools_in_flight_now and not should_nudge
                 ),
             },
         )
-        # nudged reflects whether the one nudge fired this turn: it did iff
-        # this is not itself a nudge leg — the exact condition guarding the
-        # self.process() call above, no longer also gated on tool_calls.
+        # Only reachable on the outer leg (the _is_nudge branch returned
+        # above), so nudged mirrors should_nudge: a nudge fired unless it was
+        # skipped for a tool still in flight.
         return _result(
             "I processed your message but had no response.",
             failed=True,
             error_class="EmptyAgentResponse",
-            nudged=not _is_nudge,
+            nudged=should_nudge,
         )
 
     @staticmethod

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1888,23 +1888,43 @@ class OpenClawAdapter(HarnessAdapter):
 
         if response_text.strip():
             return _result(_format_for_chat(response_text.strip()))
-        if not _is_nudge and tool_calls:
-            # The turn DID work (tool calls ran) but produced no reply —
-            # nudge once for the user-facing summary instead of sending the
-            # canned fallback (#1138, observed live on r12). Recursive call
-            # is bounded by _is_nudge; a short deadline is plenty at direct-
-            # Mantle serving speeds.
+        if not _is_nudge:
+            # The turn produced no user-visible reply — nudge once instead of
+            # sending the canned fallback (#1138, observed live on r12).
+            # Recursion is bounded by _is_nudge; a short deadline is plenty at
+            # direct-Mantle serving speeds.
+            #
+            # This fired only when tool_calls ran until 2026-08-09, on the
+            # theory that a turn with no tool work had nothing to summarize.
+            # Prod disagrees: of the EmptyAgentResponse rows since 2026-08-01,
+            # every one reached last_state=final, and half of those recorded
+            # first_events=["event:chat"] with no res/usage/lifecycle events at
+            # all. Those turns never had a tool call, so they never got a
+            # nudge — the user just got the canned fallback. They deserve the
+            # same one-shot recovery, with wording that does not assert tool
+            # work that did not happen (that would invite a SOUL rule 4
+            # violation: never fabricate outcomes).
+            has_tools = bool(tool_calls)
             logger.warning(
-                "empty final after %d tool calls — sending one nudge",
+                "empty final after %d tool calls — sending one nudge "
+                "(variant=%s)",
                 len(tool_calls),
+                "tools" if has_tools else "no-tools",
             )
             # Iteration telemetry (issue #1161): a nudge fired this turn.
             # Emit a CloudWatch metric (best-effort) so nudge-fire rate is
             # trendable in the AgentCore container log group, which has a
             # runtime-generated suffix a MetricFilter can't attach to.
+            # Deliberately the same metric name for both variants so the
+            # existing nudge-fire trend stays comparable across this change.
             emit_agent_metric("AgentNudgeFired")
+            nudge_prompt = (
+                self.EMPTY_TURN_NUDGE
+                if has_tools
+                else self.EMPTY_TURN_NUDGE_NO_TOOLS
+            )
             nudged = self.process(
-                self.EMPTY_TURN_NUDGE,
+                nudge_prompt,
                 session_id,
                 model_override,
                 deadline_s=180,
@@ -1950,16 +1970,27 @@ class OpenClawAdapter(HarnessAdapter):
                 "last_state": last_state,
                 "event_counts": event_counts,
                 "first_events": first_event_types,
+                # Reaching here means the nudge did not rescue the turn. Record
+                # whether one was even attempted, and which wording — without
+                # this, a row that never got a nudge is indistinguishable from
+                # one where the nudge fired and the model stayed silent, which
+                # is exactly the ambiguity that made these rows hard to read.
+                "nudge_attempted": not _is_nudge,
+                "nudge_variant": (
+                    None
+                    if _is_nudge
+                    else ("tools" if tool_calls else "no-tools")
+                ),
             },
         )
-        # nudged reflects whether the one nudge fired this turn: it did iff this
-        # is not itself a nudge leg AND there were tool calls to summarize (the
-        # exact condition guarding the self.process() nudge call above).
+        # nudged reflects whether the one nudge fired this turn: it did iff
+        # this is not itself a nudge leg — the exact condition guarding the
+        # self.process() call above, no longer also gated on tool_calls.
         return _result(
             "I processed your message but had no response.",
             failed=True,
             error_class="EmptyAgentResponse",
-            nudged=(not _is_nudge and bool(tool_calls)),
+            nudged=not _is_nudge,
         )
 
     @staticmethod
@@ -2008,6 +2039,17 @@ class OpenClawAdapter(HarnessAdapter):
         "user NO reply — they saw nothing. Send the user-facing summary of "
         "what you just did (and its outcome) now, as plain text. Do not "
         "re-run any tools unless something genuinely failed."
+    )
+
+    # Same one-shot recovery for a turn that ended empty having run NO tools.
+    # Worded so it cannot be read as "summarize your work": there was none, and
+    # inviting a summary here would be inviting fabrication (SOUL rule 4).
+    EMPTY_TURN_NUDGE_NO_TOOLS = (
+        "[system-nudge] Your previous turn ended without sending the user any "
+        "reply — they saw nothing at all. Answer their most recent message "
+        "now, as plain text. If you cannot answer it, say so plainly and say "
+        "what you need in order to. Do not describe any work or tool call you "
+        "did not actually perform."
     )
 
     @staticmethod

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1964,10 +1964,18 @@ class OpenClawAdapter(HarnessAdapter):
             # outer failure row entirely. Check the error class too, so a nudge
             # that did not actually recover falls through to be recorded once,
             # by this leg, with accurate nudge_* telemetry.
-            nudge_recovered = bool(nudged.text.strip()) and (
+            #
+            # Named for what it literally tests, not "recovered": a nudge leg
+            # that failed some OTHER way (a ChatDeadlineExpired partial, say)
+            # still returns text and still takes this branch. That is correct
+            # — the nested leg already recorded its own failure, and
+            # failed/error_class propagate through the TurnResult below — but
+            # only because this is a "did it come back with something to show
+            # the user" test, not a success test.
+            nudge_returned_text = bool(nudged.text.strip()) and (
                 nudged.error_class != "EmptyAgentResponse"
             )
-            if nudge_recovered:
+            if nudge_returned_text:
                 merged_tools = tool_calls + nudged.tool_calls
                 return TurnResult(
                     text=nudged.text,

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1391,8 +1391,13 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
     lifecycle events), so they never got the recovery the tool case got.
     """
 
-    def _drive_empty_final(self, adapter, *, with_tool):
-        """Run one turn that reaches state=final with no assistant text."""
+    def _drive_empty_final(self, adapter, *, with_tool, leave_in_flight=False):
+        """Run one turn that reaches state=final with no assistant text.
+
+        leave_in_flight emits the tool start WITHOUT its terminal event, the
+        shape where the side effect may already have happened but never got
+        reported — tool_calls stays empty while tool_starts does not.
+        """
         chat_id = None
 
         class FakeWebSocket:
@@ -1437,20 +1442,19 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
             lambda: envelope(type="res", id=chat_id, ok=True,
                              payload={"runId": chat_id, "status": "started"}),
         ]
+        if with_tool or leave_in_flight:
+            messages.append(lambda: current_run_event("agent", {
+                "stream": "item",
+                "data": {"itemId": "t-1", "phase": "start",
+                         "kind": "tool", "name": "write"},
+            }))
         if with_tool:
-            messages += [
-                lambda: current_run_event("agent", {
-                    "stream": "item",
-                    "data": {"itemId": "t-1", "phase": "start",
-                             "kind": "tool", "name": "read"},
-                }),
-                lambda: current_run_event("agent", {
-                    "stream": "item",
-                    "data": {"itemId": "t-1", "phase": "end",
-                             "kind": "tool", "name": "read",
-                             "status": "ok"},
-                }),
-            ]
+            messages.append(lambda: current_run_event("agent", {
+                "stream": "item",
+                "data": {"itemId": "t-1", "phase": "end",
+                         "kind": "tool", "name": "write",
+                         "status": "ok"},
+            }))
         # Final with no assistant text at all — the empty-turn shape.
         messages.append(lambda: current_run_event("chat", {"state": "final"}))
 
@@ -1461,15 +1465,31 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
         adapter._ready = True
         return fake_websocket_module
 
-    def _run(self, *, with_tool, is_nudge=False):
+    def _run(self, *, with_tool, is_nudge=False, nudge_reply=None,
+             leave_in_flight=False):
         adapter = OpenClawAdapter()
-        ws = self._drive_empty_final(adapter, with_tool=with_tool)
+        ws = self._drive_empty_final(
+            adapter, with_tool=with_tool, leave_in_flight=leave_in_flight
+        )
         nudges = []
         recorded = []
 
         def fake_process(message, *_a, **_kw):
             nudges.append(message)
-            return harness_adapter.TurnResult(text="", failed=False)
+            if nudge_reply is not None:
+                return harness_adapter.TurnResult(
+                    text=nudge_reply, failed=False
+                )
+            # A nudge leg that also ends empty does NOT return empty text — it
+            # returns the canned fallback with error_class=EmptyAgentResponse.
+            # Mocking an empty string here is an impossible shape, and it was
+            # what hid the bug where the outer leg treated a failed nudge as a
+            # success and never wrote its failure row.
+            return harness_adapter.TurnResult(
+                text="I processed your message but had no response.",
+                failed=True,
+                error_class="EmptyAgentResponse",
+            )
 
         with (
             mock.patch.dict(sys.modules, {"websocket": ws}),
@@ -1505,19 +1525,52 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
         self.assertEqual(nudges, [])
 
     def test_failure_row_records_whether_a_nudge_was_attempted(self):
-        # Without this a row that never got a nudge is indistinguishable from
-        # one where the nudge fired and the model stayed silent anyway.
+        # Exactly one row, on the outer leg, and it must say a nudge happened.
+        # Before the nudge_recovered fix the outer leg saw the nudge's canned
+        # fallback as non-empty text, returned early, and wrote NO row at all.
         _result, _nudges, recorded = self._run(with_tool=False)
-        self.assertEqual(len(recorded), 1)
+        self.assertEqual(len(recorded), 1, "exactly one row per user turn")
         ctx = recorded[0]["context"]
         self.assertTrue(ctx["nudge_attempted"])
         self.assertEqual(ctx["nudge_variant"], "no-tools")
 
-    def test_nudge_leg_failure_row_marks_no_attempt(self):
+    def test_nudge_leg_writes_no_row_of_its_own(self):
+        # The nudge leg is an internal recovery attempt. If it recorded, the
+        # turn would get two rows and the _is_nudge one would misleadingly read
+        # nudge_attempted=false on the very row proving a nudge happened.
         _result, _nudges, recorded = self._run(with_tool=False, is_nudge=True)
+        self.assertEqual(recorded, [])
+
+    def test_never_nudges_while_a_tool_is_still_in_flight(self):
+        # The dangerous shape: "write" STARTED and its terminal event never
+        # arrived, so it may already have created the file while tool_calls is
+        # empty. Classifying that as no-tools would send the no-tools nudge,
+        # whose wording does not forbid re-running tools — creating the file a
+        # second time. Same replay-unsafety _should_retry_upstream refuses on
+        # tools_in_flight. Before 2026-08-09 this case got no nudge either.
+        _result, nudges, recorded = self._run(
+            with_tool=False, leave_in_flight=True
+        )
+        self.assertEqual(nudges, [], "an in-flight tool must not be replayed")
+        self.assertEqual(len(recorded), 1)
         ctx = recorded[0]["context"]
         self.assertFalse(ctx["nudge_attempted"])
         self.assertIsNone(ctx["nudge_variant"])
+        self.assertTrue(ctx["nudge_skipped_tools_in_flight"])
+
+    def test_completed_tool_work_still_nudges_past_the_guard(self):
+        # The guard must not silence the case the nudge was built for: tools
+        # that finished get the tools wording, which forbids re-running.
+        _result, nudges, _rec = self._run(with_tool=True)
+        self.assertEqual(nudges, [OpenClawAdapter.EMPTY_TURN_NUDGE])
+
+    def test_a_recovered_nudge_writes_no_failure_row(self):
+        _result, nudges, recorded = self._run(
+            with_tool=False, nudge_reply="here is the answer"
+        )
+        self.assertEqual(len(nudges), 1)
+        self.assertEqual(recorded, [], "a rescued turn is not a failure")
+        self.assertEqual(_result.text, "here is the answer")
 
 
 def _assistant(ts_ms, *, inp=0, out=0, cr=0, cw=0, stop="stop"):

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1551,7 +1551,7 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
 
     def test_failure_row_records_whether_a_nudge_was_attempted(self):
         # Exactly one row, on the outer leg, and it must say a nudge happened.
-        # Before the nudge_recovered fix the outer leg saw the nudge's canned
+        # Before the nudge_returned_text fix the outer leg saw the canned
         # fallback as non-empty text, returned early, and wrote NO row at all.
         _result, _nudges, recorded, _m = self._run(with_tool=False)
         self.assertEqual(len(recorded), 1, "exactly one row per user turn")

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1391,12 +1391,18 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
     lifecycle events), so they never got the recovery the tool case got.
     """
 
-    def _drive_empty_final(self, adapter, *, with_tool, leave_in_flight=False):
+    def _drive_empty_final(self, adapter, *, with_tool, leave_in_flight=False,
+                           second_tool_in_flight=False):
         """Run one turn that reaches state=final with no assistant text.
 
         leave_in_flight emits the tool start WITHOUT its terminal event, the
         shape where the side effect may already have happened but never got
         reported — tool_calls stays empty while tool_starts does not.
+
+        second_tool_in_flight adds a SECOND tool (distinct itemId) that starts
+        and never reports, on top of a first that completed. Both lists are
+        then non-empty at once — the mixed shape neither flag alone builds,
+        since they share the single "t-1" itemId.
         """
         chat_id = None
 
@@ -1455,6 +1461,14 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
                          "kind": "tool", "name": "write",
                          "status": "ok"},
             }))
+        if second_tool_in_flight:
+            # Starts after t-1 already reported, so t-1 has been popped off
+            # tool_starts and only t-2 is left dangling at final.
+            messages.append(lambda: current_run_event("agent", {
+                "stream": "item",
+                "data": {"itemId": "t-2", "phase": "start",
+                         "kind": "tool", "name": "write"},
+            }))
         # Final with no assistant text at all — the empty-turn shape.
         messages.append(lambda: current_run_event("chat", {"state": "final"}))
 
@@ -1466,13 +1480,15 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
         return fake_websocket_module
 
     def _run(self, *, with_tool, is_nudge=False, nudge_reply=None,
-             leave_in_flight=False):
+             leave_in_flight=False, second_tool_in_flight=False):
         adapter = OpenClawAdapter()
         ws = self._drive_empty_final(
-            adapter, with_tool=with_tool, leave_in_flight=leave_in_flight
+            adapter, with_tool=with_tool, leave_in_flight=leave_in_flight,
+            second_tool_in_flight=second_tool_in_flight,
         )
         nudges = []
         recorded = []
+        metrics = []
 
         def fake_process(message, *_a, **_kw):
             nudges.append(message)
@@ -1501,34 +1517,43 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
             mock.patch.object(adapter, "process", side_effect=fake_process),
             mock.patch("harness_adapter.record_failure",
                        side_effect=lambda **kw: recorded.append(kw)),
-            mock.patch("harness_adapter.emit_agent_metric"),
+            mock.patch("harness_adapter.emit_agent_metric",
+                       side_effect=lambda n, *a, **kw: metrics.append(n)),
         ):
             result = adapter._process_once(
                 "hello", "s1", deadline_s=600, _is_nudge=is_nudge
             )
-        return result, nudges, recorded
+        return result, nudges, recorded, metrics
 
     def test_empty_final_without_tools_fires_the_no_tools_nudge(self):
-        _result, nudges, _rec = self._run(with_tool=False)
+        _result, nudges, _rec, metrics = self._run(with_tool=False)
         self.assertEqual(len(nudges), 1, "a no-tool empty turn must nudge")
         self.assertEqual(nudges[0], OpenClawAdapter.EMPTY_TURN_NUDGE_NO_TOOLS)
+        # One metric per nudge, under the SAME name as the tools variant, so
+        # the pre-2026-08-09 nudge-fire trend stays comparable across the
+        # change instead of silently splitting into two series.
+        self.assertEqual(metrics.count("AgentNudgeFired"), 1)
 
     def test_empty_final_with_tools_still_fires_the_tools_nudge(self):
-        _result, nudges, _rec = self._run(with_tool=True)
+        _result, nudges, _rec, metrics = self._run(with_tool=True)
         self.assertEqual(len(nudges), 1)
         self.assertEqual(nudges[0], OpenClawAdapter.EMPTY_TURN_NUDGE)
+        self.assertEqual(metrics.count("AgentNudgeFired"), 1)
 
     def test_a_nudge_leg_does_not_nudge_again(self):
         # Recursion stays bounded by _is_nudge — this is the only thing
         # standing between one recovery attempt and an unbounded loop.
-        _result, nudges, _rec = self._run(with_tool=False, is_nudge=True)
+        _result, nudges, _rec, metrics = self._run(
+            with_tool=False, is_nudge=True
+        )
         self.assertEqual(nudges, [])
+        self.assertEqual(metrics.count("AgentNudgeFired"), 0)
 
     def test_failure_row_records_whether_a_nudge_was_attempted(self):
         # Exactly one row, on the outer leg, and it must say a nudge happened.
         # Before the nudge_recovered fix the outer leg saw the nudge's canned
         # fallback as non-empty text, returned early, and wrote NO row at all.
-        _result, _nudges, recorded = self._run(with_tool=False)
+        _result, _nudges, recorded, _m = self._run(with_tool=False)
         self.assertEqual(len(recorded), 1, "exactly one row per user turn")
         ctx = recorded[0]["context"]
         self.assertTrue(ctx["nudge_attempted"])
@@ -1538,7 +1563,9 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
         # The nudge leg is an internal recovery attempt. If it recorded, the
         # turn would get two rows and the _is_nudge one would misleadingly read
         # nudge_attempted=false on the very row proving a nudge happened.
-        _result, _nudges, recorded = self._run(with_tool=False, is_nudge=True)
+        _result, _nudges, recorded, _m = self._run(
+            with_tool=False, is_nudge=True
+        )
         self.assertEqual(recorded, [])
 
     def test_never_nudges_while_a_tool_is_still_in_flight(self):
@@ -1548,24 +1575,57 @@ class TestEmptyFinalNudgeFires(unittest.TestCase):
         # whose wording does not forbid re-running tools — creating the file a
         # second time. Same replay-unsafety _should_retry_upstream refuses on
         # tools_in_flight. Before 2026-08-09 this case got no nudge either.
-        _result, nudges, recorded = self._run(
+        _result, nudges, recorded, metrics = self._run(
             with_tool=False, leave_in_flight=True
         )
         self.assertEqual(nudges, [], "an in-flight tool must not be replayed")
+        self.assertEqual(metrics.count("AgentNudgeFired"), 0)
         self.assertEqual(len(recorded), 1)
         ctx = recorded[0]["context"]
         self.assertFalse(ctx["nudge_attempted"])
         self.assertIsNone(ctx["nudge_variant"])
         self.assertTrue(ctx["nudge_skipped_tools_in_flight"])
 
-    def test_completed_tool_work_still_nudges_past_the_guard(self):
-        # The guard must not silence the case the nudge was built for: tools
-        # that finished get the tools wording, which forbids re-running.
-        _result, nudges, _rec = self._run(with_tool=True)
+    def test_completed_tool_plus_in_flight_still_gets_tools_nudge(self):
+        # The mixed shape: t-1 completed, t-2 started and never reported. Both
+        # tool_calls and tool_starts are non-empty, and the has_tools
+        # short-circuit deliberately wins — this turn keeps the tools wording
+        # rather than being silenced like the no-tools in-flight case above.
+        #
+        # Pinned as a DECISION, not an accident. Protection here is the
+        # EMPTY_TURN_NUDGE wording ("Do not re-run any tools"), which the
+        # no-tools variant cannot offer, which is why only that branch needs a
+        # hard gate. Tightening this to skip on any in-flight tool would also
+        # withdraw the nudge from turns that have had it since well before
+        # 2026-08-09 — a behavior change beyond this fix's scope. If the
+        # wording ever proves insufficient, flip the short-circuit here and
+        # this test is the one that should change with it.
+        _result, nudges, _rec, metrics = self._run(
+            with_tool=True, second_tool_in_flight=True
+        )
+        # Prove the shape really is mixed before asserting on it — with_tool
+        # alone lands tools_in_flight=0, so without this the test would just
+        # restate test_empty_final_with_tools_still_fires_the_tools_nudge.
+        self.assertEqual(len(_result.tool_calls), 1)
+        self.assertEqual(_result.tools_in_flight, 1)
         self.assertEqual(nudges, [OpenClawAdapter.EMPTY_TURN_NUDGE])
+        self.assertEqual(metrics.count("AgentNudgeFired"), 1)
+
+    def test_mixed_shape_records_the_variant_that_actually_fired(self):
+        # The telemetry must not report this as skipped-for-in-flight just
+        # because tool_starts was non-empty; the row has to say a tools nudge
+        # really went out, or the mixed shape is unreadable in prod.
+        _result, _nudges, recorded, _m = self._run(
+            with_tool=True, second_tool_in_flight=True
+        )
+        self.assertEqual(len(recorded), 1)
+        ctx = recorded[0]["context"]
+        self.assertTrue(ctx["nudge_attempted"])
+        self.assertEqual(ctx["nudge_variant"], "tools")
+        self.assertFalse(ctx["nudge_skipped_tools_in_flight"])
 
     def test_a_recovered_nudge_writes_no_failure_row(self):
-        _result, nudges, recorded = self._run(
+        _result, nudges, recorded, _m = self._run(
             with_tool=False, nudge_reply="here is the answer"
         )
         self.assertEqual(len(nudges), 1)

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1370,6 +1370,155 @@ class TestEmptyTurnNudge(unittest.TestCase):
         self.assertIn("NO reply", n)
         self.assertIn("Do not", n)
 
+    def test_no_tools_nudge_never_claims_tool_work_happened(self):
+        # The tools variant opens with "finished tool work". Reusing it on a
+        # turn that ran no tools would assert work that never happened and
+        # invite the model to invent it (SOUL rule 4).
+        n = OpenClawAdapter.EMPTY_TURN_NUDGE_NO_TOOLS
+        self.assertIn("[system-nudge]", n)
+        self.assertNotIn("tool work", n)
+        self.assertNotIn("summary of", n)
+        self.assertIn("did not actually perform", n)
+
+
+class TestEmptyFinalNudgeFires(unittest.TestCase):
+    """An empty final turn gets one nudge whether or not tools ran.
+
+    Until 2026-08-09 the nudge was gated on tool_calls, so a turn that
+    reached last_state=final having run nothing at all skipped straight to the
+    canned fallback. Half the EmptyAgentResponse rows in prod since
+    2026-08-01 are that shape (first_events=["event:chat"], no res/usage/
+    lifecycle events), so they never got the recovery the tool case got.
+    """
+
+    def _drive_empty_final(self, adapter, *, with_tool):
+        """Run one turn that reaches state=final with no assistant text."""
+        chat_id = None
+
+        class FakeWebSocket:
+            def __init__(self, messages):
+                self.messages = list(messages)
+                self.sent = []
+
+            def send(self, payload):
+                nonlocal chat_id
+                parsed = json.loads(payload)
+                self.sent.append(parsed)
+                if parsed.get("method") == "chat.send":
+                    chat_id = parsed["id"]
+
+            def recv(self):
+                message = self.messages.pop(0)
+                return message() if callable(message) else message
+
+            def settimeout(self, _timeout):
+                return None
+
+            def close(self):
+                return None
+
+        def envelope(**fields):
+            return json.dumps(fields)
+
+        def current_run_event(event, payload):
+            return envelope(
+                type="event", event=event,
+                payload={"runId": chat_id, **payload},
+            )
+
+        messages = [
+            envelope(type="event", event="connect.challenge", payload={}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={"tools": []}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={}),
+            lambda: envelope(type="res", id=chat_id, ok=True,
+                             payload={"runId": chat_id, "status": "started"}),
+        ]
+        if with_tool:
+            messages += [
+                lambda: current_run_event("agent", {
+                    "stream": "item",
+                    "data": {"itemId": "t-1", "phase": "start",
+                             "kind": "tool", "name": "read"},
+                }),
+                lambda: current_run_event("agent", {
+                    "stream": "item",
+                    "data": {"itemId": "t-1", "phase": "end",
+                             "kind": "tool", "name": "read",
+                             "status": "ok"},
+                }),
+            ]
+        # Final with no assistant text at all — the empty-turn shape.
+        messages.append(lambda: current_run_event("chat", {"state": "final"}))
+
+        socket = FakeWebSocket(messages)
+        fake_websocket_module = mock.Mock()
+        fake_websocket_module.create_connection.return_value = socket
+        fake_websocket_module.WebSocketTimeoutException = TimeoutError
+        adapter._ready = True
+        return fake_websocket_module
+
+    def _run(self, *, with_tool, is_nudge=False):
+        adapter = OpenClawAdapter()
+        ws = self._drive_empty_final(adapter, with_tool=with_tool)
+        nudges = []
+        recorded = []
+
+        def fake_process(message, *_a, **_kw):
+            nudges.append(message)
+            return harness_adapter.TurnResult(text="", failed=False)
+
+        with (
+            mock.patch.dict(sys.modules, {"websocket": ws}),
+            mock.patch.object(adapter, "_read_turn_usage", return_value={
+                "input": 0, "output": 0, "cache_read": 0,
+                "cache_write": 0, "model_calls": 0,
+                "capture_complete": False,
+            }),
+            mock.patch.object(adapter, "process", side_effect=fake_process),
+            mock.patch("harness_adapter.record_failure",
+                       side_effect=lambda **kw: recorded.append(kw)),
+            mock.patch("harness_adapter.emit_agent_metric"),
+        ):
+            result = adapter._process_once(
+                "hello", "s1", deadline_s=600, _is_nudge=is_nudge
+            )
+        return result, nudges, recorded
+
+    def test_empty_final_without_tools_fires_the_no_tools_nudge(self):
+        _result, nudges, _rec = self._run(with_tool=False)
+        self.assertEqual(len(nudges), 1, "a no-tool empty turn must nudge")
+        self.assertEqual(nudges[0], OpenClawAdapter.EMPTY_TURN_NUDGE_NO_TOOLS)
+
+    def test_empty_final_with_tools_still_fires_the_tools_nudge(self):
+        _result, nudges, _rec = self._run(with_tool=True)
+        self.assertEqual(len(nudges), 1)
+        self.assertEqual(nudges[0], OpenClawAdapter.EMPTY_TURN_NUDGE)
+
+    def test_a_nudge_leg_does_not_nudge_again(self):
+        # Recursion stays bounded by _is_nudge — this is the only thing
+        # standing between one recovery attempt and an unbounded loop.
+        _result, nudges, _rec = self._run(with_tool=False, is_nudge=True)
+        self.assertEqual(nudges, [])
+
+    def test_failure_row_records_whether_a_nudge_was_attempted(self):
+        # Without this a row that never got a nudge is indistinguishable from
+        # one where the nudge fired and the model stayed silent anyway.
+        _result, _nudges, recorded = self._run(with_tool=False)
+        self.assertEqual(len(recorded), 1)
+        ctx = recorded[0]["context"]
+        self.assertTrue(ctx["nudge_attempted"])
+        self.assertEqual(ctx["nudge_variant"], "no-tools")
+
+    def test_nudge_leg_failure_row_marks_no_attempt(self):
+        _result, _nudges, recorded = self._run(with_tool=False, is_nudge=True)
+        ctx = recorded[0]["context"]
+        self.assertFalse(ctx["nudge_attempted"])
+        self.assertIsNone(ctx["nudge_variant"])
+
 
 def _assistant(ts_ms, *, inp=0, out=0, cr=0, cw=0, stop="stop"):
     """One assistant transcript record in OpenClaw's on-disk JSONL shape."""


### PR DESCRIPTION
Closes the last unaddressed failure class from the 2026-08-05 incident window.

## The problem

`EmptyAgentResponse` — the user sees `I processed your message but had no response.` **50 rows in prod, going back to 2026-05-13**, roughly one a day at current volume. It predates the 50-new-user event; August only looked worse because volume was ~10× higher.

The recovery already existed: `_process_once` nudges once when a turn reaches a final state with no user-visible text. But it was gated on `tool_calls` being non-empty, reasoning that a turn which ran no tools had nothing to summarize.

## Why that gate is wrong

Of the 21 rows since 2026-08-01, **all 21** recorded `last_state=final`, and the contexts split into two even shapes:

```
10x  first_events = ["event:chat"]
10x  first_events = ["res","event:agent","event:agent","event:agent","event:chat"]
```

Summed `event_counts`: `event:agent` 35, `event:chat` 21 — but `res` / `_seen_stream::usage` / `_seen_stream::lifecycle` only **11 each**.

So ~half these turns reach `final` having emitted **no usage and no lifecycle stream at all**. Those ran no tools — meaning the half most likely to be a silently dropped model call was exactly the half excluded from the recovery.

## The change

Fire the nudge whenever the turn is not itself a nudge leg. Recursion stays bounded by `_is_nudge`, so this is still **at most one extra model call per empty turn** (~1/day observed).

The existing text couldn't be reused — `EMPTY_TURN_NUDGE` opens with *"Your previous turn finished tool work"*, which on a no-tool turn asserts work that never happened and invites the model to invent it (**SOUL rule 4**: never fabricate outcomes). Added `EMPTY_TURN_NUDGE_NO_TOOLS`, which asks for the reply, offers *"say what you need"* as a legitimate out, and forbids describing work not performed. A test asserts it never contains `"tool work"`.

Also records `nudge_attempted` / `nudge_variant` in the failure context — without them, a row that never got a nudge is indistinguishable from one where the nudge fired and the model stayed silent, which is the ambiguity that made this class unreadable for three months. `AgentNudgeFired` keeps one metric name for both variants so the existing trend stays comparable.

## Deliberately not changed: `user_id`

28 of 50 rows have NULL `user_id`, but the split is clean:

| | |
|---|---|
| last NULL | 2026-07-30 |
| first attributed | 2026-07-30 |

Already fixed. And the harness *should not* send `user_id` — `app/api/agent/failures/route.ts` rejects client-supplied `ownerEmail`/`userEmail`/`userId` (`"Owner selectors are not accepted"`) and derives it from the signed invocation context. `_post_failure_broker` dropping those fields is correct.

## Verification

- 6 new tests driving `_process_once` to an empty final over the existing `FakeWebSocket` harness: no-tools fires the no-tools variant, tools still fires the tools variant, a nudge leg never nudges again, both context fields asserted in each direction
- **Full image suite green: 683 tests**
- All added lines ≤79 chars

Needs a rebuilt image to take effect — not in `2026-08-09-rules-restored`.