### PR TITLE
build(tsconfig): include the .next-e2e generated types in the typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-e2e/types/**/*.ts",
+    ".next-e2e/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## What

Adds the two `.next-e2e` type globs to `tsconfig.json`'s `include`, alongside the existing `.next` ones.

```diff
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-e2e/types/**/*.ts",
+    ".next-e2e/dev/types/**/*.ts"
```

## Why

The E2E harness builds into `.next-e2e/` rather than `.next/`, so an E2E run can't clobber the dev server's build output — the two run side by side (`.next` on :3000, `.next-e2e` on :3100).

Next.js emits route and page type declarations into whichever build directory it's using, so the E2E build's generated types landed in `.next-e2e/types/` and `.next-e2e/dev/types/` — both outside the `include` list.

The effect was **silent**: `tsc --noEmit` never saw those declarations, so type errors in code exercised only by the E2E build were invisible locally. Nothing failed; the check just covered less than it appeared to.

## Safety

`.next-e2e/` is gitignored, and an include glob matching nothing is a no-op — so this is safe on a fresh checkout that has never run an E2E build.

`bun run typecheck` passes locally with the change.

## Provenance

This was an uncommitted local edit sitting in the main checkout, not on `dev`. Committing it rather than discarding it during branch cleanup, since it was real work.