### PR TITLE
fix(agent): close four failure modes seen in prod on 2026-08-10

### DIFF
--- a/infra/agent-image/skills/psd-hyperframes/SKILL.md
+++ b/infra/agent-image/skills/psd-hyperframes/SKILL.md
@@ -89,6 +89,38 @@ its path with `--file`. Small scenes can be passed inline with `--html`.
 
 ## Usage
 
+> **Rendering takes MINUTES, not seconds. Run it in the background.**
+>
+> Observed in production: 180–430 seconds per render, for scenes only a few
+> seconds long. The render seeks every frame in headless Chromium and then
+> encodes with FFmpeg, so wall time scales with `fps × duration`, not with how
+> short the video is.
+>
+> A foreground call will be killed by the tool timeout long before the render
+> finishes. The Lambda keeps running and still bills, you get an error, and
+> retrying just starts another multi-minute render — on 2026-08-10 a user
+> burned six attempts and ~28 minutes this way and never got a video.
+>
+> **Start it in the background, then poll:**
+>
+> ```bash
+> # 1. Start it — returns immediately with a handle.
+> node /opt/psd-skills/psd-hyperframes/render.js --file scene.html --duration 3 \
+>   > /tmp/hyperframes-out.json 2>/tmp/hyperframes-err.log &
+>
+> # 2. Poll every ~30s until the JSON lands. Budget 3-7 minutes.
+> #    Tell the user it is rendering BEFORE you start waiting.
+> cat /tmp/hyperframes-out.json
+> ```
+>
+> Say "this takes a few minutes, I'll post the link when it's done" in the turn
+> you start the render. Do not go silent, and do not start a second render
+> because the first looks stuck — it is not stuck, it is encoding.
+>
+> Lower `--fps` (24, or 15 for static title cards) to cut render time roughly
+> proportionally. `--fps 15` on a 6-second card is about a quarter the work of
+> `--fps 60`.
+
 ```bash
 node /opt/psd-skills/psd-hyperframes/render.js \
   --file scene.html \

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -198,6 +198,35 @@ If a skill exists for a task, its interface is the **only** path. Do not write B
 - Did the last tool result contain a `url`? Is that exact URL on a line by itself in my reply? If no, fix it.
 - Does my reply contain `X-Amz-Signature`, `X-Amz-Security-Token`, or `X-Amz-Expires`? If yes, I built the URL myself — undo it.
 
+### 9a — Never parse a skill's output with an inline script
+
+Do not pipe a skill's JSON through `python3 -c`, `node -e`, or a heredoc. Call
+the skill's CLI again with the flags that return what you want.
+
+This is the single most common way turns are lost. On 2026-08-10 it hit three
+separate users in one day: a Gmail digest, a Morning Brief, and a Superintendent
+Brief all died the same way, and one user lost roughly 50 minutes to it.
+
+**Why it fails:** the newlines in an inline script have to survive the tool
+call, the shell, and the interpreter. They usually do not — the script arrives
+with a literal `\n` where a real line break belonged and dies on a
+`SyntaxError` before doing any work. Re-writing it with more escaping produces
+a differently-broken file, so the loop can repeat for many turns.
+
+**Do this instead:**
+
+1. Prefer more CLI calls over one script. `node run.js --command "…"` twice
+   beats one `python3 -c` that parses the first call's output.
+2. If you genuinely need a script, `write` it to a real `.py`/`.js` file, then
+   run that file. Never pass a multi-line program as a `-c` argument.
+3. After writing a script file and **before running it**, `head -5` the file.
+   If you see a literal `\n`, the write did not land as intended — rewrite it
+   as a file rather than adding another layer of escaping.
+4. Never hand-author a heredoc (`<<'EOF'`) to build a file. Use `write`.
+
+**Self-check:** does my command contain `python3 -c`, `node -e`, or `<<EOF`? If
+yes, replace it with a skill call or a written-out file before running it.
+
 ---
 
 ## Rule 10 — Skill naming: `psd-` is reserved

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -129,6 +129,24 @@ node /opt/psd-skills/psd-workspace/run.js \
 
 # Create a draft on the user's account (lands in their Drafts folder, marker
 # is auto-appended to the body — they review and send themselves)
+#
+# CREATING DRAFTS IS SUPPORTED AND ALLOWED. If you conclude otherwise, you
+# have the command wrong — re-read this block instead of giving up or
+# hand-rolling a MIME payload.
+#
+#   ✅ RIGHT:  --command "gmail +draft --to … --subject … --body …"
+#   ❌ WRONG:  --command "gws +draft …"        -> "unrecognized subcommand"
+#              `gws` is implied inside --command; naming it makes `gws` the
+#              subcommand. Never write `gws` inside --command.
+#   ❌ WRONG:  bare `gws …` as a shell command -> the image's gws is a wrapper
+#              that refuses direct calls. Always go through run.js.
+#   ❌ WRONG:  --command "gmail +send --draft" -> Phase-1 forbidden. `+send`
+#              is blocked whatever flags follow it. `+draft` is a DIFFERENT
+#              verb and is NOT blocked.
+#
+# "Unrecognized subcommand" means you typed the wrong verb, NOT that drafting
+# is unavailable. On 2026-08-10 an agent hit that error, reported drafts as
+# impossible, and burned the turn writing a raw RFC5322 MIME script instead.
 node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "gmail +draft --to principal@psd401.net --subject 'Follow up' --body 'Hi Bill,...'"
@@ -192,6 +210,21 @@ node /opt/psd-skills/psd-workspace/run.js \
 node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "gmail +draft --to bill@psd401.net --subject 'Follow up' --body-file /tmp/draft-body.txt"
+
+# NO BINARY EMAIL ATTACHMENTS. There is no supported way to attach a file to a
+# draft through this transport. A base64 audio/image part inside a raw
+# multipart/mixed MIME payload is rejected by the broker with
+# `workspace-command-rejected` / "Workspace command contains an invalid
+# argument" — that rejection is the transport refusing binary content, not a
+# malformed payload, so re-encoding it will not help.
+#
+# Deliver the file as a LINK instead, and say so plainly in the same turn:
+#   - audio from psd-tts, video from psd-hyperframes, images from psd-image-gen
+#     already return a public HTTPS URL — paste that URL in the draft body
+#   - anything else: upload to Drive with --scope agent, share it, link it
+#
+# Do not attempt the MIME route first to "see if it works". It does not, and
+# on 2026-08-10 a user lost a turn to it before falling back to a link.
 
 # Chat message text (+send) uses --text-file (replaces --text)
 # Only send after the user explicitly confirms the message. Chat writes must

--- a/infra/hyperframes-render/handler.js
+++ b/infra/hyperframes-render/handler.js
@@ -485,14 +485,32 @@ async function handler(event, deps = {}) {
  * environment, so a regression is diagnosable from logs rather than only the
  * caller's error string. Non-blocking (async execFile) — never affects a render.
  */
+// 30s, not 8s. The check competes with the render it shares a cold start with:
+// on 2026-08-10 one invocation logged FAILED … signal=SIGTERM killed=true
+// after=8218ms while sibling invocations minutes apart ran the same binary in
+// 154ms and 338ms. Nothing was wrong with ffmpeg — the self-check was simply
+// starved of CPU during concurrent init and hit its own timeout. Because this
+// is a diagnostic, a false FAILED is worse than a slow OK: it is the loudest
+// line in the log group and it sends whoever is triaging a real user-facing
+// problem after a broken binary that is not broken.
+const FFMPEG_SELFCHECK_TIMEOUT_MS = 30_000;
+
 function logFfmpegSelfCheck() {
   const bin = process.env.HYPERFRAMES_FFMPEG_PATH || 'ffmpeg';
   const started = Date.now();
-  execFile(bin, ['-version'], { timeout: 8000 }, (err, stdout) => {
+  execFile(bin, ['-version'], { timeout: FFMPEG_SELFCHECK_TIMEOUT_MS }, (err, stdout) => {
     const ms = Date.now() - started;
     if (err) {
-      console.error(
-        `[ffmpeg-selfcheck] FAILED bin=${bin} code=${err.code} signal=${err.signal} killed=${err.killed} after=${ms}ms: ${String(err.message).slice(0, 200)}`,
+      // A timeout kill means "too slow to answer under load", which is NOT
+      // evidence the binary is unusable — say so on the line itself, and use
+      // warn so it cannot be mistaken for a failed render. A real missing or
+      // unrunnable binary still surfaces as an error (ENOENT, non-zero exit).
+      const starved = err.killed === true && err.signal === 'SIGTERM';
+      const level = starved ? console.warn : console.error;
+      level(
+        `[ffmpeg-selfcheck] ${starved ? 'INCONCLUSIVE (timed out under load; NOT a render failure)' : 'FAILED'} ` +
+          `bin=${bin} code=${err.code} signal=${err.signal} killed=${err.killed} after=${ms}ms: ` +
+          `${String(err.message).slice(0, 200)}`,
       );
     } else {
       console.log(`[ffmpeg-selfcheck] OK bin=${bin} after=${ms}ms — ${String(stdout).split('\n')[0]}`);


### PR DESCRIPTION
11 users hit failures today. **Four causes were ours** — all four are addressed here. Each is a case where the platform *could* do the thing and the agent concluded it couldn't, or where the agent had no way to know what to expect.

## 1. Video renders looked broken because nothing said they take minutes

`psd-hyperframes` renders in a Lambda. **Today's production timings: 429s, 418s, 253s, 189s, 180s, 182s** — for scenes a few seconds long, because wall time tracks `fps × duration`, not clip length.

SKILL.md documented a **foreground blocking call** and never mentioned duration. So the agent ran it in the foreground, the tool timeout killed the call while the Lambda kept rendering (and billing), and the agent retried. **One user made six attempts over ~28 minutes and never got a video.**

This never reached `agent_failures` — the skill error wasn't self-reported, so it was invisible in the failure table. It only surfaced because the user mentioned it.

**Fix:** SKILL.md now leads with real timing, tells the agent to background the render and poll, to say "this takes a few minutes" *before* waiting, not to start a second render because the first looks stuck, and to lower `--fps` to cut render time.

## 2. Gmail drafts are supported; the agent decided they weren't

An agent wrote `gws +draft` inside `--command`, got `unrecognized subcommand`, **reported drafting as impossible**, then spent the turn hand-building a raw RFC5322 MIME payload that failed on escaping.

`gmail +draft` is documented, allowlisted in the broker, and matched by **no** `PHASE1_FORBIDDEN` pattern — those cover `+send`/`+reply`/`+reply-all`/`+forward`, and `+draft` is a different verb. Pure wrong-command-form plus wrong conclusion.

**Fix:** SKILL.md states outright that drafting is supported, shows the one correct form, and names the three wrong forms with the exact misleading error each produces — including that `gws` must never appear inside `--command`, and that "unrecognized subcommand" means a wrong verb, not a missing capability.

## 3. Email attachments are impossible; the agent discovered that by failing

A base64 audio part in a `multipart/mixed` draft is rejected with `workspace-command-rejected` / "Workspace command contains an invalid argument" — which reads like a malformed payload and invites re-encoding. It's the transport refusing binary content.

**Fix:** SKILL.md says there's no supported attachment path, re-encoding won't help, and to deliver a link instead (`psd-tts`, `psd-hyperframes`, `psd-image-gen` already return public HTTPS URLs).

## 4. Inline scripts lose whole turns to escaping — new Rule 9a

**Three users in one day**: a Gmail digest, a Morning Brief, and a Superintendent Brief, all dead the same way. One user lost ~50 minutes.

Newlines in a `python3 -c` program or heredoc must survive the tool call, the shell, *and* the interpreter. They arrive as a literal `\n` and the program dies on `SyntaxError` before doing any work. More escaping produces a differently-broken file, so the loop repeats.

One user escaped it by dropping the script and calling the CLI directly — which is what **Rule 9 already says**, so this is **9a** under it, not a new rule: prefer more CLI calls over one script, write a real file if a script is truly needed, `head -5` it before running, never hand-author a heredoc.

## Also: the ffmpeg self-check's 8s timeout was a false alarm

One cold start logged `FAILED … signal=SIGTERM killed=true after=8218ms` while siblings ran the same binary in **154ms and 338ms** — starved of CPU during concurrent init, not broken. The check is diagnostic-only and never affects a render, so a false `FAILED` is worse than a slow `OK`: it's the loudest line in the log group, and **it sent this very investigation after a healthy binary first**.

Timeout → 30s; a timeout kill now logs `INCONCLUSIVE` at `warn`, saying on the line itself that it's not a render failure. A genuinely missing/unrunnable binary still logs `FAILED` at `error`.

## Not addressed — need owners outside this repo

- **`invalid_client` OAuth failure** on `aistudio.psd401.ai` — blocks one user entirely, both agent-connect and Workspace reauth
- **Canva `upload-asset` 401** mid-request after successful consent
- **`psd-data` GROUP BY timeouts** (15–30s, 6+ attempts) — warehouse-side

## Verification

- Bootstrap budget with Rule 9a fused in: **34,481/64,000** per file, **37,656/80,000** total
- hyperframes handler: **24/24** bun tests
- psd-workspace skill: **84/84**
- agent-image suite: **687 tests**
- `eslint --max-warnings 0` clean

Needs a rebuilt image to reach users — these are skill/prompt files plus a Lambda handler.