### PR TITLE
fix(oauth): repair the OpenClaw client registration and make redirect URIs editable

### DIFF
--- a/actions/oauth/oauth-client.actions.ts
+++ b/actions/oauth/oauth-client.actions.ts
@@ -323,3 +323,132 @@ export async function revokeOAuthClient(
     })
   }
 }
+
+const updateOAuthClientRedirectUrisInputSchema = z.object({
+  clientId: z.string().trim().min(1).max(255),
+  redirectUris: z.array(z.string()).min(1),
+  // Reactivating is part of the same edit: a client is often revoked precisely
+  // because its redirect list was wrong and revoke was the only control that
+  // existed. Omitted leaves the current state alone.
+  isActive: z.boolean().optional(),
+})
+
+export type UpdateOAuthClientRedirectUrisInput = z.infer<
+  typeof updateOAuthClientRedirectUrisInputSchema
+>
+
+/**
+ * Update a registered client's redirect URIs (and optionally reactivate it).
+ *
+ * Deliberately narrow. Before this existed the admin surface was
+ * create/list/revoke only, so a client with one bad redirect URI could not be
+ * corrected at all — on 2026-08-10 that took out agent-connect for every user,
+ * and revoking was the only button available (see migration 176). Redirect
+ * URIs are the field that actually rots: hosts move, dev callbacks get left
+ * behind, extension ids change.
+ *
+ * NOT editable here, on purpose. `applicationType`, `tokenEndpointAuthMethod`,
+ * `requirePkce`, the secret and the scopes all define the client's security
+ * profile, and changing them on a live registration silently alters what an
+ * already-issued grant means. Those still require creating a new client.
+ *
+ * The new URIs are validated against the STORED application type, never a
+ * caller-supplied one, so a native client cannot be relaxed into web rules by
+ * passing a different type alongside the URIs.
+ */
+export async function updateOAuthClientRedirectUris(
+  input: UpdateOAuthClientRedirectUrisInput
+): Promise<ActionState<{ clientId: string; redirectUris: string[] }>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("updateOAuthClientRedirectUris")
+  const log = createLogger({
+    requestId,
+    action: "updateOAuthClientRedirectUris",
+  })
+
+  try {
+    await requireRole("administrator")
+
+    const validated = updateOAuthClientRedirectUrisInputSchema.parse(input)
+
+    const [existing] = await executeQuery(
+      (db) =>
+        db
+          .select({
+            applicationType: oauthClients.applicationType,
+          })
+          .from(oauthClients)
+          .where(eq(oauthClients.clientId, validated.clientId))
+          .limit(1),
+      "updateOAuthClientRedirectUris.load"
+    )
+
+    if (!existing) {
+      throw ErrorFactories.dbRecordNotFound("oauth_clients", validated.clientId)
+    }
+
+    const applicationType = existing.applicationType as OAuthApplicationType
+    const uriValidation = validateOAuthRedirectUris(
+      applicationType,
+      validated.redirectUris
+    )
+    if (!uriValidation.valid) {
+      // Surfaced to the admin editing the form, who typed these and needs the
+      // full string to correct them. The adapter redacts before LOGGING; this
+      // path returns them to the authenticated administrator instead.
+      log.warn("Rejected redirect URI update", {
+        clientId: validated.clientId,
+        errorCount: uriValidation.errors.length,
+      })
+      throw ErrorFactories.invalidInput(
+        "redirectUris",
+        validated.redirectUris,
+        uriValidation.errors.join("; ")
+      )
+    }
+
+    const updated = await executeQuery(
+      (db) =>
+        db
+          .update(oauthClients)
+          .set({
+            redirectUris: uriValidation.normalizedUris,
+            ...(validated.isActive === undefined
+              ? {}
+              : { isActive: validated.isActive }),
+            updatedAt: new Date(),
+          })
+          .where(eq(oauthClients.clientId, validated.clientId))
+          .returning({ id: oauthClients.id }),
+      "updateOAuthClientRedirectUris"
+    )
+
+    if (updated.length === 0) {
+      // Same reasoning as revokeOAuthClient: never report a successful edit for
+      // a row that did not change, or an admin believes a broken client is fixed.
+      throw ErrorFactories.dbRecordNotFound("oauth_clients", validated.clientId)
+    }
+
+    timer({ status: "success" })
+    log.info("OAuth client redirect URIs updated", {
+      clientId: validated.clientId,
+      uriCount: uriValidation.normalizedUris.length,
+      isActive: validated.isActive,
+    })
+
+    return createSuccess(
+      {
+        clientId: validated.clientId,
+        redirectUris: uriValidation.normalizedUris,
+      },
+      "OAuth client updated"
+    )
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to update OAuth client", {
+      context: "updateOAuthClientRedirectUris",
+      requestId,
+      operation: "updateOAuthClientRedirectUris",
+    })
+  }
+}

--- a/app/(protected)/admin/oauth-clients/_components/edit-redirect-uris-dialog.tsx
+++ b/app/(protected)/admin/oauth-clients/_components/edit-redirect-uris-dialog.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+/**
+ * Edit a registered client's redirect URIs, and reactivate it if it was revoked.
+ *
+ * Before this existed the admin surface was create/list/revoke only, and the
+ * actions column rendered nothing at all once a client was inactive. A client
+ * whose redirect list was wrong therefore could not be corrected — on
+ * 2026-08-10 one stale `http://localhost:3000/...` entry took agent-connect
+ * down for every user, revoking was the only available control, and repairing
+ * the row needed a migration and a deploy (see migration 176).
+ *
+ * Scope matches the server action: redirect URIs and active state only. The
+ * security profile (application type, auth method, PKCE, secret, scopes) still
+ * requires registering a new client, because changing it on a live
+ * registration silently alters what an already-issued grant means.
+ */
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Pencil } from "lucide-react"
+import { updateOAuthClientRedirectUris } from "@/actions/oauth/oauth-client.actions"
+import type { OAuthClientRow } from "@/actions/oauth/oauth-client.actions"
+import { meridianPortalClassName } from "@/lib/meridian/fonts"
+
+export function EditRedirectUrisDialog({
+  client,
+  onSaved,
+}: {
+  client: OAuthClientRow
+  onSaved: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [value, setValue] = useState(client.redirectUris.join("\n"))
+  const [reactivate, setReactivate] = useState(!client.isActive)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    setSaving(true)
+    setError(null)
+    const redirectUris = value
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+
+    const result = await updateOAuthClientRedirectUris({
+      clientId: client.clientId,
+      redirectUris,
+      ...(client.isActive ? {} : { isActive: reactivate }),
+    })
+    setSaving(false)
+
+    if (!result.isSuccess) {
+      // The validator's message names the offending URI and why it was
+      // rejected. Show it verbatim — the admin typed these and cannot fix them
+      // from a generic failure.
+      setError(result.message || "Failed to update client")
+      return
+    }
+    setOpen(false)
+    onSaved()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (next) {
+          // Reopening after a failed edit should show what is stored, not the
+          // rejected draft.
+          setValue(client.redirectUris.join("\n"))
+          setReactivate(!client.isActive)
+          setError(null)
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" aria-label="Edit redirect URIs">
+          <Pencil className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className={`sm:max-w-lg ${meridianPortalClassName}`}>
+        <DialogHeader>
+          <DialogTitle>Edit redirect URIs</DialogTitle>
+          <DialogDescription>
+            One URI per line for &quot;{client.clientName}&quot;. Rules follow
+            the client&apos;s registered type ({client.applicationType}) — a
+            native client, for example, must use a literal{" "}
+            <code>127.0.0.1</code> or <code>[::1]</code> for HTTP callbacks,
+            never <code>localhost</code>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="redirect-uris">Redirect URIs</Label>
+            <Textarea
+              id="redirect-uris"
+              rows={5}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              className="font-mono text-xs"
+            />
+          </div>
+
+          {!client.isActive && (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="reactivate"
+                checked={reactivate}
+                onCheckedChange={(checked) => setReactivate(checked === true)}
+              />
+              <Label htmlFor="reactivate" className="font-normal">
+                Reactivate this client
+              </Label>
+            </div>
+          )}
+
+          {error && (
+            <p
+              role="alert"
+              className="text-sm text-destructive whitespace-pre-wrap"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/(protected)/admin/oauth-clients/_components/oauth-clients-page-client.tsx
+++ b/app/(protected)/admin/oauth-clients/_components/oauth-clients-page-client.tsx
@@ -39,6 +39,7 @@ import {
 import { ClientFormSheet } from "./client-form-sheet"
 import type { OAuthClientRow } from "@/actions/oauth/oauth-client.actions"
 import { revokeOAuthClient, listOAuthClients } from "@/actions/oauth/oauth-client.actions"
+import { EditRedirectUrisDialog } from "./edit-redirect-uris-dialog"
 import { Plus, Ban } from "lucide-react"
 import { meridianPortalClassName } from "@/lib/meridian/fonts"
 
@@ -60,9 +61,11 @@ function applicationTypeLabel(client: OAuthClientRow): string {
 function OAuthClientTableRow({
   client,
   onRevoke,
+  onSaved,
 }: {
   client: OAuthClientRow
   onRevoke: (clientId: string) => void
+  onSaved: () => void
 }) {
   return (
     <TableRow>
@@ -97,7 +100,11 @@ function OAuthClientTableRow({
           {client.allowedScopes.length} scope(s)
         </span>
       </TableCell>
-      <TableCell>
+      <TableCell className="flex items-center gap-1">
+        {/* Editing stays available on a REVOKED client. This column used to
+            render nothing once isActive went false, which left a client that
+            was revoked because its redirect list was wrong with no way back. */}
+        <EditRedirectUrisDialog client={client} onSaved={onSaved} />
         {client.isActive && (
           <AlertDialog>
             <AlertDialogTrigger asChild>
@@ -213,6 +220,7 @@ export function OAuthClientsPageClient({ initialClients }: Props) {
                   key={client.id}
                   client={client}
                   onRevoke={handleRevoke}
+                  onSaved={() => void refresh()}
                 />
               ))}
             </TableBody>

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -165,6 +165,7 @@
     "172-content-data-records.sql",
     "173-repository-index-generation-retention.sql",
     "174-unified-content-message-sanitizer-recovery.sql",
-    "175-atrium-library-usability.sql"
+    "175-atrium-library-usability.sql",
+    "176-openclaw-oauth-client-redirect-repair.sql"
   ]
 }

--- a/infra/database/schema/176-openclaw-oauth-client-redirect-repair.sql
+++ b/infra/database/schema/176-openclaw-oauth-client-redirect-repair.sql
@@ -1,0 +1,50 @@
+-- Migration 176: Repair the PSD OpenClaw OAuth client registration.
+--
+-- Two problems in one row, both user-visible as a generic `invalid_client`:
+--
+-- 1. The client carries a dev-only `http://localhost:3000/...` redirect URI.
+--    Its application_type is `native`, and lib/oauth/redirect-uri-policy.ts
+--    rejects an HTTP redirect whose host is not a literal loopback address —
+--    LOOPBACK_HOSTS is {"127.0.0.1", "[::1]"}, and `localhost` is not in it
+--    (RFC 8252 section 7.3). Redirect validation in DrizzleOidcAdapter is
+--    all-or-nothing, so that single entry made loadClient() return undefined
+--    and oidc-provider answer `invalid_client`. The two correct production
+--    URIs never got a chance, and agent-connect was broken for EVERY user, not
+--    just the one who reported it (prod errors 2026-08-10 19:35:28, 19:36:25,
+--    19:39:43 UTC).
+--
+-- 2. is_active was set to false on 2026-08-10 23:18 UTC. The admin UI exposes
+--    only create/list/revoke — there is no way to edit a redirect URI — so
+--    revoking was the only control available for a client that plainly needed
+--    changing. This migration reverses that, and the accompanying change adds
+--    the missing update path so the next fix does not need a deploy.
+--
+-- Verified before writing this: the client had 0 refresh tokens, 0 access
+-- tokens and 0 authorization codes, so nothing was ever issued against it and
+-- reactivating grants nothing retroactively.
+--
+-- The guard pins the exact current redirect array and the public-PKCE native
+-- profile, so an administrator-modified or unrelated client is never
+-- overwritten. Re-running after a successful update is an intentional no-op,
+-- and the migration is a no-op in any environment whose row already differs.
+--
+-- Rollback:
+-- UPDATE oauth_clients
+-- SET
+--   redirect_uris = '["http://localhost:3000/agent-connect-aistudio/callback", "https://dev.aistudio.psd401.ai/agent-connect-aistudio/callback", "https://aistudio.psd401.ai/agent-connect-aistudio/callback"]'::jsonb,
+--   is_active = false,
+--   updated_at = NOW()
+-- WHERE client_id = '7e8646f4-4091-4a34-a6b9-0d3721e8a126';
+
+UPDATE oauth_clients
+SET
+  redirect_uris = '["http://127.0.0.1:3000/agent-connect-aistudio/callback", "https://dev.aistudio.psd401.ai/agent-connect-aistudio/callback", "https://aistudio.psd401.ai/agent-connect-aistudio/callback"]'::jsonb,
+  is_active = true,
+  updated_at = NOW()
+WHERE client_id = '7e8646f4-4091-4a34-a6b9-0d3721e8a126'
+  AND application_type = 'native'
+  AND token_endpoint_auth_method = 'none'
+  AND client_secret_hash IS NULL
+  AND require_pkce = true
+  AND is_first_party = true
+  AND redirect_uris = '["http://localhost:3000/agent-connect-aistudio/callback", "https://dev.aistudio.psd401.ai/agent-connect-aistudio/callback", "https://aistudio.psd401.ai/agent-connect-aistudio/callback"]'::jsonb;

--- a/tests/unit/actions/oauth-client-actions.test.ts
+++ b/tests/unit/actions/oauth-client-actions.test.ts
@@ -217,3 +217,72 @@ const defineRevokeOAuthClientREVCOR055Suite1 = () => {
 };
 
 describe('revokeOAuthClient (REV-COR-055)', defineRevokeOAuthClientREVCOR055Suite1)
+
+describe('updateOAuthClientRedirectUris', () => {
+  let updateOAuthClientRedirectUris: typeof import('@/actions/oauth/oauth-client.actions').updateOAuthClientRedirectUris
+
+  beforeAll(async () => {
+    const actions = await import('@/actions/oauth/oauth-client.actions')
+    updateOAuthClientRedirectUris = actions.updateOAuthClientRedirectUris
+  })
+  beforeEach(() => { jest.clearAllMocks(); mockRequireRole.mockResolvedValue(undefined) })
+
+  it('requires the administrator role', async () => {
+    mockRequireRole.mockRejectedValueOnce(new Error('forbidden'))
+    const result = await updateOAuthClientRedirectUris({
+      clientId: 'c1', redirectUris: ['https://example.com/cb'],
+    })
+    expect(result.isSuccess).toBe(false)
+    expect(mockExecuteQuery).not.toHaveBeenCalled()
+  })
+
+  it('repairs the real localhost case and can reactivate in the same edit', async () => {
+    // The migration-176 scenario, done through the UI instead.
+    mockExecuteQuery
+      .mockResolvedValueOnce([{ applicationType: 'native' }])
+      .mockResolvedValueOnce([{ id: 1 }])
+    const result = await updateOAuthClientRedirectUris({
+      clientId: '7e8646f4-4091-4a34-a6b9-0d3721e8a126',
+      redirectUris: [
+        'http://127.0.0.1:3000/agent-connect-aistudio/callback',
+        'https://aistudio.psd401.ai/agent-connect-aistudio/callback',
+      ],
+      isActive: true,
+    })
+    expect(result.isSuccess).toBe(true)
+  })
+
+  it('rejects a URI the stored application type forbids', async () => {
+    // `localhost` over HTTP is exactly what broke agent-connect; a native
+    // client must not be able to store it again through this path.
+    mockExecuteQuery.mockResolvedValueOnce([{ applicationType: 'native' }])
+    const result = await updateOAuthClientRedirectUris({
+      clientId: 'c1',
+      redirectUris: ['http://localhost:3000/agent-connect-aistudio/callback'],
+    })
+    expect(result.isSuccess).toBe(false)
+    // Load happened; the UPDATE must not have.
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(1)
+  })
+
+  it('validates against the STORED type, ignoring any caller-supplied type', async () => {
+    // A web-only HTTPS host URI is invalid for a native client. Passing
+    // applicationType alongside it must not relax the rules.
+    mockExecuteQuery.mockResolvedValueOnce([{ applicationType: 'native' }])
+    const result = await updateOAuthClientRedirectUris({
+      clientId: 'c1',
+      redirectUris: ['https://example.com:8443/cb'],
+      ...({ applicationType: 'web' } as Record<string, unknown>),
+    })
+    expect(result.isSuccess).toBe(false)
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails when no row matched instead of reporting a false success', async () => {
+    mockExecuteQuery.mockResolvedValueOnce([])
+    const result = await updateOAuthClientRedirectUris({
+      clientId: 'missing', redirectUris: ['https://example.com/cb'],
+    })
+    expect(result.isSuccess).toBe(false)
+  })
+})

--- a/tests/unit/oauth-clients-admin-trust.test.tsx
+++ b/tests/unit/oauth-clients-admin-trust.test.tsx
@@ -41,6 +41,15 @@ jest.mock(
     ClientFormSheet: () => null,
   })
 )
+// Stubbed for the same reason as ClientFormSheet: this suite asserts trust and
+// status rendering, not the edit dialog's internals. Its own behaviour is
+// covered by tests/unit/oauth-edit-redirect-uris-dialog.test.tsx.
+jest.mock(
+  "@/app/(protected)/admin/oauth-clients/_components/edit-redirect-uris-dialog",
+  () => ({
+    EditRedirectUrisDialog: () => null,
+  })
+)
 jest.mock("@/components/ui/sheet", () => {
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <div>{children}</div>

--- a/tests/unit/oauth-edit-redirect-uris-dialog.test.tsx
+++ b/tests/unit/oauth-edit-redirect-uris-dialog.test.tsx
@@ -1,0 +1,182 @@
+/** @jest-environment jsdom */
+
+/**
+ * The admin OAuth surface was create/list/revoke only, and the actions column
+ * rendered nothing once a client was inactive. A client revoked *because* its
+ * redirect list was wrong was therefore unrecoverable from the UI — which is
+ * exactly what happened to the PSD OpenClaw client on 2026-08-10.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { EditRedirectUrisDialog } from "@/app/(protected)/admin/oauth-clients/_components/edit-redirect-uris-dialog"
+import { updateOAuthClientRedirectUris } from "@/actions/oauth/oauth-client.actions"
+
+jest.mock("@/actions/oauth/oauth-client.actions", () => ({
+  updateOAuthClientRedirectUris: jest.fn(),
+}))
+jest.mock("@/lib/meridian/fonts", () => ({ meridianPortalClassName: "" }))
+jest.mock("lucide-react", () => ({ Pencil: () => <span>edit</span> }))
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    "aria-label": ariaLabel,
+  }: {
+    children: ReactNode
+    onClick?: () => void
+    disabled?: boolean
+    "aria-label"?: string
+  }) => (
+    <button onClick={onClick} disabled={disabled} aria-label={ariaLabel}>
+      {children}
+    </button>
+  ),
+}))
+jest.mock("@/components/ui/label", () => ({
+  Label: ({ children }: { children: ReactNode }) => <label>{children}</label>,
+}))
+jest.mock("@/components/ui/textarea", () => ({
+  Textarea: ({
+    value,
+    onChange,
+  }: {
+    value: string
+    onChange: (e: { target: { value: string } }) => void
+  }) => (
+    <textarea
+      aria-label="uris"
+      value={value}
+      onChange={(e) => onChange({ target: { value: e.target.value } })}
+    />
+  ),
+}))
+jest.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+  }: {
+    checked?: boolean
+    onCheckedChange?: (c: boolean) => void
+  }) => (
+    <input
+      type="checkbox"
+      aria-label="reactivate"
+      checked={!!checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+    />
+  ),
+}))
+// Render the dialog inline so the content is always present.
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+}))
+
+const mockUpdate = updateOAuthClientRedirectUris as jest.MockedFunction<
+  typeof updateOAuthClientRedirectUris
+>
+
+const revokedClient = {
+  id: 1,
+  clientId: "7e8646f4-4091-4a34-a6b9-0d3721e8a126",
+  clientName: "PSD OpenClaw",
+  applicationType: "native" as const,
+  redirectUris: [
+    "http://localhost:3000/agent-connect-aistudio/callback",
+    "https://aistudio.psd401.ai/agent-connect-aistudio/callback",
+  ],
+  allowedScopes: ["openid"],
+  grantTypes: ["authorization_code"],
+  tokenEndpointAuthMethod: "none",
+  requirePkce: true,
+  isActive: false,
+  isFirstParty: true,
+  accessTokenTtl: 3600,
+  refreshTokenTtl: 2592000,
+  createdAt: new Date("2026-07-29T00:00:00.000Z"),
+  updatedAt: new Date("2026-08-10T23:18:08.000Z"),
+}
+
+describe("EditRedirectUrisDialog", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it("is available on a REVOKED client and offers reactivation", () => {
+    render(<EditRedirectUrisDialog client={revokedClient} onSaved={() => {}} />)
+    expect(screen.getByLabelText("uris")).toHaveValue(
+      revokedClient.redirectUris.join("\n")
+    )
+    expect(screen.getByLabelText("reactivate")).toBeChecked()
+  })
+
+  it("saves the corrected URI list and reactivates in one call", async () => {
+    mockUpdate.mockResolvedValue({
+      isSuccess: true,
+      message: "ok",
+      data: { clientId: revokedClient.clientId, redirectUris: [] },
+    })
+    const onSaved = jest.fn()
+    render(<EditRedirectUrisDialog client={revokedClient} onSaved={onSaved} />)
+
+    fireEvent.change(screen.getByLabelText("uris"), {
+      target: {
+        value:
+          "http://127.0.0.1:3000/agent-connect-aistudio/callback\nhttps://aistudio.psd401.ai/agent-connect-aistudio/callback",
+      },
+    })
+    fireEvent.click(screen.getByText("Save"))
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+    expect(mockUpdate).toHaveBeenCalledWith({
+      clientId: revokedClient.clientId,
+      redirectUris: [
+        "http://127.0.0.1:3000/agent-connect-aistudio/callback",
+        "https://aistudio.psd401.ai/agent-connect-aistudio/callback",
+      ],
+      isActive: true,
+    })
+    await waitFor(() => expect(onSaved).toHaveBeenCalled())
+  })
+
+  it("shows the validator's message verbatim so the admin can fix the URI", async () => {
+    mockUpdate.mockResolvedValue({
+      isSuccess: false,
+      message:
+        "http://localhost:3000/cb: native HTTP redirect URIs must use literal 127.0.0.1 or [::1]",
+    })
+    const onSaved = jest.fn()
+    render(<EditRedirectUrisDialog client={revokedClient} onSaved={onSaved} />)
+    fireEvent.click(screen.getByText("Save"))
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "must use literal 127.0.0.1"
+      )
+    )
+    expect(onSaved).not.toHaveBeenCalled()
+  })
+
+  it("drops blank lines rather than submitting empty URIs", async () => {
+    mockUpdate.mockResolvedValue({
+      isSuccess: true,
+      message: "ok",
+      data: { clientId: revokedClient.clientId, redirectUris: [] },
+    })
+    render(<EditRedirectUrisDialog client={revokedClient} onSaved={() => {}} />)
+    fireEvent.change(screen.getByLabelText("uris"), {
+      target: { value: "\n  https://a.example/cb  \n\n" },
+    })
+    fireEvent.click(screen.getByText("Save"))
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+    expect(mockUpdate.mock.calls[0][0].redirectUris).toEqual([
+      "https://a.example/cb",
+    ])
+  })
+})


### PR DESCRIPTION
Agent-connect has been broken in prod **for every user**, and the admin surface had no way to fix it. This closes both halves.

## Migration 176 — repair the row

The `PSD OpenClaw` client (`7e8646f4…`) carried a dev-only `http://localhost:3000/agent-connect-aistudio/callback` alongside two correct production URIs. Its `application_type` is `native`, and the policy rejects an HTTP redirect whose host isn't a literal loopback address — `LOOPBACK_HOSTS` is `{"127.0.0.1", "[::1]"}`, and `localhost` isn't in it (RFC 8252 §7.3).

Redirect validation is **all-or-nothing**, so that single entry made `loadClient()` return `undefined` and `oidc-provider` answer `invalid_client`. The two valid URIs never got a chance. The prod errors at `19:35:28 / 19:36:25 / 19:39:43` UTC are one user's three attempts — but the client was dead for everyone.

The row was also revoked at 23:18 UTC — reasonably, since **revoke was the only control the UI offered** for a client that plainly needed changing. The migration restores `is_active` and corrects the URI, guarded on the exact current redirect array and the public-PKCE native profile so an administrator-modified or unrelated client is never overwritten.

**Verified before committing**, against a throwaway postgres:

| check | result |
|---|---|
| applies once | `UPDATE 1` |
| re-run is a no-op | `UPDATE 0` |
| resulting array validates | `VALID: true, ERRORS: []` |
| tokens affected by reactivation | 0 refresh / 0 access / 0 codes — nothing was ever issued |

## `updateOAuthClientRedirectUris` — remove the dead end

Admin actions were create/list/revoke only, and the actions column rendered **nothing** once `isActive` went false. A client revoked *because* its redirect list was wrong was unrecoverable without a migration and a deploy — exactly the situation migration 176 exists to undo.

The action is deliberately narrow: **redirect URIs and active state, nothing else**. `applicationType`, `tokenEndpointAuthMethod`, `requirePkce`, the secret and the scopes define the security profile, and changing those on a live registration silently alters what an already-issued grant means — those still require a new client.

New URIs are validated against the **stored** application type, never a caller-supplied one, so a native client can't be relaxed into web rules by passing a type alongside the URIs. A zero-row update fails rather than reporting a false success, matching `revokeOAuthClient` (REV-COR-055).

The dialog stays available on a revoked client and offers reactivation in the same save. Validation failures are shown **verbatim** — the admin typed the URI and can't correct it from a generic error. That's the opposite of the adapter's *log* path (#1628), which redacts: this text goes to an authenticated administrator looking at their own input, not to CloudWatch.

## Tests

**Action (5):** admin role required before any query · the real localhost repair with reactivation · a native-forbidden URI that must not reach the UPDATE · validation against the stored type while ignoring a caller-supplied one · no-false-success on zero rows

**Dialog (4):** present and pre-checked on a revoked client · corrected list + reactivation in one call · verbatim error display · blank-line trimming

Also mocked the new dialog in `oauth-clients-admin-trust.test.tsx`, which renders the page client and doesn't mock `@/components/ui/dialog` — the same treatment it already gives `ClientFormSheet`.

**112 tests pass** across the OAuth suites; eslint clean; typecheck clean.

## After deploy

The migration fixes the row automatically. No manual admin step needed — and if a redirect URI ever goes wrong again, it's now editable in the UI without a deploy.