### PR TITLE
fix(e2e): verify the dev router resolved the deepest app route before running the suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ infra/agent-image/.candidate-staging.*/
 infra/agent-image/skills/validated-fs.cjs
 # Staged from lib/agent-workspace/workspace-policy.json for the image build.
 infra/agent-image/workspace_policy.json
+
+# Throwaway watcher-event file created by scripts/test/e2e-local.sh to force a
+# Next dev route-table rebuild. Its exit trap removes it; this is the backstop
+# for a SIGKILL or host crash inside the ~1s window it exists.
+app/.e2e-router-kick.tmp

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -72,8 +72,9 @@ LOCK_DIR="/tmp/aistudio-e2e-local.lock"
 # Throwaway file used to force a watchpack route-table rebuild (see the router
 # canary block below). It MUST live under app/ for Next's watcher to see it, so
 # it cannot go in /tmp — which means an interrupt during its ~1s lifetime would
-# otherwise strand it in the worktree (the path is not gitignored). Declared here
-# so on_exit can remove it unconditionally.
+# otherwise strand it in the worktree. Declared here so on_exit can remove it
+# unconditionally; .gitignore lists it too, as the backstop for the one case the
+# trap cannot cover (SIGKILL or a host crash inside that window).
 ROUTER_KICK_FILE="app/.e2e-router-kick.tmp"
 
 # Evidence-screenshot paths the specs write into. These are TRACKED files (they
@@ -342,15 +343,39 @@ ROUTER_OK=0
 for attempt in $(seq 1 10); do
   canary_status="$(curl -s -o /dev/null --max-time 15 -w '%{http_code}' "$BASE$CANARY_URL")"
   if [ "$canary_status" != "404" ] && [ "$canary_status" != "000" ] && [ -n "$canary_status" ]; then ROUTER_OK=1; break; fi
-  echo "e2e-local: dev router has not resolved $CANARY_URL (HTTP ${canary_status:-none}) — kicking the route-table scan (attempt $attempt)…"
+  # 404 and "no response at all" are DIFFERENT failures and worth separating in
+  # the log: a 404 is the watchpack route-table drop this block exists to fix
+  # (kicking helps), while 000/empty means curl never got a response — the
+  # server is unreachable, wedged, or slower than --max-time, which kicking
+  # will not fix. Kick either way (cheap, and a wedged server may still recover),
+  # but say which one is happening so the operator reads the right runbook.
+  if [ "$canary_status" = "404" ]; then
+    echo "e2e-local: dev router has not resolved $CANARY_URL (HTTP 404 — route dropped from the table) — kicking the route-table scan (attempt $attempt)…"
+  else
+    echo "e2e-local: no response from $BASE$CANARY_URL (curl status ${canary_status:-none} — server unreachable or timed out, NOT a route-table drop) — retrying (attempt $attempt)…"
+  fi
   touch "$ROUTER_KICK_FILE"
   sleep 1
   rm -f "$ROUTER_KICK_FILE"
   sleep 2
 done
 if [ "$ROUTER_OK" != "1" ]; then
-  echo "❌ e2e-local: dev router never resolved the deepest app route ($CANARY_URL after 10 kicks)."
-  echo "   The suite would 404-flake on real routes. Restart the server on :$E2E_PORT and rerun."
+  # Name the failure mode the LAST probe actually saw — they need different fixes.
+  if [ "$canary_status" = "404" ]; then
+    echo "❌ e2e-local: dev router never resolved the deepest app route ($CANARY_URL still 404 after 10 kicks)."
+    echo "   The route is missing from the table, so the suite would 404-flake on real routes."
+    echo "   Restart the server on :$E2E_PORT and rerun."
+  else
+    echo "❌ e2e-local: dev server on :$E2E_PORT never answered the canary probe ($CANARY_URL, curl status ${canary_status:-none} after 10 attempts)."
+    echo "   This is a server health problem, not a route-table drop."
+    if [ "$REUSE" = "1" ]; then
+      # A reused server was started elsewhere, so SERVER_LOG is not its log.
+      echo "   The server on :$E2E_PORT was reused, not started here — check the terminal that owns it."
+    else
+      echo "   Last log lines ($SERVER_LOG):"; tail -20 "$SERVER_LOG" 2>/dev/null
+    fi
+    echo "   Confirm nothing else owns :$E2E_PORT, then restart and rerun."
+  fi
   exit 1
 fi
 echo "e2e-local: dev router canary $CANARY_URL resolved (HTTP $canary_status)"

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -302,6 +302,40 @@ else
   fi
 fi
 
+# --- Verify the dev router resolved the deepest app route ---------------------------
+# `next dev` builds its route table from a watchpack scan of app/; under a loaded
+# cold boot the first scan aggregation can fire before the deepest files have been
+# discovered/stat'ed (next@16.2.12 setup-dev-bundler skips any file whose watch
+# metadata is incomplete). Routes missed by that scan are silently DROPPED from the
+# table — requests 404 without ever reaching the handler (guard specs expecting 401
+# see 404) — and NOTHING rebuilds the table until another file event lands under
+# app/. Observed 2026-08-10: app/api/v1/repositories/[id]/items/uploads/[sessionId]/
+# complete (the deepest route) 404'd persistently on a fresh boot and healed the
+# moment its file was touched. Deepest files are enumerated last, so the current
+# deepest route.ts is the canary: probe it; on 404, force a table rebuild with a
+# throwaway (non-page) file event in app/ and re-probe. Reused servers are checked
+# too — one may have booted with the same drop and never received a healing event.
+# Any non-404 status proves the ROUTER resolved the route (405/401 are fine — the
+# canary is probed with GET and without auth on purpose).
+CANARY_FILE="$(find app -name 'route.ts' | awk -F/ '{ print NF, $0 }' | sort -rn | head -1 | cut -d' ' -f2-)"
+CANARY_URL="$(printf '%s' "$CANARY_FILE" | sed -E -e 's|^app||' -e 's|/route\.ts$||' -e 's|/\([^/)]*\)||g' -e 's|\[+[^]/]*\]+|1|g')"
+ROUTER_OK=0
+for attempt in $(seq 1 10); do
+  canary_status="$(curl -s -o /dev/null --max-time 15 -w '%{http_code}' "$BASE$CANARY_URL")"
+  if [ "$canary_status" != "404" ] && [ "$canary_status" != "000" ] && [ -n "$canary_status" ]; then ROUTER_OK=1; break; fi
+  echo "e2e-local: dev router has not resolved $CANARY_URL (HTTP ${canary_status:-none}) — kicking the route-table scan (attempt $attempt)…"
+  touch app/.e2e-router-kick.tmp
+  sleep 1
+  rm -f app/.e2e-router-kick.tmp
+  sleep 2
+done
+if [ "$ROUTER_OK" != "1" ]; then
+  echo "❌ e2e-local: dev router never resolved the deepest app route ($CANARY_URL after 10 kicks)."
+  echo "   The suite would 404-flake on real routes. Restart the server on :$E2E_PORT and rerun."
+  exit 1
+fi
+echo "e2e-local: dev router canary $CANARY_URL resolved (HTTP $canary_status)"
+
 # --- Apply pending migrations to the LOCAL database --------------------------------
 # A migration merged to dev but never applied locally silently breaks every route
 # that touches the new table — e.g. the durable API rate limiter (migration 146)

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -69,6 +69,12 @@ STARTED_PID=""
 LOCK_ACQUIRED=0
 CLEANED=0
 LOCK_DIR="/tmp/aistudio-e2e-local.lock"
+# Throwaway file used to force a watchpack route-table rebuild (see the router
+# canary block below). It MUST live under app/ for Next's watcher to see it, so
+# it cannot go in /tmp — which means an interrupt during its ~1s lifetime would
+# otherwise strand it in the worktree (the path is not gitignored). Declared here
+# so on_exit can remove it unconditionally.
+ROUTER_KICK_FILE="app/.e2e-router-kick.tmp"
 
 # Evidence-screenshot paths the specs write into. These are TRACKED files (they
 # are committed as proof for PRs), so every run re-renders ~35 PNGs and leaves
@@ -115,6 +121,8 @@ on_exit() {
   fi
   # Unconditional: the specs write these whoever started the server.
   restore_untouched_shots
+  # Idempotent — covers an INT/TERM landing inside the router-kick window.
+  rm -f "$ROUTER_KICK_FILE"
   [ "$LOCK_ACQUIRED" = "1" ] && rm -rf "$LOCK_DIR"
   return 0
 }
@@ -318,15 +326,26 @@ fi
 # Any non-404 status proves the ROUTER resolved the route (405/401 are fine — the
 # canary is probed with GET and without auth on purpose).
 CANARY_FILE="$(find app -name 'route.ts' | awk -F/ '{ print NF, $0 }' | sort -rn | head -1 | cut -d' ' -f2-)"
+# No canary means no check. An empty CANARY_FILE yields an empty CANARY_URL, so
+# the probe below would hit $BASE (the root page) instead — which essentially
+# never 404s, so ROUTER_OK would pass without ever exercising the real route
+# table, silently defeating this entire block. Fail loudly instead.
+if [ -z "$CANARY_FILE" ]; then
+  echo "❌ e2e-local: found no route.ts under app/ — cannot verify the dev router resolved the route table."
+  echo "   Expected to run from the repo root ($ROOT). Investigate before trusting an E2E run."
+  exit 1
+fi
 CANARY_URL="$(printf '%s' "$CANARY_FILE" | sed -E -e 's|^app||' -e 's|/route\.ts$||' -e 's|/\([^/)]*\)||g' -e 's|\[+[^]/]*\]+|1|g')"
+# Only reachable if the deepest route IS app/route.ts, whose URL is legitimately "/".
+[ -n "$CANARY_URL" ] || CANARY_URL="/"
 ROUTER_OK=0
 for attempt in $(seq 1 10); do
   canary_status="$(curl -s -o /dev/null --max-time 15 -w '%{http_code}' "$BASE$CANARY_URL")"
   if [ "$canary_status" != "404" ] && [ "$canary_status" != "000" ] && [ -n "$canary_status" ]; then ROUTER_OK=1; break; fi
   echo "e2e-local: dev router has not resolved $CANARY_URL (HTTP ${canary_status:-none}) — kicking the route-table scan (attempt $attempt)…"
-  touch app/.e2e-router-kick.tmp
+  touch "$ROUTER_KICK_FILE"
   sleep 1
-  rm -f app/.e2e-router-kick.tmp
+  rm -f "$ROUTER_KICK_FILE"
   sleep 2
 done
 if [ "$ROUTER_OK" != "1" ]; then


### PR DESCRIPTION
## Summary

Kills the intermittent **401→404 flake** in the unauthenticated guard specs (`repository-write-api.guard.spec.ts` "upload completion requires authentication before session lookup"; same shape seen once in `atrium-content-api.guard.spec.ts`) during full local E2E wall runs. On 2026-08-10 it failed 3 of 7 walls (once with both Playwright retries failing) yet passed every targeted rerun.

## Root cause (next@16.2.12, reproduced live)

`next dev`'s **router** builds its route table from a watchpack scan of `app/` (`setup-dev-bundler.js`). Under a loaded cold boot the first scan aggregation can fire before the deepest files have been discovered/stat'ed — any page file whose watch metadata is incomplete at that instant is **silently skipped** when the table is built. A dropped route 404s at the router layer (the request never reaches `withApiAuth`, so a guard spec expecting 401 sees Next's HTML 404 page), and **nothing rebuilds the table until another file event lands under `app/`** — the drop persists for the whole run, because everything the suite writes (screenshots, test-results, `.next-e2e`) is in watcher-ignored paths.

The deepest route in the tree is enumerated last and was the repeat victim:
`app/api/v1/repositories/[id]/items/uploads/[sessionId]/complete/route.ts` (9 directory levels).

Evidence:
- Reproduced on a fresh worktree boot: persistent HTML-404 on that route while shallower siblings 401'd; healed the instant the route file was touched (watch event → table rebuild).
- Application code cannot produce this 404: `middleware.ts` passes `/api/v1/*` through, and `withApiAuth` returns only 401/429/handler-response/500 for unauthenticated callers.
- Targeted reruns always passed because they hit long-lived servers that some later `app/` edit had healed.

## Fix (harness only — no spec changes, the 401 assertion stays strict)

After the dev server is healthy (reused **or** freshly started), `scripts/test/e2e-local.sh` now:
1. Derives the **current deepest** `route.ts` under `app/` at runtime and converts it to a URL (strips `(groups)`, dummy-fills `[params]`).
2. Probes it with an unauthenticated GET — any non-404 (405/401/…) proves the router resolved it.
3. On 404, forces a route-table rebuild by creating+deleting a throwaway non-page file (`app/.e2e-router-kick.tmp`) — verified to trigger watchpack aggregations that rebuild the full table — and re-probes, up to 10 attempts, then aborts loudly instead of running a suite doomed to 404-flake.

Side benefit: the probe pre-compiles the highest-risk route, so the guard spec no longer pays the in-request cold-compile cost (17–27ms vs ~750–1000ms observed).

## Verification

- Canary URL derivation → `/api/v1/repositories/1/items/uploads/1/complete`; healthy-path probe returns 405 with zero kicks and no stray files; kick provably fires rebuild aggregations (instrumented next copy: 1 aggregation at boot → 3 after one create+delete).
- **Three consecutive full walls with the fix, guard spec green in all three** (previously 3/7 red):
  - Wall 1 (cold `.next-e2e`): guard spec 2/2 ✓ — 317 passed; 1 unrelated genuine failure (`nexus-chat-pii-passthrough.functional`: auto-router picked family=openai on a machine with no OpenAI key; fallback doesn't engage — pre-existing, also failed in another worktree's wall the same day).
  - Wall 2 (warm dist): guard spec 2/2 ✓ — 308 passed; 1 unrelated failure (`nexus/model-router.spec` UI click timeout, conversation-row crowding; cleared by `db:cleanup:e2e`).
  - Wall 3 (pre-push hook, after `db:cleanup:e2e`): **319 passed, 0 failed, 0 flaky (8.4m)**.

The nexus auto-router/unconfigured-provider issue is documented separately and left untouched here (different layer; touching Nexus conversation code requires its own review path).
