### PR TITLE
fix(agent): restore token-usage telemetry after the OpenClaw JSONL→SQLite transcript move

### DIFF
--- a/actions/admin/agent-cost-projection.actions.ts
+++ b/actions/admin/agent-cost-projection.actions.ts
@@ -34,11 +34,19 @@ import { handleError, createSuccess } from "@/lib/error-utils"
 import type { ActionState } from "@/types"
 import { requireRole } from "@/lib/auth/role-helpers"
 import { executeQuery } from "@/lib/db/drizzle-client"
-import { sql, gte, inArray, eq, and, isNotNull, ne } from "drizzle-orm"
+import {
+  sql,
+  gte,
+  inArray,
+  notInArray,
+  eq,
+  and,
+  isNotNull,
+} from "drizzle-orm"
 import { agentMessages } from "@/lib/db/schema/tables/agent-messages"
 import { aiModels } from "@/lib/db/schema/tables/ai-models"
 import { getDateThreshold } from "@/lib/date-utils"
-import { AGENT_MODEL_ID } from "@/lib/agents/platform-model"
+import { AGENT_MODEL_ID_ALIASES } from "@/lib/agents/platform-model"
 import { exactTokenCostUsd } from "@/lib/costs/token-cost"
 import type { TelemetryDateRange } from "@/actions/admin/agent-telemetry.actions"
 
@@ -422,12 +430,15 @@ export async function getAgentCostProjection(
 /**
  * List models that have pricing and can be used as projection candidates.
  *
- * Excludes the agent's own model (AGENT_MODEL_ID, anthropic.claude-sonnet-5) —
- * projecting the harness model onto itself is meaningless. Returns ACTIVE models
- * with both input and output prices set, sorted by blended cost so the cheapest
- * alternatives surface first. Inactive models are excluded so a retired model
- * with stale pricing can't be projected (the harness Sonnet 5 row is inactive,
- * so it's excluded here too).
+ * Excludes EVERY id form the harness model has been recorded under
+ * (AGENT_MODEL_ID_ALIASES) — projecting the harness model onto itself is
+ * meaningless, and excluding only the current id would let a re-activated
+ * historical alias (`claude-sonnet-5`, `anthropic.claude-sonnet-5`) slip back
+ * into the candidate list. Returns ACTIVE models with both input and output
+ * prices set, sorted by blended cost so the cheapest alternatives surface first.
+ * Inactive models are excluded so a retired model with stale pricing can't be
+ * projected (all three harness Sonnet 5 rows are inactive today, so the alias
+ * filter is defence in depth rather than the only thing excluding them).
  */
 export async function getPricableModels(): Promise<
   ActionState<PricableModel[]>
@@ -458,8 +469,11 @@ export async function getPricableModels(): Promise<
               eq(aiModels.active, true),
               isNotNull(aiModels.inputCostPer1kTokens),
               isNotNull(aiModels.outputCostPer1kTokens),
-              // Exclude the agent's own model from the candidate list.
-              ne(aiModels.modelId, AGENT_MODEL_ID)
+              // Exclude the agent's own model — every id form it has been
+              // recorded under, not just the current one.
+              // Spread: the exported list is readonly (it is a constant), but
+              // Drizzle's notInArray takes a mutable array.
+              notInArray(aiModels.modelId, [...AGENT_MODEL_ID_ALIASES])
             )
           )
           .orderBy(

--- a/docs/operations/agent-usage-telemetry-backfill.md
+++ b/docs/operations/agent-usage-telemetry-backfill.md
@@ -93,21 +93,40 @@ Up to **8 rows (turns)** share one sessionKey, and the transcript is append-only
 across all of them — so summing a session into one row would inflate it by the
 entire session history.
 
-Each turn's window is reconstructed from the row timestamps:
+**Row timestamps cannot be used as turn boundaries.** The obvious model — turn
+*k* covers `(created_at[k-1], created_at[k]]` — is wrong. The router releases the
+session lock in the `finally` of its invocation wrapper but does not insert the
+telemetry row until after the Google Chat response is sent, so the next turn can
+begin and write transcript records *before* the previous turn's row is stamped.
+The windows overlap and calls get billed to the wrong row.
 
-```
-turn k  =  ( created_at[k-1],  created_at[k] ]
-turn 1  =  ( session start,    created_at[1] ]
-```
+So the **transcript** is segmented by its own turn structure, and the rows supply
+only order and count:
 
-Sound because turns within a session are strictly serial: the router inserts a
-row only after the wrapper finishes the turn, and turn *k* cannot begin until
-turn *k-1* ends. Windows are half-open at the start, so a record on a boundary is
-billed to exactly one turn.
+1. Walk the session's records in append order, cutting a segment after each
+   record whose `stopReason` is terminal (`stop` / `end_turn`). OpenClaw writes
+   `toolUse` on every call that hands off to a tool, so a terminal reason is
+   exactly the end-of-turn marker.
+2. Drop a trailing segment with no terminal reason — an in-flight or aborted
+   turn, which has no row yet.
+3. Pair segment *k* with row *k*, rows ordered by `created_at`.
+4. **If the counts disagree, attribute nothing and report it.** A mismatch means
+   the model of the session is wrong, and guessing would silently misprice turns.
 
-A sessionKey with several windows (rollover, compaction, fork) has all its
-windows merged before attribution, so a mid-session rollover cannot drop the
-pre-rollover calls.
+Two consequences worth knowing:
+
+- The plan needs **every** row of a session, including already-populated ones. A
+  populated row still consumes a segment; loading only the zero rows would slide
+  every later segment onto the wrong row.
+- `--since` is applied to the resulting **updates**, never to the query. Removing
+  a session's earlier rows would delete the anchors that establish its turn
+  order.
+
+Step 4 is also what contains the two things that could otherwise corrupt
+attribution: a duplicate `agent_messages` row (the router's insert carries no
+idempotency key), and a terminal record that carries no `usage` object (dropped
+at parse time, so its segment never gets cut). Both surface as a reported count
+mismatch rather than a mispriced turn.
 
 ### Safety properties
 
@@ -133,7 +152,8 @@ most recent uncheckpointed turns, which under-counts rather than corrupting.
 |---|---|---|
 | `rows to update` | Recoverable rows | The backfill's value |
 | `rows with NO transcript coverage (unrecoverable)` | No covering record, **or** covering records that carry no usage themselves | Expected for pre-2026-07-29 rows; nothing to recover |
-| `unattributed model calls` | Records outside every turn window | **Non-zero means the plan under-counts — investigate before executing** |
+| `unattributed model calls` | Records no paired segment claimed — a trailing in-flight turn, or every record of a session that was skipped | **Non-zero means the plan under-counts — investigate before executing** |
+| `turn count mismatches` | Sessions whose completed-turn count ≠ row count, so nothing was attributed | **Investigate before executing: recoverable in principle, but the session model is wrong** |
 
 Rows before ~2026-07-29 are unrecoverable *by design of the data*: the
 transcripts of that era carry the model calls but no usage numbers on them, so

--- a/docs/operations/agent-usage-telemetry-backfill.md
+++ b/docs/operations/agent-usage-telemetry-backfill.md
@@ -1,0 +1,179 @@
+# Agent usage telemetry: outage and backfill
+
+## What broke
+
+OpenClaw `2026.7.2-beta.5` moved per-session transcripts out of
+
+```
+/home/node/.openclaw/agents/<agentId>/sessions/<sessionId>.jsonl
+```
+
+into a per-agent SQLite database
+
+```
+/home/node/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite
+  table transcript_events(session_id TEXT, seq INTEGER, event_json TEXT, created_at INTEGER)
+```
+
+and **deleted the JSONL files** (the migrated originals are archived under
+`agents/<agentId>/session-sqlite-import-archive/`).
+
+`harness_adapter._read_turn_usage()` — the only source of per-turn token usage on
+the post-#1384 SigV4 path — kept opening the JSONL path. It found nothing and
+returned honest zeros.
+
+**Nothing failed.** A zero read is indistinguishable from a genuine zero once it
+reaches `agent_messages`, so:
+
+- every turn recorded `input_tokens = output_tokens = cache_read_input_tokens = 0`
+- `admin/agents` → Cost tab showed `$0`
+- no error, no alarm, no failed turn, for **ten days**
+
+Dates: **dev from 2026-07-31**, **prod from 2026-08-01**.
+
+**Caching was never broken.** A checkpointed workspace database shows the healthy
+steady state throughout: ~2 billable input tokens against a 54k–71k-token cache
+read per turn. Only the telemetry regressed.
+
+## What was fixed
+
+| Area | Change |
+|---|---|
+| Read path | `harness_adapter` reads `transcript_events` (read-only URI, bound `session_id`, `created_at >= since_ms` prefilter, `ORDER BY seq`). JSONL remains a fallback for older hosts. |
+| Model id | `AGENT_MODEL_ID` corrected to `us.anthropic.claude-sonnet-5`, the id actually recorded since 2026-07-31. |
+| Observability | `agent_messages.usage_capture_complete` (migration 176) + the `UsageCaptureZero` metric and alarm. |
+| History | The backfill below. |
+
+### Why `ORDER BY seq`, not `created_at`
+
+Verified against a real checkpointed database: `created_at` is only *weakly*
+ordered against `seq` — **28 of 32 sessions** contain a row whose `created_at`
+precedes that of a lower `seq`. Turn completeness is decided by the **last**
+record, so ordering by `created_at` misreads it.
+
+`created_at >= since_ms` is still a safe **prefilter** because `created_at` is
+always at or after the record's own `message.timestamp` (488 records, 0
+inversions, skew 0–19,941 ms). It narrows the scan without hiding an in-window
+record; the authoritative window test stays on the record timestamp.
+
+## The backfill
+
+The transcripts survive in the S3-checkpointed workspaces, so the real numbers
+are recoverable.
+
+```bash
+# DRY RUN (default — reads only, writes NOTHING)
+AGENT_WORKSPACE_BUCKET=psd-agents-dev-390844780692 \
+DB_CLUSTER_ARN=arn:aws:rds:us-east-1:390844780692:cluster:aistudio-dev-cluster \
+DB_SECRET_ARN=arn:aws:secretsmanager:us-east-1:390844780692:secret:DbSecret685A0FA5-Tby3OSNjVCjb-i3YrMv \
+bun run db:backfill-agent-usage -- --since=2026-07-30
+
+# EXECUTE (requires BOTH flags)
+... bun run db:backfill-agent-usage -- --since=2026-07-30 \
+      --execute --confirmation=BACKFILL_AGENT_USAGE
+```
+
+Flags: `--prefix=<workspace>` limits to one workspace; `--since=<ISO date>`
+bounds which `agent_messages` rows are considered.
+
+> **Prerequisite:** migration 176 must be applied first — the script reads and
+> writes `usage_capture_complete`.
+
+### Turn attribution
+
+This is the part that matters. `agent_messages.session_id` is a PSD *sessionKey*
+(`agent-chat-<sha256>`), **not** the OpenClaw transcript UUID. The mapping lives
+in the transcript itself:
+
+```
+session_windows.session_key = "agent:main:" + agent_messages.session_id
+```
+
+Up to **8 rows (turns)** share one sessionKey, and the transcript is append-only
+across all of them — so summing a session into one row would inflate it by the
+entire session history.
+
+Each turn's window is reconstructed from the row timestamps:
+
+```
+turn k  =  ( created_at[k-1],  created_at[k] ]
+turn 1  =  ( session start,    created_at[1] ]
+```
+
+Sound because turns within a session are strictly serial: the router inserts a
+row only after the wrapper finishes the turn, and turn *k* cannot begin until
+turn *k-1* ends. Windows are half-open at the start, so a record on a boundary is
+billed to exactly one turn.
+
+A sessionKey with several windows (rollover, compaction, fork) has all its
+windows merged before attribution, so a mid-session rollover cannot drop the
+pre-rollover calls.
+
+### Safety properties
+
+- **Dry-run is the default.** Writing needs `--execute` **and** the exact
+  confirmation token — no single typo can mutate telemetry.
+- **Idempotent.** Every `UPDATE` re-asserts "all four token counters are still
+  zero" in its `WHERE` clause, enforced by the database at write time rather than
+  by the plan computed earlier. A second run updates 0 rows, and a row the fixed
+  live capture has since populated is never clobbered.
+- **Fills only zero rows.** It cannot overwrite a real measurement.
+- **Reconciliation is printed before any write:** transcript totals vs planned
+  totals vs unattributed model calls.
+- One unreadable workspace is logged and skipped, not fatal.
+
+The `-wal` sidecar is deliberately **not** fetched: a checkpointed database may
+carry a stale WAL from an earlier upload, and pairing a current `.sqlite` with an
+older `-wal` can surface a torn state. Reading the main file alone may miss the
+most recent uncheckpointed turns, which under-counts rather than corrupting.
+
+### Reading the report
+
+| Line | Meaning | Action |
+|---|---|---|
+| `rows to update` | Recoverable rows | The backfill's value |
+| `rows with NO transcript coverage (unrecoverable)` | No covering record, **or** covering records that carry no usage themselves | Expected for pre-2026-07-29 rows; nothing to recover |
+| `unattributed model calls` | Records outside every turn window | **Non-zero means the plan under-counts — investigate before executing** |
+
+Rows before ~2026-07-29 are unrecoverable *by design of the data*: the
+transcripts of that era carry the model calls but no usage numbers on them, so
+there is nothing to restore. The script reports them as unrecoverable rather than
+writing zeros over zeros and claiming success.
+
+### Dry-run result on dev (2026-08-10)
+
+Against `psd-agents-dev-390844780692`, `--since=2026-07-25`:
+
+```
+transcript sessions: 32   parsed usage records: 229
+dev zero rows: 75   non-zero rows: 21
+rows to update: 57
+rows with no coverage: 2
+unattributed model calls: 6
+planned totals: input=651,790  output=51,724
+                cacheRead=10,207,165  cacheWrite=2,600,380
+```
+
+The recovered rows show the healthy caching pattern the outage hid, e.g.
+`input=2, output=473, cacheRead=54,256, cacheWrite=121`.
+
+The 6 unattributed calls are records past the newest `agent_messages` row plus
+background (non-`agent-chat-`) sessions that have no telemetry row by design.
+
+## Preventing a repeat
+
+`UsageCaptureZero` (namespace `PSD/AgentPlatform/<env>`) counts turns that
+**succeeded and made at least one model call yet reported zero tokens** — which
+is arithmetically impossible for a real turn. Alarm
+`psd-agent-usage-capture-zero-<env>` fires at ≥ 5 in 5 minutes: a rare edge turn
+can trip the heuristic once, but a broken capture path trips it on every turn.
+
+> **Deploy note:** without `--context alertEmail=<address>` the agent alarm topic
+> is not created, and this alarm — like all existing agent-platform alarms —
+> evaluates correctly and notifies nobody. The stack emits a synth warning for
+> that case.
+
+`agent_messages.usage_capture_complete` is the persisted counterpart and is
+deliberately **nullable**: `true` = measured, `false` = the read did not complete
+(token columns are a floor, not a total), `null` = unknown (row or reporting
+image predates the column). Consumers must handle all three.

--- a/docs/operations/agent-usage-telemetry-backfill.md
+++ b/docs/operations/agent-usage-telemetry-backfill.md
@@ -41,7 +41,7 @@ read per turn. Only the telemetry regressed.
 |---|---|
 | Read path | `harness_adapter` reads `transcript_events` (read-only URI, bound `session_id`, `created_at >= since_ms` prefilter, `ORDER BY seq`). JSONL remains a fallback for older hosts. |
 | Model id | `AGENT_MODEL_ID` corrected to `us.anthropic.claude-sonnet-5`, the id actually recorded since 2026-07-31. |
-| Observability | `agent_messages.usage_capture_complete` (migration 176) + the `UsageCaptureZero` metric and alarm. |
+| Observability | `agent_messages.usage_capture_complete` (migration 177) + the `UsageCaptureZero` metric and alarm. |
 | History | The backfill below. |
 
 ### Why `ORDER BY seq`, not `created_at`
@@ -76,7 +76,7 @@ bun run db:backfill-agent-usage -- --since=2026-07-30
 Flags: `--prefix=<workspace>` limits to one workspace; `--since=<ISO date>`
 bounds which `agent_messages` rows are considered.
 
-> **Prerequisite:** migration 176 must be applied first — the script reads and
+> **Prerequisite:** migration 177 must be applied first — the script reads and
 > writes `usage_capture_complete`.
 
 ### Turn attribution

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -58,7 +58,12 @@ OPENCLAW_DATABASE_MIGRATOR = "/app/openclaw_agent_db_migrate.mjs"
 # Emergency fallback only. Candidate images read their actual primary model
 # from openclaw.json so a GLM/Kimi/Qwen/OpenAI turn is never mislabeled Claude
 # merely because neither the proxy nor transcript returned a model id.
-DEFAULT_AGENT_MODEL_ID = "claude-sonnet-5"
+#
+# Must stay equal to lib/agents/platform-model.ts AGENT_MODEL_ID — the id that
+# `agent_messages.model` is priced against. A mismatch does not fail loudly; the
+# rows simply stop joining `ai_models` and the cost UI reads $0 (bug #1083).
+# lib/agents/__tests__/platform-model.test.ts fails CI if these drift.
+DEFAULT_AGENT_MODEL_ID = "us.anthropic.claude-sonnet-5"
 BEDROCK_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK"
 CANDIDATE_MANTLE_RELAY_BASE_URL = (
     "http://127.0.0.1:18791/candidate-mantle"

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -34,6 +34,7 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Mapping
 from zoneinfo import ZoneInfo
 
 # Configure structured logging for CloudWatch
@@ -977,6 +978,47 @@ def usage_capture_is_complete(
     return bool(proxy_measured or harness_capture_complete)
 
 
+def usage_capture_looks_broken(metadata: Mapping[str, Any]) -> bool:
+    """Whether this turn's usage telemetry is impossible rather than merely zero.
+
+    A turn that SUCCEEDED and made at least one model call must have consumed
+    tokens. All four token counters reading zero is therefore not a small number
+    — it is a broken capture path, and the only reason it can happen silently is
+    that every consumer treats a zero read as an honest zero.
+
+    This is the exact signature of the 2026-07-31 regression: OpenClaw moved
+    transcripts from JSONL into SQLite, the adapter kept reading the old path,
+    and every turn logged model_call_count=10 alongside tokens_in=0 for ten days
+    without one error. Alarming on this pairing is what makes the next such
+    move loud instead of invisible.
+
+    Deliberately narrow, so it stays actionable:
+      - failed turns are excluded (a 0-token error turn is expected),
+      - turns with no model calls are excluded (nothing ran; zero is honest).
+    """
+    if metadata.get("failed"):
+        return False
+    try:
+        model_calls = int(metadata.get("model_call_count") or 0)
+    except (TypeError, ValueError):
+        return False
+    if model_calls <= 0:
+        return False
+    total = 0
+    for field in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_write_input_tokens",
+    ):
+        try:
+            total += int(metadata.get(field) or 0)
+        except (TypeError, ValueError):
+            # An unparseable counter is itself a capture problem, not a zero.
+            return True
+    return total == 0
+
+
 def read_proxy_usage() -> dict:
     """Read cumulative token usage from the Mantle proxy's /usage endpoint
     (issue #1083). Returns a dict with input_tokens / output_tokens / model and
@@ -1899,6 +1941,22 @@ def main():
                 "failed": result.failed,
                 "error_class": result.error_class,
             }
+
+        # Zero-usage successful turn: emit the metric the AgentPlatform stack
+        # alarms on (UsageCaptureZero). The container log group has a
+        # runtime-generated suffix, so a CDK MetricFilter cannot attach to it —
+        # container-origin signals put_metric_data directly. Never raises.
+        if usage_capture_looks_broken(metadata):
+            logger.warning(
+                "USAGE_CAPTURE_ZERO session=%s model=%s model_calls=%s "
+                "usage_complete=%s — a successful turn reported no tokens; the "
+                "usage read is broken, not the turn",
+                session_id,
+                metadata.get("model"),
+                metadata.get("model_call_count"),
+                metadata.get("usage_capture_complete"),
+            )
+            emit_agent_metric("UsageCaptureZero")
 
         logger.info(
             "Invocation complete: session=%s response_length=%d elapsed_s=%d "

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -657,11 +657,24 @@ class OpenClawAdapter(HarnessAdapter):
         checkpointed 2026.7.2-beta.5 database).
 
         Returns `(totals, complete)`. `complete` is True only when the newest
-        in-window assistant record carries an explicitly allowlisted terminal
-        stopReason. OpenClaw writes `stopReason: "toolUse"` on every model call
-        that hands off to a tool and "stop"/"end_turn" only on the call that
-        ends the turn, so missing or novel values cannot accidentally become a
-        "no more model calls coming" signal.
+        in-window assistant record THAT CARRIES A stopReason carries an
+        explicitly allowlisted terminal one. OpenClaw writes
+        `stopReason: "toolUse"` on every model call that hands off to a tool and
+        "stop"/"end_turn" only on the call that ends the turn, so a novel value
+        cannot accidentally become a "no more model calls coming" signal.
+
+        Completeness is deliberately decided independently of whether the record
+        also carries `usage`. Deciding it from the last record WITH usage — the
+        obvious reading, and what this did first — silently mis-reports any turn
+        whose terminal record has no usage object: the preceding `toolUse` call
+        wins and the turn reports incomplete despite having finished. That both
+        pays the full settle budget on a turn that was already done and writes a
+        FALSE into `agent_messages.usage_capture_complete`, which per migration
+        177 means "these token columns are a floor, not a total" — manufacturing
+        the exact broken-capture signature the alarm exists to catch. Records
+        with NO stopReason at all leave completeness untouched rather than
+        clearing it, so a trailing non-model-call record cannot un-finish a
+        finished turn either.
 
         Raises nothing of its own; errors from the underlying store surface as
         exceptions from `raw_records` and are handled by the callers.
@@ -689,29 +702,35 @@ class OpenClawAdapter(HarnessAdapter):
             msg = record.get("message")
             if not isinstance(msg, dict) or msg.get("role") != "assistant":
                 continue
-            usage = msg.get("usage")
-            if not isinstance(usage, dict):
-                continue
+            # The in-window test comes BEFORE the usage test so an out-of-window
+            # record can never reach the completeness update below and report a
+            # previous turn's ending as this turn's.
             ts_ms = self._record_timestamp_ms(record, msg)
             if ts_ms is None or ts_ms < since_ms:
                 continue
-            totals["model_calls"] += 1
-            for key, field in (
-                ("input", "input"),
-                ("output", "output"),
-                ("cache_read", "cacheRead"),
-                ("cache_write", "cacheWrite"),
-            ):
-                value = usage.get(field)
-                # bool is an int subclass; a JSON `true` must not add 1 token.
-                if isinstance(value, int) and not isinstance(value, bool) \
-                        and value > 0:
-                    totals[key] += value
+            usage = msg.get("usage")
+            if isinstance(usage, dict):
+                totals["model_calls"] += 1
+                for key, field in (
+                    ("input", "input"),
+                    ("output", "output"),
+                    ("cache_read", "cacheRead"),
+                    ("cache_write", "cacheWrite"),
+                ):
+                    value = usage.get(field)
+                    # bool is an int subclass; a JSON `true` must not add 1
+                    # token.
+                    if isinstance(value, int) and not isinstance(value, bool) \
+                            and value > 0:
+                        totals[key] += value
             stop_reason = msg.get("stopReason")
-            # Recomputed per record so the LAST in-window record wins:
-            # an earlier terminal reason followed by more model calls
-            # (nudge/compaction legs) must not latch `complete` True.
-            complete = stop_reason in TERMINAL_USAGE_STOP_REASONS
+            if stop_reason is not None:
+                # Recomputed per stopReason-bearing record so the LAST one wins:
+                # an earlier terminal reason followed by more model calls
+                # (nudge/compaction legs) must not latch `complete` True. A
+                # record without a stopReason is not a turn-boundary signal at
+                # all, so it leaves the verdict alone.
+                complete = stop_reason in TERMINAL_USAGE_STOP_REASONS
         return totals, complete
 
     def _sum_sqlite_transcript_usage(
@@ -827,6 +846,37 @@ class OpenClawAdapter(HarnessAdapter):
         return None
 
     def _read_turn_usage(
+        self,
+        session_uuid: Optional[str],
+        agent_id: Optional[str],
+        since_ms: int,
+    ) -> Dict[str, object]:
+        """Read this turn's usage, guaranteeing that no exception escapes.
+
+        The implementation below degrades every failure mode it ANTICIPATES to
+        zeros. This wrapper is what makes the promise hold for the ones it does
+        not, and it belongs on the callee rather than at each call site: the
+        success-path caller runs after the WebSocket try/except has already
+        closed, so an escaping exception there would throw away a reply the model
+        had already produced. Worse, that turn's tool calls have run, so any
+        higher-level retry would re-run their side effects — the precise outcome
+        `_should_retry_upstream` is written to avoid. An unforeseen error (an
+        OverflowError out of an absurd ISO timestamp, a future non-defensive
+        edit to the fold) must cost the telemetry, never the turn.
+        """
+        try:
+            return self._read_turn_usage_unguarded(
+                session_uuid, agent_id, since_ms,
+            )
+        except Exception as exc:  # noqa: BLE001 - telemetry must never break a turn
+            logger.warning(
+                "transcript usage read raised unexpectedly: %s", str(exc)[:200],
+            )
+            return {"input": 0, "output": 0, "cache_read": 0,
+                    "cache_write": 0, "model_calls": 0,
+                    "capture_complete": False}
+
+    def _read_turn_usage_unguarded(
         self,
         session_uuid: Optional[str],
         agent_id: Optional[str],

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -721,6 +721,15 @@ class OpenClawAdapter(HarnessAdapter):
         in-window test stays on the record timestamp in `_fold_usage_records`,
         exactly as the JSONL path did.
 
+        The obvious way that invariant could break is the 2026.7.2-beta.5 import
+        stamping migrated JSONL records with the MIGRATION time instead of the
+        original. It does not: the same database holds events from 2026-07-27
+        (before its 2026-07-30 import) and not one row has a skew above 60s.
+        Even if a future migration did stamp import time, a too-LARGE created_at
+        only widens the prefilter, so the record-timestamp filter still decides
+        and the result stays correct — which is precisely why the authoritative
+        test was left on the record timestamp rather than moved into SQL.
+
         Ordering is `seq`, the append order — NOT `created_at`, which is only
         weakly ordered with respect to it (28 of 32 sessions in the same real
         database contain at least one row whose `created_at` precedes that of a

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1034,12 +1034,20 @@ class OpenClawAdapter(HarnessAdapter):
             "input": 0, "output": 0, "cache_read": 0,
             "cache_write": 0, "model_calls": 0,
         }
+        # Seeded alongside `totals` so the corrupt-database fast-break below is
+        # self-contained. Nothing after the loop reads it today, but a future
+        # edit returning `complete` instead of a literal would otherwise raise
+        # UnboundLocalError on exactly the path that is hardest to reach.
+        complete = False
         for attempt in range(self.USAGE_SETTLE_ATTEMPTS):
             try:
                 totals, complete = read()
             except sqlite3.OperationalError as exc:
-                # Locked/busy database, or a host whose schema predates
-                # `transcript_events`. Retry — a checkpoint clears in ms.
+                # Locked or busy database — retry, since a checkpoint clears in
+                # ms. A host whose schema predates `transcript_events` does NOT
+                # arrive here: the sqlite_master probe raises
+                # TranscriptTableMissing for that, precisely so the retryable
+                # and fall-back-to-JSONL cases stay distinguishable.
                 logger.warning(
                     "transcript usage read unavailable: %s", str(exc)[:200],
                 )

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -93,6 +93,18 @@ _SAFE_PATH_ID = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 TERMINAL_USAGE_STOP_REASONS = frozenset({"stop", "end_turn"})
 
 
+class TranscriptTableMissing(Exception):
+    """The transcript database exists but predates the `transcript_events` table.
+
+    Distinguished from a locked/busy database because the remedies are opposite:
+    a lock clears on retry, a missing table never will. This one means the host
+    is older than 2026.7.2-beta.5, so the per-session JSONL transcripts are still
+    the real source and the reader must fall back to them rather than settle
+    through six retries and report zeros — the exact silent-zero failure this
+    module exists to prevent.
+    """
+
+
 def _is_safe_path_component(value: str) -> bool:
     """True when `value` is safe to interpolate as a single path segment.
 
@@ -736,8 +748,10 @@ class OpenClawAdapter(HarnessAdapter):
         lower `seq`). `complete` depends on which record is LAST, so ordering by
         the wrong column would mis-read turn completeness.
 
-        Propagates `sqlite3.OperationalError` (locked/busy DB, or a host whose
-        schema predates `transcript_events`) to the caller.
+        Raises `TranscriptTableMissing` when the database predates the
+        `transcript_events` table, and propagates `sqlite3.OperationalError` for
+        a locked/busy database. The caller must treat these differently: the
+        first means fall back to JSONL, the second means retry.
         """
         # `timeout` bounds the wait for a writer's exclusive lock. WAL readers
         # do not block on ordinary writes, so this is effectively only paid
@@ -752,6 +766,15 @@ class OpenClawAdapter(HarnessAdapter):
             timeout=self.USAGE_SQLITE_TIMEOUT_S,
         )
         try:
+            # Probe the schema first so "this host has no transcript_events"
+            # cannot be confused with "the table is momentarily locked" — both
+            # surface as OperationalError from a plain SELECT, but only one is
+            # worth retrying.
+            if not connection.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'transcript_events'",
+            ).fetchone():
+                raise TranscriptTableMissing(db_path)
             cursor = connection.execute(
                 "SELECT event_json FROM transcript_events "
                 "WHERE session_id = ? AND created_at >= ? "
@@ -875,15 +898,23 @@ class OpenClawAdapter(HarnessAdapter):
             db_dir, self.TRANSCRIPT_DB_FILENAME,
         )
         if db_path is not None:
-            return self._settle_usage(
-                lambda: self._sum_sqlite_transcript_usage(
-                    db_path, session_uuid, since_ms,
-                ),
-                session_uuid,
-            )
+            try:
+                return self._settle_usage(
+                    lambda: self._sum_sqlite_transcript_usage(
+                        db_path, session_uuid, since_ms,
+                    ),
+                    session_uuid,
+                )
+            except TranscriptTableMissing:
+                # Pre-2026.7.2-beta.5 host: the database exists for other state
+                # but transcripts are still per-session JSONL. Fall through
+                # rather than report zeros.
+                logger.info(
+                    "transcript database has no transcript_events — falling "
+                    "back to the JSONL transcript",
+                )
 
         sessions_dir = os.path.join(agent_dir, "sessions")
-        path = os.path.join(sessions_dir, f"{session_uuid}.jsonl")
         jsonl_path = self._contained_transcript_path(
             sessions_dir, f"{session_uuid}.jsonl",
         )
@@ -945,7 +976,9 @@ class OpenClawAdapter(HarnessAdapter):
         pays the full bounded wait before returning its honest zeros.
 
         Telemetry must never break a chat turn, so an unreadable store degrades
-        to partial totals rather than propagating.
+        to partial totals rather than propagating. The one exception is
+        `TranscriptTableMissing`, which is allowed through: it is not a read
+        failure but a signal that the caller should try the other store.
         """
         totals: Dict[str, int] = {
             "input": 0, "output": 0, "cache_read": 0,

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -10,15 +10,19 @@ import dataclasses
 import json
 import logging
 import os
+import pathlib
 import re
 import secrets
 import signal
+import sqlite3
 import subprocess
 import sys
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import (
+    Any, Callable, Dict, Iterable, List, Optional, Tuple, Union,
+)
 
 from agent_failures import emit_agent_metric, record_failure
 from chat_format import markdown_to_chat
@@ -462,14 +466,31 @@ class OpenClawAdapter(HarnessAdapter):
     """
 
     DEFAULT_CONFIG_PATH = "/home/node/.openclaw/openclaw.json"
-    # Root of the OpenClaw workspace in this container. Per-session transcripts
-    # (the token-usage ground truth — see _read_turn_usage) live under
-    # <WORKSPACE_DIR>/agents/<agentId>/sessions/<sessionId>.jsonl.
+    # Root of the OpenClaw workspace in this container. Transcripts (the
+    # token-usage ground truth — see _read_turn_usage) live in the per-agent
+    # SQLite database at
+    # <WORKSPACE_DIR>/agents/<agentId>/agent/openclaw-agent.sqlite, table
+    # transcript_events. Hosts before 2026.7.2-beta.5 instead appended one JSONL
+    # file per session at <WORKSPACE_DIR>/agents/<agentId>/sessions/<id>.jsonl;
+    # that path is still read as a fallback when the SQLite DB is absent.
     WORKSPACE_DIR = "/home/node/.openclaw"
+    # Filename of the per-agent transcript database, relative to
+    # <WORKSPACE_DIR>/agents/<agentId>/agent/. A CONSTANT, not derived from the
+    # gateway event stream — only the agentId directory component is untrusted
+    # input, and the sessionId is a bound SQL parameter rather than a path
+    # component (a strict improvement on the JSONL layout, where it was both).
+    TRANSCRIPT_DB_SUBDIR = "agent"
+    TRANSCRIPT_DB_FILENAME = "openclaw-agent.sqlite"
     # Bounded settle for the transcript read: 6 x 200ms = 1.0s worst case, paid
     # only when the turn-ending assistant record hasn't landed yet.
     USAGE_SETTLE_ATTEMPTS = 6
     USAGE_SETTLE_INTERVAL_S = 0.2
+    # Per-connection busy timeout for the transcript read. The runtime writes
+    # this DB in WAL mode, so a reader does not block on a concurrent writer;
+    # this only bounds the rare case of a writer holding the exclusive lock for
+    # a checkpoint. Kept well under one settle interval so a busy DB retries via
+    # the settle loop rather than stalling the turn.
+    USAGE_SQLITE_TIMEOUT_S = 0.1
     # Gateway auth token is generated per container at startup (see __init__),
     # never hardcoded. It is passed to the gateway via the --token CLI flag and
     # reused by this adapter's connect envelope, so launcher and client always
@@ -612,68 +633,149 @@ class OpenClawAdapter(HarnessAdapter):
             suppress_origin=True,
         )
 
-    def _sum_transcript_usage(
-        self, path: str, since_ms: int,
+    def _fold_usage_records(
+        self, raw_records: Iterable[str], since_ms: int,
     ) -> Tuple[Dict[str, int], bool]:
-        """Sum assistant-message usage in `path` for records at/after `since_ms`.
+        """Fold serialized transcript records into this turn's usage totals.
+
+        `raw_records` yields the JSON text of each transcript record in APPEND
+        order (JSONL line order, or `transcript_events` ordered by `seq`). The
+        record shape is identical in both stores — the SQLite migration moved
+        the same objects verbatim into `event_json` (verified against a
+        checkpointed 2026.7.2-beta.5 database).
 
         Returns `(totals, complete)`. `complete` is True only when the newest
         in-window assistant record carries an explicitly allowlisted terminal
         stopReason. OpenClaw writes `stopReason: "toolUse"` on every model call
         that hands off to a tool and "stop"/"end_turn" only on the call that
         ends the turn, so missing or novel values cannot accidentally become a
-        "no more model calls coming" signal. Never raises.
+        "no more model calls coming" signal.
+
+        Raises nothing of its own; errors from the underlying store surface as
+        exceptions from `raw_records` and are handled by the callers.
         """
         totals = {"input": 0, "output": 0, "cache_read": 0,
                   "cache_write": 0, "model_calls": 0}
         complete = False
+        for raw in raw_records:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                record = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                # A torn final JSONL line is expected when we read while the
+                # runtime is mid-append; a malformed `event_json` is a
+                # corrupt/unknown row. Either way clear completeness in case a
+                # prior terminal record was followed by a new partial
+                # model-call record; the settle loop will re-read once it
+                # lands whole.
+                complete = False
+                continue
+            if not isinstance(record, dict):
+                continue
+            msg = record.get("message")
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            usage = msg.get("usage")
+            if not isinstance(usage, dict):
+                continue
+            ts_ms = self._record_timestamp_ms(record, msg)
+            if ts_ms is None or ts_ms < since_ms:
+                continue
+            totals["model_calls"] += 1
+            for key, field in (
+                ("input", "input"),
+                ("output", "output"),
+                ("cache_read", "cacheRead"),
+                ("cache_write", "cacheWrite"),
+            ):
+                value = usage.get(field)
+                # bool is an int subclass; a JSON `true` must not add 1 token.
+                if isinstance(value, int) and not isinstance(value, bool) \
+                        and value > 0:
+                    totals[key] += value
+            stop_reason = msg.get("stopReason")
+            # Recomputed per record so the LAST in-window record wins:
+            # an earlier terminal reason followed by more model calls
+            # (nudge/compaction legs) must not latch `complete` True.
+            complete = stop_reason in TERMINAL_USAGE_STOP_REASONS
+        return totals, complete
+
+    def _sum_sqlite_transcript_usage(
+        self, db_path: str, session_uuid: str, since_ms: int,
+    ) -> Tuple[Dict[str, int], bool]:
+        """Sum this turn's usage from the `transcript_events` table.
+
+        Opened through a read-only `file:` URI so a telemetry read can never
+        create, migrate, or write the runtime's database — SQLite refuses any
+        mutation on an `mode=ro` connection, and `mode=ro` (unlike the default)
+        also refuses to CREATE the file if it is missing.
+
+        `session_id` is a bound parameter, never interpolated. `created_at` is
+        an epoch-ms INTEGER written when the row is inserted, which is always
+        at or after the record's own `message.timestamp` (verified across a
+        real database: 488 records, 0 inversions, skew 0..20s). That makes
+        `created_at >= since_ms` a safe SUPERSET prefilter — it narrows the scan
+        without ever hiding an in-window record, and the authoritative
+        in-window test stays on the record timestamp in `_fold_usage_records`,
+        exactly as the JSONL path did.
+
+        Ordering is `seq`, the append order — NOT `created_at`, which is only
+        weakly ordered with respect to it (28 of 32 sessions in the same real
+        database contain at least one row whose `created_at` precedes that of a
+        lower `seq`). `complete` depends on which record is LAST, so ordering by
+        the wrong column would mis-read turn completeness.
+
+        Propagates `sqlite3.OperationalError` (locked/busy DB, or a host whose
+        schema predates `transcript_events`) to the caller.
+        """
+        # `timeout` bounds the wait for a writer's exclusive lock. WAL readers
+        # do not block on ordinary writes, so this is effectively only paid
+        # during a checkpoint.
+        # as_uri() percent-encodes characters that are structural in a URI
+        # (notably `?` and `#`), so a workspace path containing one cannot be
+        # read as a query parameter. Requires an absolute path — callers pass a
+        # realpath.
+        connection = sqlite3.connect(
+            f"{pathlib.Path(db_path).as_uri()}?mode=ro",
+            uri=True,
+            timeout=self.USAGE_SQLITE_TIMEOUT_S,
+        )
+        try:
+            cursor = connection.execute(
+                "SELECT event_json FROM transcript_events "
+                "WHERE session_id = ? AND created_at >= ? "
+                "ORDER BY seq",
+                (session_uuid, since_ms),
+            )
+            return self._fold_usage_records(
+                (row[0] for row in cursor if isinstance(row[0], str)),
+                since_ms,
+            )
+        finally:
+            connection.close()
+
+    def _sum_transcript_usage(
+        self, path: str, since_ms: int,
+    ) -> Tuple[Dict[str, int], bool]:
+        """Sum assistant-message usage in the JSONL transcript at `path`.
+
+        Legacy path, retained for hosts older than 2026.7.2-beta.5 (which moved
+        transcripts into SQLite). Never raises.
+        """
         try:
             with open(path, "r", encoding="utf-8", errors="replace") as fh:
-                for line in fh:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        record = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
-                        # A torn final line is expected when we read while the
-                        # runtime is mid-append. Clear completeness in case a
-                        # prior terminal record was followed by a new partial
-                        # model-call record; the settle loop will re-read once
-                        # it lands whole.
-                        complete = False
-                        continue
-                    if not isinstance(record, dict):
-                        continue
-                    msg = record.get("message")
-                    if not isinstance(msg, dict) or msg.get("role") != "assistant":
-                        continue
-                    usage = msg.get("usage")
-                    if not isinstance(usage, dict):
-                        continue
-                    ts_ms = self._record_timestamp_ms(record, msg)
-                    if ts_ms is None or ts_ms < since_ms:
-                        continue
-                    totals["model_calls"] += 1
-                    for key, field in (
-                        ("input", "input"),
-                        ("output", "output"),
-                        ("cache_read", "cacheRead"),
-                        ("cache_write", "cacheWrite"),
-                    ):
-                        value = usage.get(field)
-                        if isinstance(value, int) and value > 0:
-                            totals[key] += value
-                    stop_reason = msg.get("stopReason")
-                    # Recomputed per record so the LAST in-window record wins:
-                    # an earlier terminal reason followed by more model calls
-                    # (nudge/compaction legs) must not latch `complete` True.
-                    complete = stop_reason in TERMINAL_USAGE_STOP_REASONS
+                return self._fold_usage_records(fh, since_ms)
         except OSError as exc:
             logger.warning(
                 "transcript usage read failed: %s", str(exc)[:200],
             )
-        return totals, complete
+        return (
+            {"input": 0, "output": 0, "cache_read": 0,
+             "cache_write": 0, "model_calls": 0},
+            False,
+        )
 
     @staticmethod
     def _record_timestamp_ms(record: dict, msg: dict) -> Optional[int]:
@@ -711,6 +813,14 @@ class OpenClawAdapter(HarnessAdapter):
         local to this container and written with plain appends (no userspace
         buffering), so it is readable the moment the runtime writes it.
 
+        As of OpenClaw 2026.7.2-beta.5 those records live in the per-agent
+        SQLite database `<workspace>/agents/<agentId>/agent/openclaw-agent.sqlite`
+        (table `transcript_events`, one row per record with the SAME JSON object
+        the JSONL file used to hold). The per-session JSONL files were migrated
+        into it and REMOVED, which silently zeroed this telemetry until this
+        read followed them. Older hosts are still supported via the JSONL
+        fallback below.
+
         The turn window is `[since_ms, now]` — the caller passes the chat.send
         wall clock, and every model call this turn is stamped after it. The
         wrapper reads this BEFORE any nudge leg is sent, so the nudge's own
@@ -745,44 +855,109 @@ class OpenClawAdapter(HarnessAdapter):
             logger.warning("transcript usage skipped — unsafe session/agent id")
             return empty
 
-        sessions_dir = os.path.join(
-            self.WORKSPACE_DIR, "agents", agent_id or "main", "sessions",
+        agent_dir = os.path.join(self.WORKSPACE_DIR, "agents", agent_id or "main")
+
+        # Preferred source: the per-agent transcript database. Contained the
+        # same way as the JSONL path below — the resolved file must sit directly
+        # beneath the resolved `agent/` directory, which rejects a SYMLINKED
+        # database pointing out of the workspace.
+        db_dir = os.path.join(agent_dir, self.TRANSCRIPT_DB_SUBDIR)
+        db_path = self._contained_transcript_path(
+            db_dir, self.TRANSCRIPT_DB_FILENAME,
         )
+        if db_path is not None:
+            return self._settle_usage(
+                lambda: self._sum_sqlite_transcript_usage(
+                    db_path, session_uuid, since_ms,
+                ),
+                session_uuid,
+            )
+
+        sessions_dir = os.path.join(agent_dir, "sessions")
         path = os.path.join(sessions_dir, f"{session_uuid}.jsonl")
-        # Containment: the resolved file must sit directly beneath the resolved
-        # sessions directory. Mirrors the Zip-Slip containment workspace_sync.py
-        # applies to restore paths, and catches a SYMLINKED transcript.
-        #
-        # It does NOT substitute for the dot-name rejection above. `sessions_dir`
-        # is built from the same untrusted agent_id, so an agent_id of ".."
-        # moves BOTH sides of this comparison to the escaped directory and they
-        # match — the check would pass on a path that already climbed out. The
-        # component check is what stops that vector; this is defence against a
-        # different one. (test_dot_dot_agent_id_cannot_climb_out_of_the_agent_
-        # directory fails if the dot-name rejection is removed, even with this
-        # check in place — verified, not assumed.)
-        resolved = os.path.realpath(path)
-        resolved_dir = os.path.realpath(sessions_dir)
-        if os.path.dirname(resolved) != resolved_dir:
+        jsonl_path = self._contained_transcript_path(
+            sessions_dir, f"{session_uuid}.jsonl",
+        )
+        if jsonl_path is None:
             logger.warning(
-                "transcript usage skipped — resolved path escapes the sessions "
-                "directory",
+                "transcript usage skipped — no transcript database at %s and no "
+                "JSONL transcript for session %s",
+                db_dir, session_uuid,
             )
             return empty
-        if not os.path.exists(resolved):
-            logger.warning("transcript usage skipped — no transcript at %s", path)
-            return empty
-        path = resolved
 
-        # OpenClaw creates the transcript at session start and appends the
-        # turn-ending assistant record before it emits the chat `final` event
-        # we broke out on, so the first read almost always lands complete. The
-        # settle loop only covers the append/emit race; a turn that made no
-        # model calls at all (aborted pre-inference) never goes `complete` and
-        # pays the full bounded wait before returning its honest zeros.
-        totals = empty
+        return self._settle_usage(
+            lambda: self._sum_transcript_usage(jsonl_path, since_ms),
+            session_uuid,
+        )
+
+    @staticmethod
+    def _contained_transcript_path(
+        directory: str, filename: str,
+    ) -> Optional[str]:
+        """Resolve `directory/filename`, or None if missing or uncontained.
+
+        Containment: the resolved file must sit directly beneath the resolved
+        directory. Mirrors the Zip-Slip containment workspace_sync.py applies to
+        restore paths, and catches a SYMLINKED transcript.
+
+        It does NOT substitute for the dot-name rejection in the caller.
+        `directory` is built from the same untrusted agent_id, so an agent_id of
+        ".." moves BOTH sides of this comparison to the escaped directory and
+        they match — the check would pass on a path that already climbed out.
+        The component check is what stops that vector; this is defence against a
+        different one. (test_dot_dot_agent_id_cannot_climb_out_of_the_agent_
+        directory fails if the dot-name rejection is removed, even with this
+        check in place — verified, not assumed.)
+        """
+        path = os.path.join(directory, filename)
+        resolved = os.path.realpath(path)
+        if os.path.dirname(resolved) != os.path.realpath(directory):
+            logger.warning(
+                "transcript usage skipped — resolved path escapes %s", directory,
+            )
+            return None
+        if not os.path.exists(resolved):
+            return None
+        return resolved
+
+    def _settle_usage(
+        self,
+        read: "Callable[[], Tuple[Dict[str, int], bool]]",
+        session_uuid: str,
+    ) -> Dict[str, object]:
+        """Retry `read` on a bounded schedule until the turn reads complete.
+
+        OpenClaw appends the turn-ending assistant record before it emits the
+        chat `final` event we broke out on, so the first read almost always
+        lands complete. The settle loop only covers the append/emit race (and,
+        on the SQLite path, a momentarily locked database); a turn that made no
+        model calls at all (aborted pre-inference) never goes `complete` and
+        pays the full bounded wait before returning its honest zeros.
+
+        Telemetry must never break a chat turn, so an unreadable store degrades
+        to partial totals rather than propagating.
+        """
+        totals: Dict[str, int] = {
+            "input": 0, "output": 0, "cache_read": 0,
+            "cache_write": 0, "model_calls": 0,
+        }
         for attempt in range(self.USAGE_SETTLE_ATTEMPTS):
-            totals, complete = self._sum_transcript_usage(path, since_ms)
+            try:
+                totals, complete = read()
+            except sqlite3.OperationalError as exc:
+                # Locked/busy database, or a host whose schema predates
+                # `transcript_events`. Retry — a checkpoint clears in ms.
+                logger.warning(
+                    "transcript usage read unavailable: %s", str(exc)[:200],
+                )
+                complete = False
+            except sqlite3.DatabaseError as exc:
+                # Corrupt or non-SQLite file: retrying cannot help.
+                logger.warning(
+                    "transcript usage read failed: %s", str(exc)[:200],
+                )
+                break
             if complete:
                 return {**totals, "capture_complete": True}
             if attempt < self.USAGE_SETTLE_ATTEMPTS - 1:

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1753,6 +1753,73 @@ class SqliteTranscriptUsageTests(unittest.TestCase):
         self.assertEqual(usage["cache_write"], 40)
         self.assertEqual(usage["model_calls"], 2)
 
+    def test_a_terminal_record_without_usage_still_completes_the_turn(self):
+        # Completeness must be decided by the last record carrying a stopReason,
+        # NOT the last record carrying usage. When the turn-ending record has no
+        # usage object, deciding from the latter lets the preceding "toolUse"
+        # win, so a finished turn reports incomplete: it burns the whole settle
+        # budget and then writes usage_capture_complete=FALSE, which downstream
+        # reads as "these token columns are a floor" — the same signature as a
+        # genuinely broken capture path.
+        terminal = _assistant(6_000)
+        del terminal["message"]["usage"]
+        self._write("s1", [
+            _assistant(5_000, inp=10, out=1, cr=30, stop="toolUse"),
+            terminal,
+        ])
+        usage = self.adapter._read_turn_usage("s1", "main", 5_000)
+        self.assertTrue(usage["capture_complete"])
+        # The usage-less record is not a model call and adds no tokens.
+        self.assertEqual(usage["model_calls"], 1)
+        self.assertEqual(usage["input"], 10)
+        self.assertEqual(usage["cache_read"], 30)
+
+    def test_a_record_with_no_stop_reason_does_not_unfinish_the_turn(self):
+        # The converse risk of the fix above: a trailing record that carries no
+        # stopReason at all is not a turn boundary, so it must leave the verdict
+        # alone rather than clear it.
+        self._write("s1", [
+            _assistant(5_000, inp=10, out=1),
+            _assistant(6_000, inp=5, out=2, stop=None),
+        ])
+        usage = self.adapter._read_turn_usage("s1", "main", 5_000)
+        self.assertTrue(usage["capture_complete"])
+        self.assertEqual(usage["model_calls"], 2)
+        self.assertEqual(usage["input"], 15)
+
+    def test_a_previous_turns_terminal_record_cannot_complete_this_turn(self):
+        # The in-window test runs BEFORE the completeness update, so an earlier
+        # turn's "stop" is invisible here. Reversing that order would report an
+        # unfinished turn as fully captured.
+        self._write("s1", [
+            _assistant(1_000, inp=999, out=999, stop="stop"),   # previous turn
+            _assistant(5_000, inp=10, out=1, stop="toolUse"),   # still running
+        ])
+        usage = self.adapter._read_turn_usage("s1", "main", 5_000)
+        self.assertFalse(usage["capture_complete"])
+        self.assertEqual(usage["input"], 10)
+        self.assertEqual(usage["model_calls"], 1)
+
+    def test_an_unexpected_exception_degrades_to_zeros_not_a_broken_turn(self):
+        # The success-path caller runs after the WebSocket try/except has closed,
+        # so anything escaping this read would discard a reply the model already
+        # produced — and its tool calls have already run, so a higher-level retry
+        # would re-run their side effects. Only sqlite3 errors are handled
+        # inside; the guard is what covers everything else.
+        self._write("s1", [_assistant(5_000, inp=10, out=1)])
+
+        def _boom(*_args, **_kwargs):
+            raise OverflowError("timestamp out of range")
+
+        self.adapter._fold_usage_records = _boom
+        usage = self.adapter._read_turn_usage("s1", "main", 5_000)
+        self.assertFalse(usage["capture_complete"])
+        self.assertEqual(usage["input"], 0)
+        self.assertEqual(usage["output"], 0)
+        self.assertEqual(usage["cache_read"], 0)
+        self.assertEqual(usage["cache_write"], 0)
+        self.assertEqual(usage["model_calls"], 0)
+
     def test_another_sessions_rows_are_never_billed_to_this_turn(self):
         # Session isolation used to be the FILENAME; it is now a WHERE clause.
         # A missing/broken session_id predicate would bill every concurrent

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -20,6 +20,7 @@ plain attributes.
 import json
 import os
 import pathlib
+import sqlite3
 import sys
 import time
 import unittest
@@ -1651,12 +1652,420 @@ def _assistant(ts_ms, *, inp=0, out=0, cr=0, cw=0, stop="stop"):
     }
 
 
-class TranscriptUsageTests(unittest.TestCase):
-    """Per-turn token usage read back from the OpenClaw session transcript.
+def _transcript_db(path, rows):
+    """Build a transcript database in the pinned host's real shape.
+
+    DDL copied from a checkpointed 2026.7.2-beta.5 `openclaw-agent.sqlite`
+    (`SELECT sql FROM sqlite_master WHERE name='transcript_events'`), minus the
+    FK to `session_windows` so a fixture needs only the one table. STRICT and
+    the composite primary key are preserved because both constrain what the
+    reader may assume.
+
+    `rows` is an iterable of `(session_id, seq, event_json, created_at)`.
+    """
+    connection = sqlite3.connect(path)
+    try:
+        # The runtime keeps this DB in WAL mode; readers must cope with it.
+        connection.execute("PRAGMA journal_mode=wal")
+        connection.execute(
+            "CREATE TABLE transcript_events ("
+            "  session_id TEXT NOT NULL,"
+            "  seq INTEGER NOT NULL,"
+            "  event_json TEXT NOT NULL,"
+            "  created_at INTEGER NOT NULL,"
+            "  PRIMARY KEY (session_id, seq)"
+            ") STRICT"
+        )
+        connection.executemany(
+            "INSERT INTO transcript_events "
+            "(session_id, seq, event_json, created_at) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _rows(session_id, records, *, created_at_skew_ms=0, start_seq=1):
+    """Turn transcript records into `transcript_events` rows.
+
+    `created_at` is the row's INSERT time, so it is at or after the record's own
+    `message.timestamp` — verified across a real database (488 records, zero
+    inversions). `created_at_skew_ms` models that lag.
+    """
+    rows = []
+    for offset, record in enumerate(records):
+        message = record.get("message") or {}
+        timestamp = message.get("timestamp")
+        if not isinstance(timestamp, int):
+            # Undatable/ISO-only records still get a plausible insert time so
+            # the created_at prefilter cannot be what excludes them.
+            timestamp = 0
+        rows.append((
+            session_id,
+            start_seq + offset,
+            json.dumps(record),
+            timestamp + created_at_skew_ms,
+        ))
+    return rows
+
+
+class SqliteTranscriptUsageTests(unittest.TestCase):
+    """Per-turn token usage read from `transcript_events` (2026.7.2-beta.5+).
 
     This is the only usage source on the post-#1384 SigV4 path: the gateway's
-    WS event stream carries none, so before this the wrapper logged
-    tokens_in=0 tokens_out=0 on every single invocation.
+    WS event stream carries none. OpenClaw 2026.7.2-beta.5 migrated the
+    per-session JSONL transcripts into this per-agent SQLite database and
+    DELETED them, which silently zeroed input/output/cache telemetry on every
+    invocation until the reader followed.
+    """
+
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.adapter = OpenClawAdapter()
+        self.adapter.WORKSPACE_DIR = self.tmp.name
+        # Keep the settle loop from adding real seconds to the suite.
+        self.adapter.USAGE_SETTLE_INTERVAL_S = 0
+        self.agent_dir = pathlib.Path(self.tmp.name) / "agents" / "main" / "agent"
+        self.agent_dir.mkdir(parents=True)
+        self.db_path = self.agent_dir / "openclaw-agent.sqlite"
+
+    def _write(self, session_uuid, records, **kwargs):
+        _transcript_db(str(self.db_path), _rows(session_uuid, records, **kwargs))
+        return self.db_path
+
+    def test_sums_only_records_inside_the_turn_window(self):
+        # transcript_events is append-only across the whole session, so a prior
+        # turn's model calls sit in the same table. Billing them again would
+        # inflate every turn by the entire session history.
+        self._write("s1", [
+            _assistant(1_000, inp=999, out=999),          # previous turn
+            _assistant(5_000, inp=10, out=1, stop="toolUse"),
+            _assistant(6_000, inp=20, out=2, cr=30, cw=40),
+        ])
+        usage = self.adapter._read_turn_usage("s1", "main", 5_000)
+        self.assertTrue(usage["capture_complete"])
+        self.assertEqual(usage["input"], 30)
+        self.assertEqual(usage["output"], 3)
+        self.assertEqual(usage["cache_read"], 30)
+        self.assertEqual(usage["cache_write"], 40)
+        self.assertEqual(usage["model_calls"], 2)
+
+    def test_another_sessions_rows_are_never_billed_to_this_turn(self):
+        # Session isolation used to be the FILENAME; it is now a WHERE clause.
+        # A missing/broken session_id predicate would bill every concurrent
+        # session's model calls to whichever turn read the table.
+        rows = _rows("s1", [_assistant(5_000, inp=10, out=1)])
+        rows += _rows("other", [_assistant(5_000, inp=7777, out=7777)])
+        _transcript_db(str(self.db_path), rows)
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertEqual(usage["input"], 10)
+        self.assertEqual(usage["output"], 1)
+        self.assertEqual(usage["model_calls"], 1)
+
+    def test_boundary_record_at_since_ms_is_included(self):
+        self._write("s1", [_assistant(5_000, inp=7, out=3)])
+        self.assertEqual(
+            self.adapter._read_turn_usage("s1", "main", 5_000)["input"], 7,
+        )
+
+    def test_created_at_lag_does_not_hide_an_in_window_record(self):
+        # created_at is the row's INSERT time and runs AHEAD of the record's own
+        # timestamp (up to ~20s observed). Because the prefilter is
+        # `created_at >= since_ms` and created_at >= message.timestamp, it can
+        # only ever be a superset of the real window — never narrower.
+        self._write(
+            "s1", [_assistant(5_000, inp=42, out=1)], created_at_skew_ms=19_941,
+        )
+        usage = self.adapter._read_turn_usage("s1", "main", 5_000)
+        self.assertEqual(usage["input"], 42)
+        self.assertEqual(usage["model_calls"], 1)
+
+    def test_completeness_follows_seq_not_created_at(self):
+        # created_at is only weakly ordered against seq (28 of 32 sessions in a
+        # real database contain an inversion). `complete` is decided by the LAST
+        # record, so ordering the scan by created_at would read the wrong one —
+        # here it would see `toolUse` last and wrongly report the turn partial.
+        rows = [
+            (
+                "s1", 1,
+                json.dumps(_assistant(5_000, inp=10, stop="toolUse")),
+                9_000,  # inserted LATE despite the lower seq
+            ),
+            (
+                "s1", 2,
+                json.dumps(_assistant(6_000, inp=20, stop="stop")),
+                6_100,
+            ),
+        ]
+        _transcript_db(str(self.db_path), rows)
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertTrue(usage["capture_complete"])
+        self.assertEqual(usage["input"], 30)
+
+    def test_tool_use_stop_reason_means_the_turn_is_still_running(self):
+        # `toolUse` is OpenClaw's "another model call is coming" marker; a read
+        # that stops there would drop the turn's final (largest) model call.
+        self._write("s1", [_assistant(5_000, inp=10, stop="toolUse")])
+        _, complete = self.adapter._sum_sqlite_transcript_usage(
+            str(self.db_path), "s1", 0,
+        )
+        self.assertFalse(complete)
+
+        self.db_path.unlink()
+        self._write("s2", [
+            _assistant(5_000, inp=10, stop="toolUse"),
+            _assistant(6_000, inp=20, stop="stop"),
+        ])
+        totals, complete = self.adapter._sum_sqlite_transcript_usage(
+            str(self.db_path), "s2", 0,
+        )
+        self.assertTrue(complete)
+        self.assertEqual(totals["input"], 30)
+
+    def test_only_allowlisted_terminal_stop_reasons_complete_capture(self):
+        cases = (
+            (None, False),
+            ("", False),
+            ("toolUse", False),
+            ("novel-terminal", False),
+            ("stop", True),
+            ("end_turn", True),
+        )
+        rows = []
+        for index, (stop_reason, _expected) in enumerate(cases, start=1):
+            rows += _rows(
+                f"terminal-{index}",
+                [_assistant(5_000, inp=10, stop=stop_reason)],
+            )
+        _transcript_db(str(self.db_path), rows)
+        for index, (stop_reason, expected) in enumerate(cases, start=1):
+            with self.subTest(stop_reason=stop_reason):
+                _, complete = self.adapter._sum_sqlite_transcript_usage(
+                    str(self.db_path), f"terminal-{index}", 0,
+                )
+                self.assertIs(complete, expected)
+
+    def test_missing_database_and_transcript_returns_zeros_without_settling(self):
+        started = time.monotonic()
+        # Non-zero interval so a wrongly-taken settle path would be visible.
+        self.adapter.USAGE_SETTLE_INTERVAL_S = 0.05
+        usage = self.adapter._read_turn_usage("nope", "main", 0)
+        self.assertFalse(usage["capture_complete"])
+        self.assertEqual(usage["model_calls"], 0)
+        self.assertLess(time.monotonic() - started, 0.05)
+
+    def test_unknown_session_in_an_existing_database_reports_honest_zeros(self):
+        self._write("s1", [_assistant(5_000, inp=10)])
+        usage = self.adapter._read_turn_usage("absent-session", "main", 0)
+        self.assertFalse(usage["capture_complete"])
+        self.assertEqual(usage["model_calls"], 0)
+        self.assertEqual(usage["input"], 0)
+
+    def test_malformed_event_json_is_skipped_not_fatal(self):
+        # event_json is TEXT, not JSON-validated by SQLite. A corrupt or
+        # unrecognized row must not lose the records around it, and must clear
+        # completeness so the settle loop re-reads.
+        rows = _rows("s1", [_assistant(5_000, inp=11, out=2)])
+        rows.append(("s1", 2, '{"message": {"rol', 5_100))
+        _transcript_db(str(self.db_path), rows)
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertFalse(usage["capture_complete"])
+        self.assertEqual(usage["input"], 11)
+        self.assertEqual(usage["model_calls"], 1)
+
+    def test_non_json_and_non_object_event_json_are_ignored(self):
+        rows = [
+            ("s1", 1, "not json at all", 5_000),
+            ("s1", 2, '"a bare string"', 5_050),
+            ("s1", 3, "[1, 2, 3]", 5_060),
+            ("s1", 4, "null", 5_070),
+        ]
+        rows += _rows("s1", [_assistant(5_100, inp=4, out=1)], start_seq=5)
+        _transcript_db(str(self.db_path), rows)
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertEqual(usage["model_calls"], 1)
+        self.assertEqual(usage["input"], 4)
+
+    def test_a_busy_database_degrades_to_zeros_without_raising(self):
+        # A telemetry read must never break a chat turn. Hold the write lock
+        # from another connection so the reader gets OperationalError, and
+        # confirm the settle loop absorbs it.
+        self._write("s1", [_assistant(5_000, inp=10, out=2)])
+        blocker = sqlite3.connect(str(self.db_path))
+        self.addCleanup(blocker.close)
+        blocker.execute("PRAGMA journal_mode=delete")
+        blocker.execute("BEGIN EXCLUSIVE")
+        blocker.execute(
+            "INSERT INTO transcript_events VALUES ('s1', 99, '{}', 1)",
+        )
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertFalse(usage["capture_complete"])
+        self.assertEqual(usage["model_calls"], 0)
+
+    def test_a_corrupt_database_file_does_not_retry_or_raise(self):
+        # Retrying a non-SQLite file cannot help, so it must break out of the
+        # settle loop rather than pay the full bounded wait on every turn.
+        self.db_path.write_bytes(b"this is not a sqlite database" * 64)
+        self.adapter.USAGE_SETTLE_INTERVAL_S = 0.05
+        started = time.monotonic()
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertFalse(usage["capture_complete"])
+        self.assertEqual(usage["model_calls"], 0)
+        self.assertLess(time.monotonic() - started, 0.05)
+
+    def test_the_read_never_creates_or_writes_the_database(self):
+        # mode=ro must be what opens the DB: a telemetry read may not create,
+        # migrate, or mutate the runtime's own state.
+        self._write("s1", [_assistant(5_000, inp=10)])
+        before = self.db_path.stat().st_mtime_ns
+        digest_before = self.db_path.read_bytes()
+        self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertEqual(self.db_path.stat().st_mtime_ns, before)
+        self.assertEqual(self.db_path.read_bytes(), digest_before)
+
+    def test_a_missing_database_is_not_created_by_the_read(self):
+        self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertFalse(self.db_path.exists())
+
+    def test_non_assistant_and_usageless_records_ignored(self):
+        self._write("s1", [
+            {"type": "session", "timestamp": "2026-07-27T14:18:48.704Z"},
+            {"type": "message", "message": {"role": "user", "timestamp": 5_000}},
+            {"type": "message", "message": {"role": "toolResult", "timestamp": 5_100}},
+            {"type": "message", "message": {"role": "assistant", "timestamp": 5_200}},
+            _assistant(5_300, inp=4, out=1),
+        ])
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertEqual(usage["model_calls"], 1)
+        self.assertEqual(usage["input"], 4)
+
+    def test_iso_timestamp_used_when_message_timestamp_absent(self):
+        record = _assistant(0, inp=5)
+        del record["message"]["timestamp"]
+        record["timestamp"] = "2026-07-27T14:20:19.758Z"
+        since = int(
+            datetime(2026, 7, 27, 14, 0, tzinfo=timezone.utc).timestamp() * 1000
+        )
+        # created_at must not be what admits the row — set it at the window edge.
+        _transcript_db(
+            str(self.db_path), [("s1", 1, json.dumps(record), since)],
+        )
+        self.assertEqual(
+            self.adapter._read_turn_usage("s1", "main", since)["input"], 5,
+        )
+
+    def test_undatable_record_is_not_attributed_to_this_turn(self):
+        record = _assistant(0, inp=5)
+        del record["message"]["timestamp"]
+        del record["timestamp"]
+        _transcript_db(str(self.db_path), [("s1", 1, json.dumps(record), 5_000)])
+        self.assertEqual(
+            self.adapter._read_turn_usage("s1", "main", 0)["model_calls"], 0,
+        )
+
+    def test_session_and_agent_ids_are_path_constrained(self):
+        # agentId is still a path component, and sessionId is still a path
+        # component on the JSONL fallback, so both stay untrusted input.
+        outside_dir = pathlib.Path(self.tmp.name) / "agent"
+        outside_dir.mkdir(parents=True, exist_ok=True)
+        _transcript_db(
+            str(outside_dir / "openclaw-agent.sqlite"),
+            _rows("s1", [_assistant(5_000, inp=123)]),
+        )
+        for sid, aid in (
+            ("../../escaped", "main"),
+            ("s1", "../.."),
+            ("s1/../../escaped", "main"),
+        ):
+            self.assertEqual(
+                self.adapter._read_turn_usage(sid, aid, 0)["input"], 0,
+                f"unsafe ids must not read a database: {sid!r} {aid!r}",
+            )
+
+    def test_dot_dot_agent_id_cannot_climb_out_of_the_agent_directory(self):
+        # `.` is a legal id character, so ".." satisfies the charset regex —
+        # the one traversal a slash-free component can still perform. Plant a
+        # READABLE database at exactly the path it would reach
+        # (<workspace>/agents/../agent/ == <workspace>/agent/) so this fails
+        # loudly if the guard regresses, instead of passing because the file
+        # merely happened not to exist.
+        sibling = pathlib.Path(self.tmp.name) / "agent"
+        sibling.mkdir(parents=True, exist_ok=True)
+        _transcript_db(
+            str(sibling / "openclaw-agent.sqlite"),
+            _rows("s1", [_assistant(5_000, inp=4242)]),
+        )
+        for aid in ("..", "."):
+            usage = self.adapter._read_turn_usage("s1", aid, 0)
+            self.assertEqual(
+                usage["input"], 0, f"agentId={aid!r} must not read a database",
+            )
+            self.assertEqual(usage["model_calls"], 0)
+
+    def test_symlinked_database_is_rejected_by_containment(self):
+        # realpath containment also covers a database symlinked in from
+        # elsewhere in the workspace.
+        outside = pathlib.Path(self.tmp.name) / "elsewhere.sqlite"
+        _transcript_db(str(outside), _rows("s1", [_assistant(5_000, inp=99)]))
+        self.db_path.symlink_to(outside)
+        self.assertEqual(
+            self.adapter._read_turn_usage("s1", "main", 0)["input"], 0,
+        )
+
+    def test_agent_id_defaults_to_main(self):
+        self._write("s1", [_assistant(5_000, inp=9)])
+        self.assertEqual(
+            self.adapter._read_turn_usage("s1", None, 0)["input"], 9,
+        )
+
+    def test_missing_session_id_is_a_no_op(self):
+        self._write("s1", [_assistant(5_000, inp=9)])
+        self.assertEqual(
+            self.adapter._read_turn_usage(None, "main", 0)["model_calls"], 0,
+        )
+
+    def test_negative_and_non_int_usage_values_ignored(self):
+        record = _assistant(5_000, inp=10, out=5)
+        record["message"]["usage"]["cacheRead"] = -100
+        record["message"]["usage"]["cacheWrite"] = "lots"
+        self._write("s1", [record])
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertEqual(usage["cache_read"], 0)
+        self.assertEqual(usage["cache_write"], 0)
+        self.assertEqual(usage["input"], 10)
+
+    def test_boolean_usage_values_are_not_counted_as_tokens(self):
+        # bool is an int subclass in Python; a JSON `true` must not add 1 token.
+        record = _assistant(5_000, inp=10)
+        record["message"]["usage"]["output"] = True
+        self._write("s1", [record])
+        self.assertEqual(
+            self.adapter._read_turn_usage("s1", "main", 0)["output"], 0,
+        )
+
+    def test_the_database_wins_when_a_legacy_jsonl_also_exists(self):
+        # A host migrated in place can have both. The database is authoritative;
+        # the archived JSONL would double-bill the same model calls.
+        sessions = pathlib.Path(self.tmp.name) / "agents" / "main" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "s1.jsonl").write_text(
+            json.dumps(_assistant(5_000, inp=5555)) + "\n", encoding="utf-8",
+        )
+        self._write("s1", [_assistant(5_000, inp=10, out=2)])
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertEqual(usage["input"], 10)
+        self.assertEqual(usage["model_calls"], 1)
+
+
+class TranscriptUsageJsonlFallbackTests(unittest.TestCase):
+    """Legacy per-session JSONL transcripts (hosts before 2026.7.2-beta.5).
+
+    Read only when the per-agent SQLite database is absent, so an older pinned
+    host — or a candidate image on an older base — still reports real usage
+    instead of silently regressing to zeros.
     """
 
     def setUp(self):

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -2046,6 +2046,56 @@ class SqliteTranscriptUsageTests(unittest.TestCase):
             self.adapter._read_turn_usage("s1", "main", 0)["output"], 0,
         )
 
+    def test_a_database_without_transcript_events_falls_back_to_jsonl(self):
+        # An OpenClaw host older than 2026.7.2-beta.5 HAS openclaw-agent.sqlite
+        # (it holds other state) but no transcript_events table — transcripts are
+        # still per-session JSONL. Keying the fallback on the FILE's existence
+        # instead of the TABLE's would report zeros on every such host: the exact
+        # silent-zero regression this module exists to prevent, in reverse.
+        connection = sqlite3.connect(str(self.db_path))
+        connection.execute("CREATE TABLE session_nodes (session_key TEXT)")
+        connection.commit()
+        connection.close()
+
+        sessions = pathlib.Path(self.tmp.name) / "agents" / "main" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "s1.jsonl").write_text(
+            json.dumps(_assistant(5_000, inp=31, out=7)) + "\n", encoding="utf-8",
+        )
+
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertTrue(usage["capture_complete"])
+        self.assertEqual(usage["input"], 31)
+        self.assertEqual(usage["output"], 7)
+
+    def test_a_database_without_transcript_events_and_no_jsonl_settles_fast(self):
+        # Nothing to read from either source: report zeros immediately rather
+        # than paying the full bounded retry on every turn for a table that will
+        # never appear.
+        connection = sqlite3.connect(str(self.db_path))
+        connection.execute("CREATE TABLE session_nodes (session_key TEXT)")
+        connection.commit()
+        connection.close()
+
+        self.adapter.USAGE_SETTLE_INTERVAL_S = 0.05
+        started = time.monotonic()
+        usage = self.adapter._read_turn_usage("s1", "main", 0)
+        self.assertFalse(usage["capture_complete"])
+        self.assertEqual(usage["model_calls"], 0)
+        self.assertLess(time.monotonic() - started, 0.05)
+
+    def test_missing_table_is_not_confused_with_a_locked_database(self):
+        # Both surface as OperationalError from a plain SELECT, but only a lock
+        # is worth retrying. The schema probe is what separates them.
+        connection = sqlite3.connect(str(self.db_path))
+        connection.execute("CREATE TABLE session_nodes (session_key TEXT)")
+        connection.commit()
+        connection.close()
+        with self.assertRaises(harness_adapter.TranscriptTableMissing):
+            self.adapter._sum_sqlite_transcript_usage(
+                str(self.db_path), "s1", 0,
+            )
+
     def test_the_database_wins_when_a_legacy_jsonl_also_exists(self):
         # A host migrated in place can have both. The database is authoritative;
         # the archived JSONL would double-bill the same model calls.

--- a/infra/agent-image/test_iteration_telemetry.py
+++ b/infra/agent-image/test_iteration_telemetry.py
@@ -238,6 +238,93 @@ class TurnResultNudgedTests(unittest.TestCase):
         self.assertTrue(TurnResult(text="hi", nudged=True).nudged)
 
 
+class UsageCaptureLooksBrokenTests(unittest.TestCase):
+    """The zero-usage detector behind the UsageCaptureZero alarm.
+
+    The 2026-07-31 regression (transcripts moved JSONL -> SQLite, adapter kept
+    reading the deleted path) recorded model_call_count=10 alongside
+    tokens_in=0 on every turn for ten days with no error anywhere. This
+    predicate is the signal that would have caught it on day one, so it has to
+    fire on that exact shape and stay quiet on the honest zeros.
+    """
+
+    @staticmethod
+    def _metadata(**overrides):
+        base = {
+            "failed": False,
+            "model_call_count": 10,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+        }
+        base.update(overrides)
+        return base
+
+    def test_fires_on_the_exact_outage_shape(self):
+        # Verbatim from a real dev agent_messages row during the outage.
+        self.assertTrue(
+            agentcore_wrapper.usage_capture_looks_broken(self._metadata())
+        )
+
+    def test_quiet_when_any_counter_is_populated(self):
+        for field in (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_input_tokens",
+            "cache_write_input_tokens",
+        ):
+            with self.subTest(field=field):
+                self.assertFalse(
+                    agentcore_wrapper.usage_capture_looks_broken(
+                        self._metadata(**{field: 1})
+                    )
+                )
+
+    def test_quiet_on_a_cache_only_turn(self):
+        # The healthy steady state: ~2 billable input tokens against a 65k
+        # cache read. Must never be mistaken for a broken capture.
+        self.assertFalse(
+            agentcore_wrapper.usage_capture_looks_broken(
+                self._metadata(input_tokens=2, cache_read_input_tokens=65_301)
+            )
+        )
+
+    def test_quiet_on_a_failed_turn(self):
+        # A 0-token error turn is expected, and already has an agent_failures row.
+        self.assertFalse(
+            agentcore_wrapper.usage_capture_looks_broken(
+                self._metadata(failed=True)
+            )
+        )
+
+    def test_quiet_when_no_model_call_happened(self):
+        # Nothing ran, so zero is honest rather than impossible.
+        for calls in (0, None, "", "not-a-number"):
+            with self.subTest(model_call_count=calls):
+                self.assertFalse(
+                    agentcore_wrapper.usage_capture_looks_broken(
+                        self._metadata(model_call_count=calls)
+                    )
+                )
+
+    def test_an_unparseable_counter_counts_as_broken(self):
+        # A non-numeric counter is a capture problem in its own right; treating
+        # it as zero would hide it.
+        self.assertTrue(
+            agentcore_wrapper.usage_capture_looks_broken(
+                self._metadata(input_tokens="lots")
+            )
+        )
+
+    def test_missing_counters_are_treated_as_zero(self):
+        self.assertTrue(
+            agentcore_wrapper.usage_capture_looks_broken(
+                {"failed": False, "model_call_count": 3}
+            )
+        )
+
+
 class EmitAgentMetricTests(unittest.TestCase):
     def test_put_metric_data_shape(self):
         from agent_failures import emit_agent_metric

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -165,6 +165,7 @@
     "172-content-data-records.sql",
     "173-repository-index-generation-retention.sql",
     "174-unified-content-message-sanitizer-recovery.sql",
-    "175-atrium-library-usability.sql"
+    "175-atrium-library-usability.sql",
+    "176-agent-usage-capture-complete.sql"
   ]
 }

--- a/infra/database/schema/176-agent-usage-capture-complete.sql
+++ b/infra/database/schema/176-agent-usage-capture-complete.sql
@@ -1,0 +1,43 @@
+-- Migration 176: persist the agent turn's usage-capture completeness flag
+--
+-- WHY THIS EXISTS
+-- OpenClaw 2026.7.2-beta.5 moved per-session transcripts out of JSONL files
+-- into a per-agent SQLite database. The harness adapter kept reading the old
+-- JSONL path, so from 2026-07-31 (dev) / 2026-08-01 (prod) every turn recorded
+-- input_tokens = output_tokens = cache_read_input_tokens = 0. Nothing failed:
+-- a zero read is indistinguishable from an honest zero once it reaches this
+-- table, so the admin/agents Cost tab quietly showed $0 for ten days.
+--
+-- The wrapper ALREADY computed a `usage_capture_complete` boolean for exactly
+-- this purpose (agentcore_wrapper.usage_capture_is_complete) — but only the
+-- eval harness ever consumed it. Production turns dropped it on the floor,
+-- which is why the outage had no persisted signal to alarm on or query.
+-- This column keeps it.
+--
+-- NULLABLE ON PURPOSE. Unlike the token columns this is not "0 when absent":
+--   TRUE  = the harness (or the proxy) positively measured this turn's usage.
+--   FALSE = the turn ended without a complete usage read; the token columns
+--           are a floor, not a total. THIS IS THE OUTAGE SIGNATURE.
+--   NULL  = unknown — the row predates this column, or the reporting image is
+--           older than it. A default of TRUE would silently assert that ten
+--           days of all-zero rows were fully measured, and a default of FALSE
+--           would flag every historical row as suspect. Neither is true, so
+--           the honest value is "we do not know".
+--
+-- Safe to re-run.
+
+ALTER TABLE agent_messages
+  ADD COLUMN IF NOT EXISTS usage_capture_complete BOOLEAN;
+
+COMMENT ON COLUMN agent_messages.usage_capture_complete IS
+  'TRUE = token usage was positively measured for this turn; FALSE = the usage '
+  'read did not complete, so the token columns are a floor rather than a total '
+  '(the 2026-07-31 JSONL-to-SQLite transcript regression); NULL = unknown, the '
+  'row predates the column or the reporting agent image does.';
+
+-- Partial index: the only queries that need this column look for the failure
+-- case, which is a small minority of rows in a healthy system. A full index
+-- would be mostly dead weight on the hot insert path.
+CREATE INDEX IF NOT EXISTS idx_agent_messages_usage_capture_incomplete
+  ON agent_messages (created_at)
+  WHERE usage_capture_complete IS FALSE;

--- a/infra/database/schema/177-agent-usage-capture-complete.sql
+++ b/infra/database/schema/177-agent-usage-capture-complete.sql
@@ -1,4 +1,4 @@
--- Migration 176: persist the agent turn's usage-capture completeness flag
+-- Migration 177: persist the agent turn's usage-capture completeness flag
 --
 -- WHY THIS EXISTS
 -- OpenClaw 2026.7.2-beta.5 moved per-session transcripts out of JSONL files

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1964,6 +1964,9 @@ interface AgentCoreResult {
   cacheWriteInputTokens: number;
   model: string | null;
   latencyMs: number;
+  // null = the agent image reported no completeness flag (older image), which
+  // is NOT the same as reporting an incomplete capture. See migration 176.
+  usageCaptureComplete: boolean | null;
   modelCallCount: number;
   durationMs: number;
   nudged: boolean;
@@ -2019,6 +2022,10 @@ function failedAgentCoreResult(
     cacheWriteInputTokens: 0,
     model: null,
     latencyMs: 0,
+    // The turn never produced a usage read at all, so completeness is unknown
+    // rather than false — a router-side failure must not look like the
+    // transcript-read regression migration 176 exists to surface.
+    usageCaptureComplete: null,
     modelCallCount: 0,
     durationMs: 0,
     nudged: false,
@@ -2345,6 +2352,13 @@ function parseAgentCoreResult(
     cacheWriteInputTokens: (metadata.cache_write_input_tokens as number) || 0,
     model: (metadata.model as string) || 'unknown',
     latencyMs: (metadata.latency_ms as number) || 0,
+    // Deliberately NOT `=== true`: an image that omits the field is unknown,
+    // not incomplete. Collapsing absent to false would brand every turn from an
+    // older image as a capture failure and drown the real signal.
+    usageCaptureComplete:
+      typeof metadata.usage_capture_complete === 'boolean'
+        ? metadata.usage_capture_complete
+        : null,
     modelCallCount: (metadata.model_call_count as number) || 0,
     durationMs: (metadata.duration_ms as number) || 0,
     nudged: metadata.nudged === true,
@@ -3554,6 +3568,7 @@ interface TelemetryParams {
   inputTokens: number;
   outputTokens: number;
   cacheReadInputTokens?: number;
+  usageCaptureComplete?: boolean | null;
   cacheWriteInputTokens?: number;
   latencyMs: number;
   modelCallCount?: number;
@@ -3574,6 +3589,7 @@ interface TelemetryDefaults {
   topic: Topic | null;
   cacheReadTokens: number;
   cacheWriteTokens: number;
+  usageCaptureComplete: boolean | null;
   modelCallCount: number;
   durationMs: number;
   nudged: boolean;
@@ -3592,6 +3608,8 @@ function normalizeTelemetryParams(params: TelemetryParams): TelemetryDefaults {
     topic: params.topic ?? null,
     cacheReadTokens,
     cacheWriteTokens,
+    // `??` not `||`: false is a meaningful value here and must survive.
+    usageCaptureComplete: params.usageCaptureComplete ?? null,
     modelCallCount: params.modelCallCount ?? 0,
     durationMs: params.durationMs ?? 0,
     nudged: params.nudged ?? false,
@@ -3612,12 +3630,13 @@ async function insertTelemetrySummary(
     sql<{ id: number }[]>`INSERT INTO agent_messages
         (user_id, session_id, model, input_tokens, output_tokens,
          cache_read_input_tokens, cache_write_input_tokens,
-         latency_ms, model_call_count, duration_ms, nudged,
+         latency_ms, usage_capture_complete, model_call_count, duration_ms, nudged,
          guardrail_blocked, space_name, invoked_by, agent_owner_id, topic, created_at)
         VALUES (${params.userId}, ${params.sessionId}, ${params.model},
                 ${params.inputTokens}, ${params.outputTokens},
                 ${defaults.cacheReadTokens}, ${defaults.cacheWriteTokens},
-                ${params.latencyMs}, ${defaults.modelCallCount}, ${defaults.durationMs}, ${defaults.nudged},
+                ${params.latencyMs}, ${defaults.usageCaptureComplete},
+                ${defaults.modelCallCount}, ${defaults.durationMs}, ${defaults.nudged},
                 ${params.guardrailBlocked},
                 ${params.spaceName}, ${defaults.invokedBy}, ${defaults.agentOwnerId}, ${defaults.topic}, NOW())
         RETURNING id`,
@@ -4624,6 +4643,7 @@ function agentResultTelemetry(
   | 'outputTokens'
   | 'cacheReadInputTokens'
   | 'cacheWriteInputTokens'
+  | 'usageCaptureComplete'
   | 'modelCallCount'
   | 'durationMs'
   | 'nudged'
@@ -4636,6 +4656,7 @@ function agentResultTelemetry(
     outputTokens: result.outputTokens,
     cacheReadInputTokens: result.cacheReadInputTokens,
     cacheWriteInputTokens: result.cacheWriteInputTokens,
+    usageCaptureComplete: result.usageCaptureComplete,
     modelCallCount: result.modelCallCount,
     durationMs: result.durationMs,
     nudged: result.nudged,

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1965,7 +1965,7 @@ interface AgentCoreResult {
   model: string | null;
   latencyMs: number;
   // null = the agent image reported no completeness flag (older image), which
-  // is NOT the same as reporting an incomplete capture. See migration 176.
+  // is NOT the same as reporting an incomplete capture. See migration 177.
   usageCaptureComplete: boolean | null;
   modelCallCount: number;
   durationMs: number;
@@ -2024,7 +2024,7 @@ function failedAgentCoreResult(
     latencyMs: 0,
     // The turn never produced a usage read at all, so completeness is unknown
     // rather than false — a router-side failure must not look like the
-    // transcript-read regression migration 176 exists to surface.
+    // transcript-read regression migration 177 exists to surface.
     usageCaptureComplete: null,
     modelCallCount: 0,
     durationMs: 0,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -4210,6 +4210,35 @@ export class AgentPlatformStack extends cdk.Stack {
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }),
     );
+    // Zero-usage capture: a SUCCESSFUL turn that made model calls but reported
+    // no tokens at all. That is arithmetically impossible for a real turn, so it
+    // means the usage-capture path is broken rather than the numbers being
+    // small. This is the alarm that was missing on 2026-07-31, when OpenClaw
+    // moved transcripts from JSONL into SQLite: the adapter kept reading the
+    // deleted path and every turn recorded zeros for TEN DAYS with no error
+    // anywhere, because a zero read is indistinguishable from an honest zero
+    // once it lands in agent_messages. The wrapper emits UsageCaptureZero
+    // (see agentcore_wrapper.usage_capture_looks_broken).
+    //
+    // Threshold 5-in-5-min rather than 1: a rare edge turn can legitimately
+    // trip the heuristic, but a BROKEN capture path trips it on every single
+    // turn, so a real regression clears this in one period while noise does not.
+    iterationAlarms.push(
+      new cloudwatch.Alarm(this, 'UsageCaptureZeroAlarm', {
+        alarmName: `psd-agent-usage-capture-zero-${environment}`,
+        alarmDescription:
+          'Successful agent turns are reporting ZERO tokens (>= 5 in 5 min) — ' +
+          'token/cache telemetry capture is broken, not merely low. Cost and ' +
+          'usage reporting is silently wrong while this fires. Most likely a ' +
+          'pinned-host upgrade moved the transcript store again: check ' +
+          'harness_adapter._read_turn_usage against the live OpenClaw layout.',
+        metric: sumMetric('UsageCaptureZero'),
+        threshold: 5,
+        evaluationPeriods: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }),
+    );
     // Dead-boot detector (the r10 signature): a microVM logged BUILD_MARKER but
     // never reached BOOT_OK. BuildMarkerBoot counts starts, BootOk counts
     // serving-ready boots; a positive difference over the window means a boot

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -4086,7 +4086,6 @@ export class AgentPlatformStack extends cdk.Stack {
     const alarmPeriod = cdk.Duration.minutes(5);
     const iterationAlarms: cloudwatch.Alarm[] = [];
 
-    const routerLog = resources.routerLambda.logGroup;
     const sumMetric = (metricName: string) =>
       new cloudwatch.Metric({
         namespace: resources.failureMetricNamespace,
@@ -4095,52 +4094,9 @@ export class AgentPlatformStack extends cdk.Stack {
         statistic: 'Sum',
       });
 
-    // -- Router-log metric filters (marker-keyed) --
-    new logs.MetricFilter(this, 'GuardrailDenialMetric', {
-      logGroup: routerLog,
-      metricNamespace: resources.failureMetricNamespace,
-      metricName: 'GuardrailDenials',
-      filterPattern: logs.FilterPattern.literal('GUARDRAIL_DENIAL'),
-      metricValue: '1',
-      defaultValue: 0,
-    });
-    new logs.MetricFilter(this, 'ErrorTurnMetric', {
-      logGroup: routerLog,
-      metricNamespace: resources.failureMetricNamespace,
-      metricName: 'ErrorTurns',
-      filterPattern: logs.FilterPattern.literal('AGENT_ERROR_TURN'),
-      metricValue: '1',
-      defaultValue: 0,
-    });
-    new logs.MetricFilter(this, 'EmptyAgentResponseMetric', {
-      logGroup: routerLog,
-      metricNamespace: resources.failureMetricNamespace,
-      metricName: 'EmptyAgentResponses',
-      filterPattern: logs.FilterPattern.literal('EmptyAgentResponse'),
-      metricValue: '1',
-      defaultValue: 0,
-    });
-    // Background-promotion counter — a metric WITHOUT an alarm (the platform
-    // compensating for model behavior; its trend feeds Loop-2 tuning, #1161).
-    new logs.MetricFilter(this, 'BackgroundPromotionMetric', {
-      logGroup: routerLog,
-      metricNamespace: resources.failureMetricNamespace,
-      metricName: 'BackgroundPromotions',
-      filterPattern: logs.FilterPattern.literal('BACKGROUND_PROMOTION'),
-      metricValue: '1',
-      defaultValue: 0,
-    });
-    // -- Job-runner (ECS) task-failure filter --
-    new logs.MetricFilter(this, 'JobRunnerFailureMetric', {
-      logGroup: resources.jobLogGroup,
-      metricNamespace: resources.failureMetricNamespace,
-      metricName: 'JobRunnerFailures',
-      filterPattern: logs.FilterPattern.literal('JOB_RUNNER_FAILED_TURN'),
-      metricValue: '1',
-      defaultValue: 0,
-    });
+    this.createIterationMetricFilters(resources);
 
-    // -- Alarms (6). Thresholds mirror the existing operational style
+    // -- Alarms (7). Thresholds mirror the existing operational style
     //    (DLQ >= 1, errors >= 5, failures >= 10). --
     iterationAlarms.push(
       new cloudwatch.Alarm(this, 'GuardrailDenialRateAlarm', {
@@ -4273,6 +4229,74 @@ export class AgentPlatformStack extends cdk.Stack {
         a.addAlarmAction(iterationSnsAction);
       }
     }
+  }
+
+  /**
+   * Log-derived metrics for the degradation alarms (issue #1161).
+   *
+   * Split out of createIterationMonitoring purely to keep that method within the
+   * max-lines-per-function budget; the filters and the alarms that consume them
+   * are one logical unit and must stay in sync.
+   *
+   * Marker-keyed on purpose: each filter counts a literal marker the router or
+   * job runner writes, so the alarm threshold is a count of real events rather
+   * than a log-volume proxy. Container-origin signals (BootOk, BootTruncationWarn,
+   * UsageCaptureZero) cannot be filtered this way — the AgentCore log group name
+   * carries a runtime-generated suffix — so those are emitted directly via
+   * put_metric_data and only alarmed on here.
+   */
+  private createIterationMetricFilters(
+    resources: AgentPlatformBuildResources,
+  ): void {
+    const routerLog = resources.routerLambda.logGroup;
+    const routerFilters: Array<{
+      id: string;
+      metricName: string;
+      marker: string;
+    }> = [
+      {
+        id: 'GuardrailDenialMetric',
+        metricName: 'GuardrailDenials',
+        marker: 'GUARDRAIL_DENIAL',
+      },
+      {
+        id: 'ErrorTurnMetric',
+        metricName: 'ErrorTurns',
+        marker: 'AGENT_ERROR_TURN',
+      },
+      {
+        id: 'EmptyAgentResponseMetric',
+        metricName: 'EmptyAgentResponses',
+        marker: 'EmptyAgentResponse',
+      },
+      // Background-promotion counter — a metric WITHOUT an alarm (the platform
+      // compensating for model behavior; its trend feeds Loop-2 tuning, #1161).
+      {
+        id: 'BackgroundPromotionMetric',
+        metricName: 'BackgroundPromotions',
+        marker: 'BACKGROUND_PROMOTION',
+      },
+    ];
+    for (const { id, metricName, marker } of routerFilters) {
+      new logs.MetricFilter(this, id, {
+        logGroup: routerLog,
+        metricNamespace: resources.failureMetricNamespace,
+        metricName,
+        filterPattern: logs.FilterPattern.literal(marker),
+        metricValue: '1',
+        defaultValue: 0,
+      });
+    }
+
+    // -- Job-runner (ECS) task-failure filter (different log group) --
+    new logs.MetricFilter(this, 'JobRunnerFailureMetric', {
+      logGroup: resources.jobLogGroup,
+      metricNamespace: resources.failureMetricNamespace,
+      metricName: 'JobRunnerFailures',
+      filterPattern: logs.FilterPattern.literal('JOB_RUNNER_FAILED_TURN'),
+      metricValue: '1',
+      defaultValue: 0,
+    });
   }
 
   private createHealthMonitor(

--- a/infra/test/agent-invocation-context.test.ts
+++ b/infra/test/agent-invocation-context.test.ts
@@ -338,6 +338,24 @@ describe('Agent schedule reliability infrastructure', () => {
     }
   });
 
+  it('alarms successful turns that report zero tokens', () => {
+    // Regression guard for the 2026-07-31 telemetry outage: OpenClaw moved
+    // transcripts from JSONL into SQLite, the harness adapter kept reading the
+    // deleted path, and every turn recorded zero tokens for ten days without
+    // surfacing one error — because no alarm existed for "capture returned
+    // nothing". The wrapper now emits UsageCaptureZero for a SUCCESSFUL turn
+    // that made model calls but reported no tokens; this asserts the alarm on
+    // it ships, wired to the agent alarm topic.
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: `psd-agent-usage-capture-zero-${ENV}`,
+      Namespace: `PSD/AgentPlatform/${ENV}`,
+      MetricName: 'UsageCaptureZero',
+      Threshold: 5,
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+      AlarmActions: Match.anyValue(),
+    });
+  });
+
   it('alarms schedule-reference rejections before invocation', () => {
     template.hasResourceProperties('AWS::Logs::MetricFilter', {
       MetricTransformations: Match.arrayWith([

--- a/lib/agents/__tests__/platform-model.test.ts
+++ b/lib/agents/__tests__/platform-model.test.ts
@@ -1,6 +1,10 @@
 
 import { join, resolve } from "node:path"
-import { AGENT_MODEL_ID, AGENT_REQUEST_MODEL_ID } from "@/lib/agents/platform-model"
+import {
+  AGENT_MODEL_ID,
+  AGENT_MODEL_ID_ALIASES,
+  AGENT_REQUEST_MODEL_ID,
+} from "@/lib/agents/platform-model"
 import { validatedFs } from "@/lib/filesystem/validated-fs";
 
 /**
@@ -75,6 +79,24 @@ const defineAgentPlatformModelIdConsistency108310874Suite1 = () => {
     expect(sql).toContain(`'${AGENT_MODEL_ID}'`)
     // Request id seeded as an alias too (defensive, in case Mantle ever echoes it).
     expect(sql).toContain(`'${AGENT_REQUEST_MODEL_ID}'`)
+  })
+
+  it("every harness alias is priced, so no historical id reads as $0", () => {
+    // agent_messages still holds rows under the OLD ids (dev: `claude-sonnet-5`
+    // up to 2026-07-29, `us.anthropic.claude-sonnet-5` from 2026-07-31). The
+    // cost UI aggregates across the whole range, so an unpriced alias silently
+    // drops those rows to $0 rather than failing.
+    const sql = read("infra/database/schema/092-agent-cache-tokens.sql")
+    for (const alias of AGENT_MODEL_ID_ALIASES) {
+      expect(sql).toContain(`'${alias}'`)
+    }
+  })
+
+  it("the alias list covers both the recorded and request ids", () => {
+    // The projection filter excludes by this list; a current id missing from it
+    // would offer the harness model as a projection candidate against itself.
+    expect(AGENT_MODEL_ID_ALIASES).toContain(AGENT_MODEL_ID)
+    expect(AGENT_MODEL_ID_ALIASES).toContain(AGENT_REQUEST_MODEL_ID)
   })
 };
 

--- a/lib/agents/__tests__/usage-backfill.test.ts
+++ b/lib/agents/__tests__/usage-backfill.test.ts
@@ -1,11 +1,12 @@
 import {
   BACKFILL_CONFIRMATION,
-  assignTurnWindows,
   isBackfillCandidate,
   mergePlans,
   parseBackfillArguments,
   parseTranscriptRecord,
   planSessionBackfill,
+  restrictPlanToRowsSince,
+  segmentTurns,
   sessionIdFromTranscriptKey,
   transcriptSessionKey,
   type CandidateRow,
@@ -15,9 +16,15 @@ import {
 /**
  * The backfill's risk is not "does it run" — it is "does it attribute the right
  * model calls to the right turn". Up to 8 agent_messages rows share one
- * sessionKey and the transcript is append-only across all of them, so a window
- * bug either double-bills a turn or silently drops usage. These tests pin the
- * attribution rules and the write guard.
+ * sessionKey and the transcript is append-only across all of them, so an
+ * attribution bug either double-bills a turn or silently drops usage, and does
+ * it while reporting success.
+ *
+ * Row timestamps CANNOT bound a turn: the router releases the session lock
+ * before it inserts the telemetry row, so the next turn can write transcript
+ * records before the previous row is stamped. These tests pin the replacement —
+ * segment the transcript by its own terminal stopReasons, pair segment k with
+ * row k, and refuse to attribute anything when the counts disagree.
  */
 
 const row = (overrides: Partial<CandidateRow> & { id: number; createdAtMs: number }): CandidateRow => ({
@@ -45,36 +52,34 @@ const record = (
   stopReason,
 })
 
-const defineTurnWindowSuite = () => {
-  it("opens the first turn at the session start and chains the rest", () => {
-    const windows = assignTurnWindows(
-      [row({ id: 2, createdAtMs: 3_000 }), row({ id: 1, createdAtMs: 2_000 })],
-      1_000
-    )
-    // Input order must not matter — sorted by created_at.
-    expect(windows.map((w) => [w.row.id, w.startMs, w.endMs])).toEqual([
-      [1, 1_000, 2_000],
-      [2, 2_000, 3_000],
+const defineSegmentSuite = () => {
+  it("cuts one segment per terminal stop reason", () => {
+    const segments = segmentTurns([
+      record(1_000, { input: 1 }, "toolUse"),
+      record(2_000, { input: 2 }, "stop"),
+      record(3_000, { input: 3 }, "end_turn"),
+    ])
+    expect(segments.map((s) => s.map((r) => r.timestampMs))).toEqual([
+      [1_000, 2_000],
+      [3_000],
     ])
   })
 
-  it("bills a record on a shared boundary to exactly one turn", () => {
-    // Windows are half-open at the start, so the record at t=2000 belongs to
-    // turn 1 (which ends there) and NOT to turn 2 (which starts there).
-    const rows = [
-      row({ id: 1, createdAtMs: 2_000 }),
-      row({ id: 2, createdAtMs: 3_000 }),
-    ]
-    const plan = planSessionBackfill(
-      rows,
-      [record(2_000, { input: 11 })],
-      1_000
-    )
-    expect(plan.updates).toHaveLength(1)
-    expect(plan.updates[0].id).toBe(1)
-    expect(plan.updates[0].after.input).toBe(11)
-    expect(plan.unmatchedRowIds).toEqual([2])
-    expect(plan.unattributedModelCalls).toBe(0)
+  it("drops a trailing run with no terminal reason", () => {
+    // An in-flight or aborted turn has no agent_messages row to receive it.
+    // Returning it would shift the pairing and misprice every turn after it.
+    const segments = segmentTurns([
+      record(1_000, { input: 1 }, "stop"),
+      record(2_000, { input: 2 }, "toolUse"),
+    ])
+    expect(segments).toHaveLength(1)
+    expect(segments[0].map((r) => r.timestampMs)).toEqual([1_000])
+  })
+
+  it("never treats a novel or absent reason as terminal", () => {
+    for (const stopReason of ["toolUse", "error", "novel-terminal", null]) {
+      expect(segmentTurns([record(1_000, { input: 1 }, stopReason)])).toEqual([])
+    }
   })
 }
 
@@ -92,7 +97,7 @@ const definePlanSuite = () => {
       record(3_500, { input: 2, cacheRead: 200 }),
       record(5_500, { input: 3, cacheRead: 300 }),
     ]
-    const plan = planSessionBackfill(rows, records, 1_000)
+    const plan = planSessionBackfill(rows, records)
     expect(plan.updates.map((u) => [u.id, u.after.input, u.after.cacheRead])).toEqual([
       [1, 1, 100],
       [2, 2, 200],
@@ -101,6 +106,7 @@ const definePlanSuite = () => {
     // Reconciliation must balance: nothing double-billed, nothing dropped.
     expect(plan.plannedTotals).toEqual(plan.transcriptTotals)
     expect(plan.unattributedModelCalls).toBe(0)
+    expect(plan.turnCountMismatches).toBe(0)
   })
 
   it("sums every model call within one turn", () => {
@@ -110,85 +116,115 @@ const definePlanSuite = () => {
         record(2_000, { input: 1, output: 10 }, "toolUse"),
         record(3_000, { input: 2, output: 20 }, "toolUse"),
         record(4_000, { input: 3, output: 30 }, "stop"),
-      ],
-      1_000
+      ]
     )
     expect(plan.updates[0].after).toMatchObject({
       input: 6,
       output: 60,
+      // Every paired segment ends on a terminal reason by construction.
       usageCaptureComplete: true,
     })
     expect(plan.updates[0].modelCalls).toBe(3)
+    expect(plan.updates[0].turnIndex).toBe(0)
   })
 
-  it("reports rows with no transcript coverage instead of writing zeros", () => {
+  it("lets an already-populated row consume its segment without touching it", () => {
+    // The pairing needs EVERY row, not just the zero ones. Filtering populated
+    // rows out beforehand would slide turn 2's segment onto turn 2's row while
+    // it actually belongs to turn 1 — a silently mispriced turn.
     const plan = planSessionBackfill(
-      [row({ id: 42, createdAtMs: 5_000 })],
-      [],
-      1_000
+      [
+        row({ id: 1, createdAtMs: 2_000, inputTokens: 500, outputTokens: 5 }),
+        row({ id: 2, createdAtMs: 4_000 }),
+      ],
+      [
+        record(1_500, { input: 111 }),
+        record(3_500, { input: 222 }),
+      ]
     )
+    expect(plan.updates).toHaveLength(1)
+    expect(plan.updates[0].id).toBe(2)
+    // The SECOND segment, not the first.
+    expect(plan.updates[0].after.input).toBe(222)
+    expect(plan.updates[0].turnIndex).toBe(1)
+    expect(plan.unmatchedRowIds).toEqual([])
+    expect(plan.unattributedModelCalls).toBe(0)
+  })
+
+  it("refuses to attribute anything when turn and row counts disagree", () => {
+    // A count mismatch means our model of the session is wrong. Pairing the
+    // wrong segment with the wrong row would write confidently wrong costs, so
+    // the run reports the gap instead.
+    const plan = planSessionBackfill(
+      [row({ id: 1, createdAtMs: 2_000 }), row({ id: 2, createdAtMs: 4_000 })],
+      [record(1_500, { input: 5 })]
+    )
+    expect(plan.updates).toEqual([])
+    expect(plan.turnCountMismatches).toBe(1)
+    expect(plan.unmatchedRowIds).toEqual([1, 2])
+    expect(plan.unattributedModelCalls).toBe(1)
+    expect(plan.plannedTotals.input).toBe(0)
+    // The transcript total is still reported, so the shortfall is visible.
+    expect(plan.transcriptTotals.input).toBe(5)
+  })
+
+  it("reports a row with no transcript coverage instead of writing zeros", () => {
+    const plan = planSessionBackfill([row({ id: 42, createdAtMs: 5_000 })], [])
     expect(plan.updates).toHaveLength(0)
     expect(plan.unmatchedRowIds).toEqual([42])
+    expect(plan.turnCountMismatches).toBe(1)
   })
 
   it("treats a covered turn whose records carry no usage as unrecoverable", () => {
     // Observed on real dev rows from before ~2026-07-29: the transcript has the
     // model calls but no usage numbers on them. Writing zeros over zeros would
-    // report a fixed row while recovering nothing, so it must be reported
-    // unrecoverable instead.
+    // report a fixed row while recovering nothing.
     const plan = planSessionBackfill(
       [row({ id: 7, createdAtMs: 5_000 })],
-      [record(2_000, {}, "toolUse"), record(3_000, {}, "stop")],
-      1_000
+      [record(2_000, {}, "toolUse"), record(3_000, {}, "stop")]
     )
     expect(plan.updates).toHaveLength(0)
     expect(plan.unmatchedRowIds).toEqual([7])
-    // The records WERE found, so they are not "unattributed" either.
+    // The records WERE found and paired, so they are not "unattributed".
     expect(plan.unattributedModelCalls).toBe(0)
   })
 
-  it("counts model calls outside every window as unattributed, not nearest-turn", () => {
-    // A record after the last row's created_at cannot belong to any known turn.
-    // Forcing it into the closest one would invent cost; it must surface as a
-    // reconciliation shortfall instead.
+  it("counts a trailing in-flight turn's calls as unattributed", () => {
+    // Records after the last completed turn cannot belong to any existing row.
+    // They must surface as a reconciliation shortfall, never be folded into the
+    // nearest turn.
     const plan = planSessionBackfill(
       [row({ id: 1, createdAtMs: 3_000 })],
-      [record(2_000, { input: 5 }), record(9_999, { input: 777 })],
-      1_000
+      [record(2_000, { input: 5 }), record(9_999, { input: 777 }, "toolUse")]
     )
     expect(plan.updates[0].after.input).toBe(5)
     expect(plan.unattributedModelCalls).toBe(1)
     expect(plan.transcriptTotals.input).toBe(782)
     expect(plan.plannedTotals.input).toBe(5)
   })
+}
 
-  it("lets the LAST in-window record decide completeness", () => {
-    // A terminal reason followed by more model calls (a nudge leg) must not
-    // latch complete — same rule as the live adapter.
+const defineRestrictSuite = () => {
+  it("drops updates for rows older than the cutoff and recomputes totals", () => {
+    // --since selects which rows may be WRITTEN. It must never remove rows
+    // before pairing, or it would delete the anchors that establish turn order.
     const plan = planSessionBackfill(
-      [row({ id: 1, createdAtMs: 9_000 })],
-      [record(2_000, { input: 1 }, "stop"), record(3_000, { input: 1 }, "toolUse")],
-      1_000
+      [row({ id: 1, createdAtMs: 2_000 }), row({ id: 2, createdAtMs: 6_000 })],
+      [record(1_500, { input: 5 }), record(5_500, { input: 70 })]
     )
-    expect(plan.updates[0].after.usageCaptureComplete).toBe(false)
+    const restricted = restrictPlanToRowsSince(plan, 5_000)
+    expect(restricted.updates.map((u) => u.id)).toEqual([2])
+    expect(restricted.plannedTotals.input).toBe(70)
+    // The transcript total is untouched — the shortfall stays visible.
+    expect(restricted.transcriptTotals.input).toBe(75)
   })
 
-  it("treats only allowlisted stop reasons as terminal", () => {
-    for (const [stopReason, expected] of [
-      ["stop", true],
-      ["end_turn", true],
-      ["toolUse", false],
-      ["error", false],
-      ["novel-terminal", false],
-      [null, false],
-    ] as Array<[string | null, boolean]>) {
-      const plan = planSessionBackfill(
-        [row({ id: 1, createdAtMs: 9_000 })],
-        [record(2_000, { input: 1 }, stopReason)],
-        1_000
-      )
-      expect(plan.updates[0].after.usageCaptureComplete).toBe(expected)
-    }
+  it("passes the plan through unchanged with no cutoff", () => {
+    const plan = planSessionBackfill(
+      [row({ id: 1, createdAtMs: 2_000 })],
+      [record(1_500, { input: 5 })]
+    )
+    expect(restrictPlanToRowsSince(plan, null)).toBe(plan)
   })
 }
 
@@ -300,6 +336,7 @@ const defineArgumentSuite = () => {
     const args = parseBackfillArguments([])
     expect(args.execute).toBe(false)
     expect(args.confirmed).toBe(false)
+    expect(args.errors).toEqual([])
   })
 
   it("requires the exact confirmation token", () => {
@@ -312,6 +349,7 @@ const defineArgumentSuite = () => {
       `--confirmation=${BACKFILL_CONFIRMATION}`,
     ])
     expect(good.execute && good.confirmed).toBe(true)
+    expect(good.errors).toEqual([])
   })
 
   it("parses the prefix and since filters", () => {
@@ -321,34 +359,49 @@ const defineArgumentSuite = () => {
     ])
     expect(args.prefix).toBe("hagelk-db0f32b5")
     expect(args.sinceMs).toBe(Date.parse("2026-07-30T00:00:00Z"))
+    expect(args.errors).toEqual([])
   })
 
-  it("degrades an unparseable since to no filter rather than to epoch 0", () => {
-    // Silently becoming 0 would widen the scan to all history.
-    expect(parseBackfillArguments(["--since=not-a-date"]).sinceMs).toBeNull()
+  it("errors on an unparseable since rather than silently dropping the filter", () => {
+    // Degrading to "no filter" would widen a production run from the outage
+    // window to ALL history — the opposite of what a mistyped date asked for.
+    const args = parseBackfillArguments(["--since=not-a-date"])
+    expect(args.sinceMs).toBeNull()
+    expect(args.errors).toHaveLength(1)
+  })
+
+  it("errors on an empty prefix and on any unrecognized argument", () => {
+    expect(parseBackfillArguments(["--prefix="]).errors).toHaveLength(1)
+    expect(parseBackfillArguments(["--dry-run"]).errors).toHaveLength(1)
   })
 }
 
 const defineMergeSuite = () => {
-  it("sums totals across sessions", () => {
+  it("sums totals and mismatch counts across sessions", () => {
     const a = planSessionBackfill(
       [row({ id: 1, createdAtMs: 3_000 })],
-      [record(2_000, { input: 5, cacheRead: 50 })],
-      1_000
+      [record(2_000, { input: 5, cacheRead: 50 })]
     )
     const b = planSessionBackfill(
       [row({ id: 2, createdAtMs: 3_000, sessionId: "agent-chat-two" })],
-      [record(2_000, { input: 7, cacheRead: 70 })],
-      1_000
+      [record(2_000, { input: 7, cacheRead: 70 })]
     )
-    const merged = mergePlans([a, b])
+    // A session we refused to attribute must still be counted in the merge.
+    const c = planSessionBackfill(
+      [row({ id: 3, createdAtMs: 3_000, sessionId: "agent-chat-three" })],
+      []
+    )
+    const merged = mergePlans([a, b, c])
     expect(merged.updates.map((u) => u.id)).toEqual([1, 2])
     expect(merged.plannedTotals).toMatchObject({ input: 12, cacheRead: 120 })
+    expect(merged.turnCountMismatches).toBe(1)
+    expect(merged.unmatchedRowIds).toEqual([3])
   })
 }
 
-describe("agent usage backfill — turn windows", defineTurnWindowSuite)
+describe("agent usage backfill — turn segmentation", defineSegmentSuite)
 describe("agent usage backfill — plan", definePlanSuite)
+describe("agent usage backfill — since filter", defineRestrictSuite)
 describe("agent usage backfill — record parsing", defineRecordParsingSuite)
 describe("agent usage backfill — write guard", defineGuardSuite)
 describe("agent usage backfill — arguments", defineArgumentSuite)

--- a/lib/agents/__tests__/usage-backfill.test.ts
+++ b/lib/agents/__tests__/usage-backfill.test.ts
@@ -1,0 +1,355 @@
+import {
+  BACKFILL_CONFIRMATION,
+  assignTurnWindows,
+  isBackfillCandidate,
+  mergePlans,
+  parseBackfillArguments,
+  parseTranscriptRecord,
+  planSessionBackfill,
+  sessionIdFromTranscriptKey,
+  transcriptSessionKey,
+  type CandidateRow,
+  type TranscriptRecord,
+} from "@/lib/agents/usage-backfill"
+
+/**
+ * The backfill's risk is not "does it run" — it is "does it attribute the right
+ * model calls to the right turn". Up to 8 agent_messages rows share one
+ * sessionKey and the transcript is append-only across all of them, so a window
+ * bug either double-bills a turn or silently drops usage. These tests pin the
+ * attribution rules and the write guard.
+ */
+
+const row = (overrides: Partial<CandidateRow> & { id: number; createdAtMs: number }): CandidateRow => ({
+  sessionId: "agent-chat-abc",
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadInputTokens: 0,
+  cacheWriteInputTokens: 0,
+  usageCaptureComplete: null,
+  ...overrides,
+})
+
+const record = (
+  timestampMs: number,
+  usage: Partial<TranscriptRecord["usage"]> = {},
+  stopReason: string | null = "stop"
+): TranscriptRecord => ({
+  timestampMs,
+  usage: {
+    input: usage.input ?? 0,
+    output: usage.output ?? 0,
+    cacheRead: usage.cacheRead ?? 0,
+    cacheWrite: usage.cacheWrite ?? 0,
+  },
+  stopReason,
+})
+
+const defineTurnWindowSuite = () => {
+  it("opens the first turn at the session start and chains the rest", () => {
+    const windows = assignTurnWindows(
+      [row({ id: 2, createdAtMs: 3_000 }), row({ id: 1, createdAtMs: 2_000 })],
+      1_000
+    )
+    // Input order must not matter — sorted by created_at.
+    expect(windows.map((w) => [w.row.id, w.startMs, w.endMs])).toEqual([
+      [1, 1_000, 2_000],
+      [2, 2_000, 3_000],
+    ])
+  })
+
+  it("bills a record on a shared boundary to exactly one turn", () => {
+    // Windows are half-open at the start, so the record at t=2000 belongs to
+    // turn 1 (which ends there) and NOT to turn 2 (which starts there).
+    const rows = [
+      row({ id: 1, createdAtMs: 2_000 }),
+      row({ id: 2, createdAtMs: 3_000 }),
+    ]
+    const plan = planSessionBackfill(
+      rows,
+      [record(2_000, { input: 11 })],
+      1_000
+    )
+    expect(plan.updates).toHaveLength(1)
+    expect(plan.updates[0].id).toBe(1)
+    expect(plan.updates[0].after.input).toBe(11)
+    expect(plan.unmatchedRowIds).toEqual([2])
+    expect(plan.unattributedModelCalls).toBe(0)
+  })
+}
+
+const definePlanSuite = () => {
+  it("never bills one session's history to a single turn", () => {
+    // The failure this whole design guards against: three turns in one session,
+    // each must get only its own model calls.
+    const rows = [
+      row({ id: 1, createdAtMs: 2_000 }),
+      row({ id: 2, createdAtMs: 4_000 }),
+      row({ id: 3, createdAtMs: 6_000 }),
+    ]
+    const records = [
+      record(1_500, { input: 1, cacheRead: 100 }),
+      record(3_500, { input: 2, cacheRead: 200 }),
+      record(5_500, { input: 3, cacheRead: 300 }),
+    ]
+    const plan = planSessionBackfill(rows, records, 1_000)
+    expect(plan.updates.map((u) => [u.id, u.after.input, u.after.cacheRead])).toEqual([
+      [1, 1, 100],
+      [2, 2, 200],
+      [3, 3, 300],
+    ])
+    // Reconciliation must balance: nothing double-billed, nothing dropped.
+    expect(plan.plannedTotals).toEqual(plan.transcriptTotals)
+    expect(plan.unattributedModelCalls).toBe(0)
+  })
+
+  it("sums every model call within one turn", () => {
+    const plan = planSessionBackfill(
+      [row({ id: 1, createdAtMs: 9_000 })],
+      [
+        record(2_000, { input: 1, output: 10 }, "toolUse"),
+        record(3_000, { input: 2, output: 20 }, "toolUse"),
+        record(4_000, { input: 3, output: 30 }, "stop"),
+      ],
+      1_000
+    )
+    expect(plan.updates[0].after).toMatchObject({
+      input: 6,
+      output: 60,
+      usageCaptureComplete: true,
+    })
+    expect(plan.updates[0].modelCalls).toBe(3)
+  })
+
+  it("reports rows with no transcript coverage instead of writing zeros", () => {
+    const plan = planSessionBackfill(
+      [row({ id: 42, createdAtMs: 5_000 })],
+      [],
+      1_000
+    )
+    expect(plan.updates).toHaveLength(0)
+    expect(plan.unmatchedRowIds).toEqual([42])
+  })
+
+  it("treats a covered turn whose records carry no usage as unrecoverable", () => {
+    // Observed on real dev rows from before ~2026-07-29: the transcript has the
+    // model calls but no usage numbers on them. Writing zeros over zeros would
+    // report a fixed row while recovering nothing, so it must be reported
+    // unrecoverable instead.
+    const plan = planSessionBackfill(
+      [row({ id: 7, createdAtMs: 5_000 })],
+      [record(2_000, {}, "toolUse"), record(3_000, {}, "stop")],
+      1_000
+    )
+    expect(plan.updates).toHaveLength(0)
+    expect(plan.unmatchedRowIds).toEqual([7])
+    // The records WERE found, so they are not "unattributed" either.
+    expect(plan.unattributedModelCalls).toBe(0)
+  })
+
+  it("counts model calls outside every window as unattributed, not nearest-turn", () => {
+    // A record after the last row's created_at cannot belong to any known turn.
+    // Forcing it into the closest one would invent cost; it must surface as a
+    // reconciliation shortfall instead.
+    const plan = planSessionBackfill(
+      [row({ id: 1, createdAtMs: 3_000 })],
+      [record(2_000, { input: 5 }), record(9_999, { input: 777 })],
+      1_000
+    )
+    expect(plan.updates[0].after.input).toBe(5)
+    expect(plan.unattributedModelCalls).toBe(1)
+    expect(plan.transcriptTotals.input).toBe(782)
+    expect(plan.plannedTotals.input).toBe(5)
+  })
+
+  it("lets the LAST in-window record decide completeness", () => {
+    // A terminal reason followed by more model calls (a nudge leg) must not
+    // latch complete — same rule as the live adapter.
+    const plan = planSessionBackfill(
+      [row({ id: 1, createdAtMs: 9_000 })],
+      [record(2_000, { input: 1 }, "stop"), record(3_000, { input: 1 }, "toolUse")],
+      1_000
+    )
+    expect(plan.updates[0].after.usageCaptureComplete).toBe(false)
+  })
+
+  it("treats only allowlisted stop reasons as terminal", () => {
+    for (const [stopReason, expected] of [
+      ["stop", true],
+      ["end_turn", true],
+      ["toolUse", false],
+      ["error", false],
+      ["novel-terminal", false],
+      [null, false],
+    ] as Array<[string | null, boolean]>) {
+      const plan = planSessionBackfill(
+        [row({ id: 1, createdAtMs: 9_000 })],
+        [record(2_000, { input: 1 }, stopReason)],
+        1_000
+      )
+      expect(plan.updates[0].after.usageCaptureComplete).toBe(expected)
+    }
+  })
+}
+
+const defineRecordParsingSuite = () => {
+  it("parses the real transcript record shape", () => {
+    const parsed = parseTranscriptRecord({
+      id: "e1",
+      type: "message",
+      timestamp: "2026-08-10T04:08:47.346Z",
+      message: {
+        role: "assistant",
+        timestamp: 1786334925287,
+        stopReason: "stop",
+        usage: { input: 2, output: 28, cacheRead: 65301, cacheWrite: 995 },
+      },
+    })
+    expect(parsed).toEqual({
+      timestampMs: 1786334925287,
+      usage: { input: 2, output: 28, cacheRead: 65301, cacheWrite: 995 },
+      stopReason: "stop",
+    })
+  })
+
+  it("falls back to the top-level ISO timestamp", () => {
+    const parsed = parseTranscriptRecord({
+      timestamp: "2026-08-10T04:08:47.346Z",
+      message: { role: "assistant", stopReason: "stop", usage: { input: 5 } },
+    })
+    expect(parsed?.timestampMs).toBe(Date.parse("2026-08-10T04:08:47.346Z"))
+  })
+
+  it("rejects records that carry no usable timestamp", () => {
+    expect(
+      parseTranscriptRecord({
+        message: { role: "assistant", usage: { input: 5 } },
+      })
+    ).toBeNull()
+  })
+
+  it("ignores non-assistant, usageless, and non-object records", () => {
+    for (const raw of [
+      null,
+      "a string",
+      [1, 2, 3],
+      { message: { role: "user", timestamp: 1, usage: { input: 5 } } },
+      { message: { role: "assistant", timestamp: 1 } },
+      { type: "session", timestamp: "2026-08-10T04:08:47.346Z" },
+    ]) {
+      expect(parseTranscriptRecord(raw)).toBeNull()
+    }
+  })
+
+  it("drops negative, non-numeric, and boolean token values", () => {
+    // bool is not a number in TS, but transcript JSON is model-written and a
+    // stray `true` must never be counted as a token.
+    const parsed = parseTranscriptRecord({
+      message: {
+        role: "assistant",
+        timestamp: 1,
+        stopReason: "stop",
+        usage: {
+          input: 10,
+          output: -5,
+          cacheRead: "lots",
+          cacheWrite: true,
+        },
+      },
+    })
+    expect(parsed?.usage).toEqual({
+      input: 10,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    })
+  })
+}
+
+const defineGuardSuite = () => {
+  it("only treats an all-zero row as a candidate", () => {
+    expect(isBackfillCandidate(row({ id: 1, createdAtMs: 0 }))).toBe(true)
+    for (const field of [
+      "inputTokens",
+      "outputTokens",
+      "cacheReadInputTokens",
+      "cacheWriteInputTokens",
+    ] as const) {
+      expect(
+        isBackfillCandidate(row({ id: 1, createdAtMs: 0, [field]: 1 }))
+      ).toBe(false)
+    }
+  })
+
+  it("round-trips the transcript session key", () => {
+    const sessionId = "agent-chat-646172ab014f27d5"
+    const key = transcriptSessionKey(sessionId)
+    // Verified against a real checkpointed database.
+    expect(key).toBe(`agent:main:${sessionId}`)
+    expect(sessionIdFromTranscriptKey(key)).toBe(sessionId)
+  })
+
+  it("returns null for a session key that is not ours", () => {
+    expect(sessionIdFromTranscriptKey("agent:other:xyz")).toBeNull()
+    expect(sessionIdFromTranscriptKey("something-else")).toBeNull()
+  })
+}
+
+const defineArgumentSuite = () => {
+  it("defaults to a dry run with no flags", () => {
+    const args = parseBackfillArguments([])
+    expect(args.execute).toBe(false)
+    expect(args.confirmed).toBe(false)
+  })
+
+  it("requires the exact confirmation token", () => {
+    expect(parseBackfillArguments(["--execute"]).confirmed).toBe(false)
+    expect(
+      parseBackfillArguments(["--execute", "--confirmation=nope"]).confirmed
+    ).toBe(false)
+    const good = parseBackfillArguments([
+      "--execute",
+      `--confirmation=${BACKFILL_CONFIRMATION}`,
+    ])
+    expect(good.execute && good.confirmed).toBe(true)
+  })
+
+  it("parses the prefix and since filters", () => {
+    const args = parseBackfillArguments([
+      "--prefix=hagelk-db0f32b5",
+      "--since=2026-07-30T00:00:00Z",
+    ])
+    expect(args.prefix).toBe("hagelk-db0f32b5")
+    expect(args.sinceMs).toBe(Date.parse("2026-07-30T00:00:00Z"))
+  })
+
+  it("degrades an unparseable since to no filter rather than to epoch 0", () => {
+    // Silently becoming 0 would widen the scan to all history.
+    expect(parseBackfillArguments(["--since=not-a-date"]).sinceMs).toBeNull()
+  })
+}
+
+const defineMergeSuite = () => {
+  it("sums totals across sessions", () => {
+    const a = planSessionBackfill(
+      [row({ id: 1, createdAtMs: 3_000 })],
+      [record(2_000, { input: 5, cacheRead: 50 })],
+      1_000
+    )
+    const b = planSessionBackfill(
+      [row({ id: 2, createdAtMs: 3_000, sessionId: "agent-chat-two" })],
+      [record(2_000, { input: 7, cacheRead: 70 })],
+      1_000
+    )
+    const merged = mergePlans([a, b])
+    expect(merged.updates.map((u) => u.id)).toEqual([1, 2])
+    expect(merged.plannedTotals).toMatchObject({ input: 12, cacheRead: 120 })
+  })
+}
+
+describe("agent usage backfill — turn windows", defineTurnWindowSuite)
+describe("agent usage backfill — plan", definePlanSuite)
+describe("agent usage backfill — record parsing", defineRecordParsingSuite)
+describe("agent usage backfill — write guard", defineGuardSuite)
+describe("agent usage backfill — arguments", defineArgumentSuite)
+describe("agent usage backfill — merge", defineMergeSuite)

--- a/lib/agents/platform-model.ts
+++ b/lib/agents/platform-model.ts
@@ -9,13 +9,16 @@
  * module keeps them from drifting. If a second agent model is ever added, turn
  * AGENT_MODEL_ID into a set and update the consumers.
  *
- * Switched GLM-5 -> Claude Sonnet 5 for #1089 (caching-capable harness model)
- * over Bedrock Mantle's Anthropic Messages endpoint. IMPORTANT: the REQUEST id
- * OpenClaw sends (openclaw.json) and the id Mantle RECORDS on the response
- * DIFFER — the request uses the Bedrock form `anthropic.claude-sonnet-5` but the
- * response echoes the bare `claude-sonnet-5` (verified live). So there are two
- * ids: AGENT_REQUEST_MODEL_ID (what we send) and AGENT_MODEL_ID (what we record
- * + price). Migration 092 seeds pricing for all three forms to be safe.
+ * Switched GLM-5 -> Claude Sonnet 5 for #1089 (caching-capable harness model).
+ * Historically the REQUEST id OpenClaw sent and the id RECORDED on the response
+ * DIFFERED — Bedrock Mantle's Anthropic Messages endpoint echoed the bare
+ * `claude-sonnet-5` for a request of `anthropic.claude-sonnet-5` — so this
+ * module carries two constants. Since #1227 moved the provider onto
+ * bedrock-runtime's native endpoint, which echoes the request's
+ * inference-profile id verbatim, the two happen to be EQUAL again. They are
+ * kept separate anyway: they are distinct concepts, and the next provider swap
+ * can split them apart once more. Migration 092 seeds pricing for all three
+ * forms to be safe.
  *
  * This lives outside the `"use server"` action files on purpose — a server
  * action module may only export async functions, so a plain constant export
@@ -24,12 +27,34 @@
 
 /**
  * The model id the wrapper RECORDS on agent_messages.model (and that cost
- * lookups price against). Bedrock Mantle's Anthropic Messages endpoint echoes
- * the response model as the bare `claude-sonnet-5` (verified live), so that —
- * not the request-form `anthropic.claude-sonnet-5` — is what lands on
- * agent_messages.model. Migration 092 seeds pricing for it (+ two aliases).
+ * lookups price against).
+ *
+ * As of #1227 the provider talks directly to bedrock-runtime's native
+ * anthropic-messages endpoint, which echoes the request's `us.` inference-profile
+ * id verbatim — so `us.anthropic.claude-sonnet-5` is what lands on
+ * agent_messages.model. VERIFIED against the dev database 2026-08-10: every
+ * agent_messages row created on/after 2026-07-31 carries this id, and the prior
+ * bare `claude-sonnet-5` appears only up to 2026-07-29.
+ *
+ * Getting this wrong does NOT fail loudly — the rows simply stop joining
+ * ai_models and the cost UI silently reads $0 (bug #1083). Migration 092 seeds
+ * pricing for this id and both aliases.
  */
-export const AGENT_MODEL_ID = "claude-sonnet-5"
+export const AGENT_MODEL_ID = "us.anthropic.claude-sonnet-5"
+
+/**
+ * Every id form the harness model has EVER been recorded under, including
+ * historical ones still present in `agent_messages` and priced by migration 092.
+ *
+ * Used to exclude the harness model from the cost-projection candidate list:
+ * projecting the harness model onto itself is meaningless, and excluding only
+ * the current id would let a re-activated historical alias slip back in.
+ */
+export const AGENT_MODEL_ID_ALIASES: readonly string[] = [
+  "us.anthropic.claude-sonnet-5",
+  "anthropic.claude-sonnet-5",
+  "claude-sonnet-5",
+]
 
 /**
  * The model id OpenClaw SENDS (the provider model `id` in openclaw.json).
@@ -40,6 +65,9 @@ export const AGENT_MODEL_ID = "claude-sonnet-5"
  * bare `anthropic.claude-sonnet-5` (Mantle) form is still priced in
  * migration 092 as an alias — revert this constant alongside openclaw.json
  * if/when Mantle serves sonnet-5 again.
+ *
+ * Currently equal to AGENT_MODEL_ID because that endpoint echoes the request id
+ * verbatim; see the AGENT_MODEL_ID doc comment.
  */
 export const AGENT_REQUEST_MODEL_ID = "us.anthropic.claude-sonnet-5"
 

--- a/lib/agents/usage-backfill.ts
+++ b/lib/agents/usage-backfill.ts
@@ -21,13 +21,32 @@
  * events into one row would inflate it by the entire session history — the exact
  * mistake the live adapter's `since_ms` window exists to avoid.
  *
- * We reconstruct each turn's window from the row timestamps instead, which is
- * sound because turns within a session are strictly serial: turn k's window is
- * (created_at of row k-1, created_at of row k]. The router inserts a row only
- * after the wrapper finishes the turn, so every model call of turn k is stamped
- * at or before row k's created_at; and turn k cannot begin until turn k-1 has
- * ended, so none of its calls precede row k-1's created_at. The first turn's
- * window opens at the session's own start.
+ * ROW TIMESTAMPS CANNOT BE USED AS TURN BOUNDARIES. The obvious model — turn k
+ * covers (created_at[k-1], created_at[k]] — is WRONG, and a reviewer caught it:
+ * the router releases the session lock in the `finally` of its invocation
+ * wrapper (agent-router invokeWithSessionLockLease) but does not insert the
+ * telemetry row until after the Google Chat response is sent
+ * (recordOwnerResult). The next turn can therefore begin — and write transcript
+ * records — BEFORE the previous turn's row is stamped, so the windows overlap
+ * and calls get billed to the wrong row. Writing confidently wrong cost numbers
+ * is worse than writing none.
+ *
+ * So we segment the TRANSCRIPT by its own turn structure instead, and use the
+ * rows only for ORDER and count:
+ *   1. Walk the session's records in append order, cutting a segment after each
+ *      record whose stopReason is terminal ("stop"/"end_turn"). OpenClaw writes
+ *      "toolUse" on every call that hands off to a tool, so a terminal reason is
+ *      exactly the end-of-turn marker.
+ *   2. Drop a trailing segment with no terminal reason — that is an in-flight or
+ *      aborted turn, which has no row yet.
+ *   3. Pair segment k with row k, rows ordered by created_at.
+ *   4. If the counts DISAGREE, attribute nothing and report it. A count mismatch
+ *      means our model of the session is wrong, and guessing would silently
+ *      misprice turns.
+ *
+ * This needs EVERY row of the session, not just the zero ones — a populated row
+ * still consumes a segment. Loading only candidates would shift every later
+ * segment onto the wrong row (the second half of the same review finding).
  */
 
 /** One assistant model call's token usage, as stored in a transcript record. */
@@ -64,9 +83,13 @@ export interface CandidateRow {
 export interface PlannedUpdate {
   id: number
   sessionId: string
-  /** Inclusive-exclusive window actually used, for the dry-run report. */
-  windowStartMs: number
-  windowEndMs: number
+  /** 0-based position of this turn within the session, for the dry-run report. */
+  turnIndex: number
+  /** The row's own created_at, so callers can apply a date filter AFTER pairing. */
+  rowCreatedAtMs: number
+  /** Timestamps of the paired segment's first and last model call. */
+  firstRecordMs: number
+  lastRecordMs: number
   before: TranscriptUsage & { usageCaptureComplete: boolean | null }
   after: TranscriptUsage & { usageCaptureComplete: boolean }
   modelCalls: number
@@ -81,11 +104,18 @@ export interface BackfillPlan {
    */
   unmatchedRowIds: number[]
   /**
-   * Model calls present in the transcript that fell outside every turn window.
-   * Must be reported: a non-zero value means attribution dropped real usage and
-   * the plan under-counts.
+   * Model calls present in the transcript that no paired segment claimed —
+   * an in-flight trailing turn, or every record of a session we refused to
+   * attribute. Must be reported: a non-zero value means the plan under-counts.
    */
   unattributedModelCalls: number
+  /**
+   * Sessions where the number of completed turns in the transcript did not match
+   * the number of `agent_messages` rows, so nothing was attributed. Non-zero
+   * means real usage is recoverable in principle but our session model is wrong
+   * — investigate before trusting the rest of the run.
+   */
+  turnCountMismatches: number
   /** Sum of every model call in the transcript, attributed or not. */
   transcriptTotals: TranscriptUsage
   /** Sum of what the plan would write. */
@@ -180,78 +210,100 @@ function recordTimestampMs(
 }
 
 /**
- * Per-turn windows for one session's rows.
+ * Split a session's records into one segment per completed turn.
  *
- * Rows are sorted by created_at ascending. Turn k covers
- * (created_at[k-1], created_at[k]]; the first turn opens at `sessionStartMs`.
- * Windows are half-open at the start so a record on a boundary is billed to
- * exactly one turn — never both.
+ * Records must arrive in append order. A segment ends at each record whose
+ * stopReason is terminal; OpenClaw writes "toolUse" on every call that hands off
+ * to a tool, so a terminal reason is precisely the end-of-turn marker and a
+ * novel/absent value can never be mistaken for one.
+ *
+ * A trailing run of records with no terminal reason is DROPPED — that is an
+ * in-flight or aborted turn, which has no `agent_messages` row to receive it.
+ * Returning it would shift the pairing and misprice every turn in the session.
  */
-export function assignTurnWindows(
-  rows: readonly CandidateRow[],
-  sessionStartMs: number
-): Array<{ row: CandidateRow; startMs: number; endMs: number }> {
-  const sorted = [...rows].sort((a, b) => a.createdAtMs - b.createdAtMs)
-  return sorted.map((row, index) => ({
-    row,
-    startMs: index === 0 ? sessionStartMs : sorted[index - 1].createdAtMs,
-    endMs: row.createdAtMs,
-  }))
+export function segmentTurns(
+  records: readonly TranscriptRecord[]
+): TranscriptRecord[][] {
+  const segments: TranscriptRecord[][] = []
+  let current: TranscriptRecord[] = []
+  for (const record of records) {
+    current.push(record)
+    if (
+      record.stopReason !== null &&
+      TERMINAL_STOP_REASONS.includes(record.stopReason)
+    ) {
+      segments.push(current)
+      current = []
+    }
+  }
+  // `current` is deliberately discarded: no terminal reason means no finished
+  // turn.
+  return segments
+}
+
+function foldSegment(segment: readonly TranscriptRecord[]): TranscriptUsage {
+  return segment.reduce<TranscriptUsage>(
+    (totals, record) => addUsage(totals, record.usage),
+    ZERO
+  )
 }
 
 /**
  * Build the backfill plan for ONE session.
  *
- * `sessionStartMs` bounds the first turn. Records outside every window are
- * counted into `unattributedModelCalls` rather than forced into the nearest
- * turn: inventing attribution would corrupt per-turn cost, and the caller needs
- * to see that the reconciliation does not balance.
+ * `rows` must be EVERY `agent_messages` row for the session — including already
+ * populated ones — ordered arbitrarily; they are sorted here. A populated row
+ * still consumes a turn segment, so filtering to zero rows before this point
+ * would shift every later segment onto the wrong row.
  */
 export function planSessionBackfill(
   rows: readonly CandidateRow[],
-  records: readonly TranscriptRecord[],
-  sessionStartMs: number
+  records: readonly TranscriptRecord[]
 ): BackfillPlan {
-  const windows = assignTurnWindows(rows, sessionStartMs)
-  const updates: PlannedUpdate[] = []
-  const unmatchedRowIds: number[] = []
+  const ordered = [...rows].sort((a, b) => a.createdAtMs - b.createdAtMs)
+  const segments = segmentTurns(records)
 
-  let transcriptTotals = ZERO
-  for (const record of records) {
-    transcriptTotals = addUsage(transcriptTotals, record.usage)
+  const transcriptTotals = records.reduce<TranscriptUsage>(
+    (totals, record) => addUsage(totals, record.usage),
+    ZERO
+  )
+
+  // A count mismatch means our model of this session is wrong — a turn we
+  // cannot see, a row written by something else, an aborted turn that still
+  // produced a row. Attribute NOTHING rather than pair the wrong segment with
+  // the wrong row: silently mispriced turns are worse than a reported gap.
+  if (segments.length !== ordered.length) {
+    return {
+      updates: [],
+      unmatchedRowIds: ordered.filter(isBackfillCandidate).map((r) => r.id),
+      unattributedModelCalls: records.length,
+      turnCountMismatches: ordered.length === 0 && segments.length === 0 ? 0 : 1,
+      transcriptTotals,
+      plannedTotals: ZERO,
+    }
   }
 
-  const attributed = new Set<TranscriptRecord>()
+  const updates: PlannedUpdate[] = []
+  const unmatchedRowIds: number[] = []
   let plannedTotals = ZERO
+  let unattributed = records.length
 
-  for (const { row, startMs, endMs } of windows) {
-    let totals = ZERO
-    let modelCalls = 0
-    let complete = false
-    // Ascending timestamp so the LAST in-window record decides completeness,
-    // matching the live adapter: an earlier terminal reason followed by more
-    // model calls (a nudge leg) must not latch it true.
-    const inWindow = records
-      .filter((r) => r.timestampMs > startMs && r.timestampMs <= endMs)
-      .sort((a, b) => a.timestampMs - b.timestampMs)
-    for (const record of inWindow) {
-      totals = addUsage(totals, record.usage)
-      modelCalls += 1
-      complete =
-        record.stopReason !== null &&
-        TERMINAL_STOP_REASONS.includes(record.stopReason)
-      attributed.add(record)
-    }
+  for (const [index, row] of ordered.entries()) {
+    const segment = segments[index]
+    unattributed -= segment.length
 
+    // A populated row is left strictly alone; it only existed here to keep the
+    // pairing aligned.
+    if (!isBackfillCandidate(row)) continue
+
+    const totals = foldSegment(segment)
     const recovered =
       totals.input + totals.output + totals.cacheRead + totals.cacheWrite
-    if (modelCalls === 0 || recovered === 0) {
-      // Either no transcript record covers this turn, or the records that do
-      // carry zero usage themselves — which is what the pre-2026-07-29 rows
-      // look like, when the transcript was not recording usage either. Both are
-      // UNRECOVERABLE, not a zero-value update: writing zeros over zeros
-      // recovers nothing while reporting a success, and would let the run claim
-      // it fixed rows it did not.
+    if (recovered === 0) {
+      // The records covering this turn carry no usage themselves — what the
+      // pre-2026-07-29 transcripts look like. UNRECOVERABLE, not a zero-value
+      // update: writing zeros over zeros recovers nothing while reporting a
+      // success.
       unmatchedRowIds.push(row.id)
       continue
     }
@@ -260,8 +312,10 @@ export function planSessionBackfill(
     updates.push({
       id: row.id,
       sessionId: row.sessionId,
-      windowStartMs: startMs,
-      windowEndMs: endMs,
+      turnIndex: index,
+      rowCreatedAtMs: row.createdAtMs,
+      firstRecordMs: segment[0].timestampMs,
+      lastRecordMs: segment[segment.length - 1].timestampMs,
       before: {
         input: row.inputTokens,
         output: row.outputTokens,
@@ -269,17 +323,44 @@ export function planSessionBackfill(
         cacheWrite: row.cacheWriteInputTokens,
         usageCaptureComplete: row.usageCaptureComplete,
       },
-      after: { ...totals, usageCaptureComplete: complete },
-      modelCalls,
+      // Every segment ends on a terminal stopReason by construction, so a
+      // paired turn is by definition completely captured.
+      after: { ...totals, usageCaptureComplete: true },
+      modelCalls: segment.length,
     })
   }
 
   return {
     updates,
     unmatchedRowIds,
-    unattributedModelCalls: records.length - attributed.size,
+    unattributedModelCalls: unattributed,
+    turnCountMismatches: 0,
     transcriptTotals,
     plannedTotals,
+  }
+}
+
+/**
+ * Drop updates for rows older than `sinceMs`, recomputing `plannedTotals`.
+ *
+ * Applied AFTER pairing, never before. Filtering rows out of the query would
+ * remove the anchors that establish a session's turn ordering and shift every
+ * later segment onto the wrong row; restricting the resulting updates is safe
+ * because pairing has already happened.
+ */
+export function restrictPlanToRowsSince(
+  plan: BackfillPlan,
+  sinceMs: number | null
+): BackfillPlan {
+  if (sinceMs === null) return plan
+  const updates = plan.updates.filter((u) => u.rowCreatedAtMs >= sinceMs)
+  return {
+    ...plan,
+    updates,
+    plannedTotals: updates.reduce<TranscriptUsage>(
+      (totals, update) => addUsage(totals, update.after),
+      ZERO
+    ),
   }
 }
 
@@ -291,6 +372,8 @@ export function mergePlans(plans: readonly BackfillPlan[]): BackfillPlan {
       unmatchedRowIds: [...acc.unmatchedRowIds, ...plan.unmatchedRowIds],
       unattributedModelCalls:
         acc.unattributedModelCalls + plan.unattributedModelCalls,
+      turnCountMismatches:
+        acc.turnCountMismatches + plan.turnCountMismatches,
       transcriptTotals: addUsage(acc.transcriptTotals, plan.transcriptTotals),
       plannedTotals: addUsage(acc.plannedTotals, plan.plannedTotals),
     }),
@@ -298,6 +381,7 @@ export function mergePlans(plans: readonly BackfillPlan[]): BackfillPlan {
       updates: [],
       unmatchedRowIds: [],
       unattributedModelCalls: 0,
+      turnCountMismatches: 0,
       transcriptTotals: ZERO,
       plannedTotals: ZERO,
     }
@@ -351,18 +435,30 @@ export interface BackfillArguments {
   prefix: string | null
   /** Ignore agent_messages rows created before this epoch-ms, if given. */
   sinceMs: number | null
+  /**
+   * Fatal argument errors. Non-empty means the caller must abort — never
+   * proceed with a partially understood invocation.
+   */
+  errors: string[]
 }
 
 /**
  * Parse argv. Dry-run is the default and requires no flags; writing needs BOTH
  * --execute and the exact confirmation token, so no single typo can mutate
  * production telemetry.
+ *
+ * A malformed `--since` is an ERROR, not an omission. Silently falling back to
+ * "no filter" would widen a production run from the outage window to ALL
+ * history — and the documented execute command relies on that filter to stay
+ * narrow, so a mistyped date is exactly when the blast radius must not grow
+ * (review finding).
  */
 export function parseBackfillArguments(argv: readonly string[]): BackfillArguments {
   let execute = false
   let confirmed = false
   let prefix: string | null = null
   let sinceMs: number | null = null
+  const errors: string[] = []
 
   for (const arg of argv) {
     if (arg === "--execute") {
@@ -371,12 +467,26 @@ export function parseBackfillArguments(argv: readonly string[]): BackfillArgumen
       confirmed = arg.slice("--confirmation=".length) === BACKFILL_CONFIRMATION
     } else if (arg.startsWith("--prefix=")) {
       const value = arg.slice("--prefix=".length).trim()
-      prefix = value.length > 0 ? value : null
+      if (value.length === 0) {
+        errors.push("--prefix was given but empty")
+      } else {
+        prefix = value
+      }
     } else if (arg.startsWith("--since=")) {
-      const parsed = Date.parse(arg.slice("--since=".length))
-      sinceMs = Number.isNaN(parsed) ? null : parsed
+      const raw = arg.slice("--since=".length).trim()
+      const parsed = Date.parse(raw)
+      if (raw.length === 0 || Number.isNaN(parsed)) {
+        errors.push(
+          `--since=${raw || "(empty)"} is not a valid date — refusing to run ` +
+            "without the date filter it was meant to apply"
+        )
+      } else {
+        sinceMs = parsed
+      }
+    } else {
+      errors.push(`unrecognized argument: ${arg}`)
     }
   }
 
-  return { execute, confirmed, prefix, sinceMs }
+  return { execute, confirmed, prefix, sinceMs, errors }
 }

--- a/lib/agents/usage-backfill.ts
+++ b/lib/agents/usage-backfill.ts
@@ -1,0 +1,382 @@
+/**
+ * Pure logic for backfilling agent_messages token usage from checkpointed
+ * OpenClaw transcript databases.
+ *
+ * WHY A BACKFILL EXISTS
+ * OpenClaw 2026.7.2-beta.5 moved per-session transcripts from JSONL files into a
+ * per-agent SQLite database. The harness adapter kept reading the deleted JSONL
+ * path, so from 2026-07-31 (dev) / 2026-08-01 (prod) every agent_messages row
+ * recorded input_tokens = output_tokens = cache_read_input_tokens = 0. The turns
+ * themselves were fine and the transcripts are intact in the S3-checkpointed
+ * workspaces, so the real numbers are recoverable.
+ *
+ * All I/O lives in scripts/db/backfill-agent-message-usage.ts. Everything here
+ * is a pure function over plain data so the risky parts — which transcript
+ * records belong to which turn, and what the resulting UPDATE would be — are
+ * unit-testable without S3, SQLite, or a database.
+ *
+ * TURN ATTRIBUTION IS THE WHOLE PROBLEM
+ * agent_messages.session_id is a PSD sessionKey, and up to 8 rows (turns) share
+ * one. The transcript is append-only across all of them, so summing a session's
+ * events into one row would inflate it by the entire session history — the exact
+ * mistake the live adapter's `since_ms` window exists to avoid.
+ *
+ * We reconstruct each turn's window from the row timestamps instead, which is
+ * sound because turns within a session are strictly serial: turn k's window is
+ * (created_at of row k-1, created_at of row k]. The router inserts a row only
+ * after the wrapper finishes the turn, so every model call of turn k is stamped
+ * at or before row k's created_at; and turn k cannot begin until turn k-1 has
+ * ended, so none of its calls precede row k-1's created_at. The first turn's
+ * window opens at the session's own start.
+ */
+
+/** One assistant model call's token usage, as stored in a transcript record. */
+export interface TranscriptUsage {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+}
+
+/** A transcript record reduced to the fields turn attribution needs. */
+export interface TranscriptRecord {
+  /** Epoch-ms timestamp of the model call. */
+  timestampMs: number
+  usage: TranscriptUsage
+  /** OpenClaw's stopReason; only terminal values mean the turn finished. */
+  stopReason: string | null
+}
+
+/** An agent_messages row that is a backfill candidate. */
+export interface CandidateRow {
+  id: number
+  sessionId: string
+  /** Epoch-ms of agent_messages.created_at. */
+  createdAtMs: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadInputTokens: number
+  cacheWriteInputTokens: number
+  usageCaptureComplete: boolean | null
+}
+
+/** The proposed change for one row. */
+export interface PlannedUpdate {
+  id: number
+  sessionId: string
+  /** Inclusive-exclusive window actually used, for the dry-run report. */
+  windowStartMs: number
+  windowEndMs: number
+  before: TranscriptUsage & { usageCaptureComplete: boolean | null }
+  after: TranscriptUsage & { usageCaptureComplete: boolean }
+  modelCalls: number
+}
+
+export interface BackfillPlan {
+  updates: PlannedUpdate[]
+  /**
+   * Rows we could not attribute any usage to. Reported rather than silently
+   * skipped: a zero row with no transcript coverage is unrecoverable, and that
+   * is a finding, not a no-op.
+   */
+  unmatchedRowIds: number[]
+  /**
+   * Model calls present in the transcript that fell outside every turn window.
+   * Must be reported: a non-zero value means attribution dropped real usage and
+   * the plan under-counts.
+   */
+  unattributedModelCalls: number
+  /** Sum of every model call in the transcript, attributed or not. */
+  transcriptTotals: TranscriptUsage
+  /** Sum of what the plan would write. */
+  plannedTotals: TranscriptUsage
+}
+
+/**
+ * OpenClaw writes `toolUse` on every model call that hands off to a tool and
+ * these only on the call that ends the turn. Mirrors
+ * harness_adapter.TERMINAL_USAGE_STOP_REASONS — a novel value must never be
+ * read as "the turn finished".
+ */
+export const TERMINAL_STOP_REASONS: readonly string[] = ["stop", "end_turn"]
+
+const ZERO: TranscriptUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+}
+
+function addUsage(a: TranscriptUsage, b: TranscriptUsage): TranscriptUsage {
+  return {
+    input: a.input + b.input,
+    output: a.output + b.output,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheWrite: a.cacheWrite + b.cacheWrite,
+  }
+}
+
+function isPositiveInt(value: unknown): value is number {
+  // Excludes booleans, NaN, Infinity, and negatives. A transcript is
+  // model-written JSON, so none of those are hypothetical.
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0
+  )
+}
+
+/**
+ * Extract a transcript record from a parsed `event_json` object.
+ *
+ * Returns null for anything that is not an assistant message carrying usage and
+ * a usable timestamp — the same filter the live adapter applies. Never throws.
+ */
+export function parseTranscriptRecord(raw: unknown): TranscriptRecord | null {
+  if (typeof raw !== "object" || raw === null) return null
+  const record = raw as Record<string, unknown>
+  const message = record.message
+  if (typeof message !== "object" || message === null) return null
+  const msg = message as Record<string, unknown>
+  if (msg.role !== "assistant") return null
+  const usageRaw = msg.usage
+  if (typeof usageRaw !== "object" || usageRaw === null) return null
+  const usage = usageRaw as Record<string, unknown>
+
+  const timestampMs = recordTimestampMs(record, msg)
+  if (timestampMs === null) return null
+
+  return {
+    timestampMs,
+    usage: {
+      input: isPositiveInt(usage.input) ? usage.input : 0,
+      output: isPositiveInt(usage.output) ? usage.output : 0,
+      cacheRead: isPositiveInt(usage.cacheRead) ? usage.cacheRead : 0,
+      cacheWrite: isPositiveInt(usage.cacheWrite) ? usage.cacheWrite : 0,
+    },
+    stopReason: typeof msg.stopReason === "string" ? msg.stopReason : null,
+  }
+}
+
+/**
+ * Epoch-ms of a transcript record. Prefers message.timestamp (already epoch-ms)
+ * and falls back to the top-level ISO-8601 string, matching
+ * harness_adapter._record_timestamp_ms.
+ */
+function recordTimestampMs(
+  record: Record<string, unknown>,
+  msg: Record<string, unknown>
+): number | null {
+  const messageTs = msg.timestamp
+  if (typeof messageTs === "number" && Number.isFinite(messageTs)) {
+    return Math.trunc(messageTs)
+  }
+  const topTs = record.timestamp
+  if (typeof topTs === "string" && topTs.length > 0) {
+    const parsed = Date.parse(topTs)
+    if (!Number.isNaN(parsed)) return parsed
+  }
+  return null
+}
+
+/**
+ * Per-turn windows for one session's rows.
+ *
+ * Rows are sorted by created_at ascending. Turn k covers
+ * (created_at[k-1], created_at[k]]; the first turn opens at `sessionStartMs`.
+ * Windows are half-open at the start so a record on a boundary is billed to
+ * exactly one turn — never both.
+ */
+export function assignTurnWindows(
+  rows: readonly CandidateRow[],
+  sessionStartMs: number
+): Array<{ row: CandidateRow; startMs: number; endMs: number }> {
+  const sorted = [...rows].sort((a, b) => a.createdAtMs - b.createdAtMs)
+  return sorted.map((row, index) => ({
+    row,
+    startMs: index === 0 ? sessionStartMs : sorted[index - 1].createdAtMs,
+    endMs: row.createdAtMs,
+  }))
+}
+
+/**
+ * Build the backfill plan for ONE session.
+ *
+ * `sessionStartMs` bounds the first turn. Records outside every window are
+ * counted into `unattributedModelCalls` rather than forced into the nearest
+ * turn: inventing attribution would corrupt per-turn cost, and the caller needs
+ * to see that the reconciliation does not balance.
+ */
+export function planSessionBackfill(
+  rows: readonly CandidateRow[],
+  records: readonly TranscriptRecord[],
+  sessionStartMs: number
+): BackfillPlan {
+  const windows = assignTurnWindows(rows, sessionStartMs)
+  const updates: PlannedUpdate[] = []
+  const unmatchedRowIds: number[] = []
+
+  let transcriptTotals = ZERO
+  for (const record of records) {
+    transcriptTotals = addUsage(transcriptTotals, record.usage)
+  }
+
+  const attributed = new Set<TranscriptRecord>()
+  let plannedTotals = ZERO
+
+  for (const { row, startMs, endMs } of windows) {
+    let totals = ZERO
+    let modelCalls = 0
+    let complete = false
+    // Ascending timestamp so the LAST in-window record decides completeness,
+    // matching the live adapter: an earlier terminal reason followed by more
+    // model calls (a nudge leg) must not latch it true.
+    const inWindow = records
+      .filter((r) => r.timestampMs > startMs && r.timestampMs <= endMs)
+      .sort((a, b) => a.timestampMs - b.timestampMs)
+    for (const record of inWindow) {
+      totals = addUsage(totals, record.usage)
+      modelCalls += 1
+      complete =
+        record.stopReason !== null &&
+        TERMINAL_STOP_REASONS.includes(record.stopReason)
+      attributed.add(record)
+    }
+
+    const recovered =
+      totals.input + totals.output + totals.cacheRead + totals.cacheWrite
+    if (modelCalls === 0 || recovered === 0) {
+      // Either no transcript record covers this turn, or the records that do
+      // carry zero usage themselves — which is what the pre-2026-07-29 rows
+      // look like, when the transcript was not recording usage either. Both are
+      // UNRECOVERABLE, not a zero-value update: writing zeros over zeros
+      // recovers nothing while reporting a success, and would let the run claim
+      // it fixed rows it did not.
+      unmatchedRowIds.push(row.id)
+      continue
+    }
+
+    plannedTotals = addUsage(plannedTotals, totals)
+    updates.push({
+      id: row.id,
+      sessionId: row.sessionId,
+      windowStartMs: startMs,
+      windowEndMs: endMs,
+      before: {
+        input: row.inputTokens,
+        output: row.outputTokens,
+        cacheRead: row.cacheReadInputTokens,
+        cacheWrite: row.cacheWriteInputTokens,
+        usageCaptureComplete: row.usageCaptureComplete,
+      },
+      after: { ...totals, usageCaptureComplete: complete },
+      modelCalls,
+    })
+  }
+
+  return {
+    updates,
+    unmatchedRowIds,
+    unattributedModelCalls: records.length - attributed.size,
+    transcriptTotals,
+    plannedTotals,
+  }
+}
+
+/** Merge per-session plans into one, summing every total. */
+export function mergePlans(plans: readonly BackfillPlan[]): BackfillPlan {
+  return plans.reduce<BackfillPlan>(
+    (acc, plan) => ({
+      updates: [...acc.updates, ...plan.updates],
+      unmatchedRowIds: [...acc.unmatchedRowIds, ...plan.unmatchedRowIds],
+      unattributedModelCalls:
+        acc.unattributedModelCalls + plan.unattributedModelCalls,
+      transcriptTotals: addUsage(acc.transcriptTotals, plan.transcriptTotals),
+      plannedTotals: addUsage(acc.plannedTotals, plan.plannedTotals),
+    }),
+    {
+      updates: [],
+      unmatchedRowIds: [],
+      unattributedModelCalls: 0,
+      transcriptTotals: ZERO,
+      plannedTotals: ZERO,
+    }
+  )
+}
+
+/**
+ * A row is only a candidate while every token counter is still zero.
+ *
+ * This is the idempotency predicate, and it is also asserted in the UPDATE's
+ * WHERE clause so a re-run — or two concurrent runs — cannot double-write. Once
+ * a row carries real numbers, whether from this backfill or from a fixed live
+ * capture, the backfill must leave it alone.
+ */
+export function isBackfillCandidate(row: CandidateRow): boolean {
+  return (
+    row.inputTokens === 0 &&
+    row.outputTokens === 0 &&
+    row.cacheReadInputTokens === 0 &&
+    row.cacheWriteInputTokens === 0
+  )
+}
+
+/** Derive the PSD sessionKey stored in the transcript from an agent_messages row. */
+export function transcriptSessionKey(
+  sessionId: string,
+  agentId = "main"
+): string {
+  // Verified against a checkpointed database: session_windows.session_key is
+  // `agent:<agentId>:<agent_messages.session_id>`.
+  return `agent:${agentId}:${sessionId}`
+}
+
+/** Recover the agent_messages.session_id from a transcript sessionKey. */
+export function sessionIdFromTranscriptKey(
+  sessionKey: string,
+  agentId = "main"
+): string | null {
+  const prefix = `agent:${agentId}:`
+  return sessionKey.startsWith(prefix)
+    ? sessionKey.slice(prefix.length)
+    : null
+}
+
+export const BACKFILL_CONFIRMATION = "BACKFILL_AGENT_USAGE"
+
+export interface BackfillArguments {
+  execute: boolean
+  confirmed: boolean
+  /** Restrict to one workspace prefix; omitted means every prefix in the bucket. */
+  prefix: string | null
+  /** Ignore agent_messages rows created before this epoch-ms, if given. */
+  sinceMs: number | null
+}
+
+/**
+ * Parse argv. Dry-run is the default and requires no flags; writing needs BOTH
+ * --execute and the exact confirmation token, so no single typo can mutate
+ * production telemetry.
+ */
+export function parseBackfillArguments(argv: readonly string[]): BackfillArguments {
+  let execute = false
+  let confirmed = false
+  let prefix: string | null = null
+  let sinceMs: number | null = null
+
+  for (const arg of argv) {
+    if (arg === "--execute") {
+      execute = true
+    } else if (arg.startsWith("--confirmation=")) {
+      confirmed = arg.slice("--confirmation=".length) === BACKFILL_CONFIRMATION
+    } else if (arg.startsWith("--prefix=")) {
+      const value = arg.slice("--prefix=".length).trim()
+      prefix = value.length > 0 ? value : null
+    } else if (arg.startsWith("--since=")) {
+      const parsed = Date.parse(arg.slice("--since=".length))
+      sinceMs = Number.isNaN(parsed) ? null : parsed
+    }
+  }
+
+  return { execute, confirmed, prefix, sinceMs }
+}

--- a/lib/db/schema/tables/agent-messages.ts
+++ b/lib/db/schema/tables/agent-messages.ts
@@ -46,7 +46,7 @@ export const agentMessages = pgTable("agent_messages", {
   modelCallCount: integer("model_call_count").notNull().default(0),
   durationMs: integer("duration_ms").notNull().default(0),
   nudged: boolean("nudged").notNull().default(false),
-  // Usage-capture completeness (migration 176). NULLABLE on purpose — this is
+  // Usage-capture completeness (migration 177). NULLABLE on purpose — this is
   // NOT "false when absent":
   //   true  = usage was positively measured for this turn.
   //   false = the usage read did not complete, so the token columns above are a

--- a/lib/db/schema/tables/agent-messages.ts
+++ b/lib/db/schema/tables/agent-messages.ts
@@ -46,6 +46,18 @@ export const agentMessages = pgTable("agent_messages", {
   modelCallCount: integer("model_call_count").notNull().default(0),
   durationMs: integer("duration_ms").notNull().default(0),
   nudged: boolean("nudged").notNull().default(false),
+  // Usage-capture completeness (migration 176). NULLABLE on purpose — this is
+  // NOT "false when absent":
+  //   true  = usage was positively measured for this turn.
+  //   false = the usage read did not complete, so the token columns above are a
+  //           FLOOR, not a total. This is the signature of the 2026-07-31
+  //           JSONL-to-SQLite transcript regression, which zeroed every token
+  //           column for ten days without surfacing a single error.
+  //   null  = unknown; the row predates the column, or the reporting agent
+  //           image does.
+  // Treating null as either extreme would assert something untrue about ten
+  // days of history, so consumers must handle three states.
+  usageCaptureComplete: boolean("usage_capture_complete"),
   guardrailBlocked: boolean("guardrail_blocked").notNull().default(false),
   spaceName: varchar("space_name", { length: 512 }),
   // Cross-user invocation (migration 068). NULL = owner's own invocation.

--- a/lib/filesystem/validated-fs.ts
+++ b/lib/filesystem/validated-fs.ts
@@ -28,6 +28,13 @@ const WRITE_METHODS = new Set([
   "chmodSync",
   "mkdir",
   "mkdirSync",
+  // mkdtemp creates a directory from its FIRST argument used as a path prefix,
+  // so it is a write whose target this facade must confine like any other. It
+  // was previously absent, which meant the proxy passed it straight through
+  // unchecked — safe only for as long as every call site happened to hardcode
+  // its prefix.
+  "mkdtemp",
+  "mkdtempSync",
   "rename",
   "rm",
   "rmSync",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "db:logs": "docker compose -f docker-compose.dev.yml logs -f postgres",
     "db:migrate": "bun scripts/db/run-migrations.ts",
     "db:finalize-content-retirement": "bun scripts/db/finalize-unified-content-retirement.ts",
+    "db:backfill-agent-usage": "bun scripts/db/backfill-agent-message-usage.ts",
     "db:seed": "docker exec -i aistudio-postgres psql -U postgres -d aistudio < scripts/db/seed-local.sql",
     "db:studio": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run drizzle:studio",
     "db:psql": "docker exec -it aistudio-postgres psql -U postgres -d aistudio",

--- a/scripts/db/backfill-agent-message-usage.ts
+++ b/scripts/db/backfill-agent-message-usage.ts
@@ -1,0 +1,545 @@
+/**
+ * Backfill agent_messages token usage from checkpointed OpenClaw transcripts.
+ *
+ * WHY
+ * OpenClaw 2026.7.2-beta.5 moved per-session transcripts from JSONL files into a
+ * per-agent SQLite database. The harness adapter kept reading the deleted JSONL
+ * path, so from 2026-07-31 (dev) / 2026-08-01 (prod) every agent_messages row
+ * recorded zero tokens. The turns were fine and the transcripts survive in the
+ * S3-checkpointed workspaces, so the real numbers are recoverable.
+ *
+ * Dry-run (default — reads only, writes NOTHING):
+ *   AGENT_WORKSPACE_BUCKET=psd-agents-dev-390844780692 \
+ *   DB_CLUSTER_ARN=arn:aws:rds:us-east-1:...:cluster:aistudio-dev-cluster \
+ *   DB_SECRET_ARN=arn:aws:secretsmanager:us-east-1:...:secret:DbSecret... \
+ *   bun scripts/db/backfill-agent-message-usage.ts --since=2026-07-30
+ *
+ * Execute (requires BOTH flags):
+ *   ... bun scripts/db/backfill-agent-message-usage.ts --since=2026-07-30 \
+ *       --execute --confirmation=BACKFILL_AGENT_USAGE
+ *
+ * SAFETY PROPERTIES
+ *   - Dry-run is the default. Writing needs --execute AND the exact
+ *     confirmation token, so no single typo can mutate telemetry.
+ *   - Every UPDATE re-asserts "all four token counters are still zero" in its
+ *     WHERE clause, so the run is idempotent: a second run updates 0 rows, and
+ *     a row that the fixed live capture has since populated is never clobbered.
+ *   - It only ever fills zero rows. It cannot overwrite a real measurement.
+ *   - Reconciliation is printed before any write: transcript totals vs planned
+ *     totals vs unattributed model calls. A non-zero unattributed count means
+ *     attribution dropped usage and the plan under-counts — investigate rather
+ *     than execute.
+ *
+ * All decision logic lives in lib/agents/usage-backfill.ts and is unit-tested;
+ * this file is I/O only.
+ */
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import {
+  ListObjectsV2Command,
+  GetObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import {
+  ExecuteStatementCommand,
+  RDSDataClient,
+  type Field,
+  type SqlParameter,
+} from "@aws-sdk/client-rds-data";
+// Path-validating fs facade: confines every write to the working directory and
+// the OS temp roots, which is where this script's scratch files live.
+import { validatedFs } from "../../lib/filesystem/validated-fs";
+import {
+  BACKFILL_CONFIRMATION,
+  isBackfillCandidate,
+  mergePlans,
+  parseBackfillArguments,
+  parseTranscriptRecord,
+  planSessionBackfill,
+  sessionIdFromTranscriptKey,
+  type BackfillPlan,
+  type CandidateRow,
+  type TranscriptRecord,
+} from "../../lib/agents/usage-backfill";
+import { scriptLogger as log } from "./script-logger";
+
+const BUCKET = process.env.AGENT_WORKSPACE_BUCKET ?? "";
+const CLUSTER_ARN = process.env.DB_CLUSTER_ARN ?? "";
+const SECRET_ARN = process.env.DB_SECRET_ARN ?? "";
+const DATABASE = process.env.DB_NAME ?? "aistudio";
+const REGION = process.env.AWS_REGION ?? "us-east-1";
+
+const TRANSCRIPT_KEY_SUFFIX = "agents/main/agent/openclaw-agent.sqlite";
+
+const s3 = new S3Client({ region: REGION });
+const rds = new RDSDataClient({ region: REGION });
+
+/** Bind a value as text and let Postgres cast it — the RDS Data API has no
+ * bigint parameter type, and ms epochs / bigint ids overflow int32. */
+const text = (name: string, value: string | number): SqlParameter => ({
+  name,
+  value: { stringValue: String(value) },
+});
+
+const flag = (name: string, value: boolean): SqlParameter => ({
+  name,
+  value: { booleanValue: value },
+});
+
+/** Read a Field as a number, tolerating long vs text encodings. */
+function fieldNumber(field: Field | undefined): number {
+  if (!field) return 0;
+  if (typeof field.longValue === "number") return field.longValue;
+  if (typeof field.stringValue === "string") return Number(field.stringValue);
+  if (typeof field.doubleValue === "number") return field.doubleValue;
+  return 0;
+}
+
+function fieldString(field: Field | undefined): string {
+  return field?.stringValue ?? "";
+}
+
+/** Read a nullable boolean, preserving the three-state semantics of
+ * usage_capture_complete (true / false / unknown). */
+function fieldNullableBoolean(field: Field | undefined): boolean | null {
+  if (!field || field.isNull) return null;
+  return typeof field.booleanValue === "boolean" ? field.booleanValue : null;
+}
+
+async function query(
+  sql: string,
+  parameters: SqlParameter[] = []
+): Promise<Field[][]> {
+  const result = await rds.send(
+    new ExecuteStatementCommand({
+      resourceArn: CLUSTER_ARN,
+      secretArn: SECRET_ARN,
+      database: DATABASE,
+      sql,
+      parameters,
+    })
+  );
+  return result.records ?? [];
+}
+
+/** List every workspace prefix in the bucket (the top-level "directories"). */
+async function listWorkspacePrefixes(): Promise<string[]> {
+  const prefixes: string[] = [];
+  let token: string | undefined;
+  do {
+    const page = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: BUCKET,
+        Delimiter: "/",
+        ContinuationToken: token,
+      })
+    );
+    for (const entry of page.CommonPrefixes ?? []) {
+      const prefix = entry.Prefix?.replace(/\/$/, "");
+      // Skip the checkpoint staging area — not a user workspace.
+      if (prefix && !prefix.startsWith(".")) prefixes.push(prefix);
+    }
+    token = page.NextContinuationToken;
+  } while (token);
+  return prefixes;
+}
+
+/**
+ * Download one workspace's transcript database, or null when it has none.
+ *
+ * The -wal sidecar is deliberately NOT fetched: a checkpointed database may
+ * carry a stale WAL from an earlier upload, and pairing a current .sqlite with
+ * an older -wal can make SQLite read a torn or rolled-back state. Reading the
+ * main file alone means we may miss the most recent uncheckpointed turns, which
+ * under-counts rather than corrupting — the right direction to fail.
+ */
+async function fetchTranscriptDatabase(
+  prefix: string,
+  directory: string
+): Promise<string | null> {
+  const key = `${prefix}/${TRANSCRIPT_KEY_SUFFIX}`;
+  try {
+    const response = await s3.send(
+      new GetObjectCommand({ Bucket: BUCKET, Key: key })
+    );
+    const bytes = await response.Body?.transformToByteArray();
+    if (!bytes) return null;
+    const path = join(directory, "openclaw-agent.sqlite");
+    validatedFs.writeFileSync(path, bytes);
+    return path;
+  } catch (error) {
+    const name = (error as { name?: string }).name;
+    if (name === "NoSuchKey" || name === "NotFound") return null;
+    throw error;
+  }
+}
+
+interface SessionTranscript {
+  /** agent_messages.session_id this transcript belongs to. */
+  sessionId: string;
+  /** Earliest session-window start, bounding the first turn. */
+  sessionStartMs: number;
+  records: TranscriptRecord[];
+}
+
+/**
+ * Read per-session transcripts out of a workspace database.
+ *
+ * session_windows maps the OpenClaw transcript session_id (a UUID) to the PSD
+ * sessionKey `agent:main:<agent_messages.session_id>` — verified against a real
+ * checkpointed database. A sessionKey can own SEVERAL windows (rollover,
+ * compaction, fork), so every window's events are merged under one sessionId
+ * before turn attribution; otherwise a mid-session rollover would silently drop
+ * the pre-rollover model calls.
+ */
+function readSessionTranscripts(databasePath: string): SessionTranscript[] {
+  // `immutable=1` is REQUIRED, not an optimization. The checkpointed file is in
+  // WAL mode but arrives without its -wal/-shm sidecars, and a plain read-only
+  // open of a WAL database needs to build the -shm — which read-only forbids, so
+  // it fails with "unable to open database file". `immutable` tells SQLite to
+  // skip WAL recovery and locking entirely.
+  //
+  // Safe HERE and only here: this is a static snapshot in a private temp
+  // directory with no concurrent writer. The live adapter
+  // (harness_adapter._sum_sqlite_transcript_usage) must NEVER use immutable —
+  // it reads a database the runtime is actively writing, where skipping locking
+  // would risk a torn read.
+  const db = new Database(`file:${databasePath}?mode=ro&immutable=1`, {
+    readonly: true,
+  });
+  try {
+    const windows = db
+      .query(
+        "SELECT session_id, session_key, created_at FROM session_windows",
+      )
+      .all() as Array<{
+        session_id: string;
+        session_key: string;
+        created_at: number;
+      }>;
+
+    const bySessionId = new Map<string, SessionTranscript>();
+    const windowToSession = new Map<string, string>();
+    for (const window of windows) {
+      const sessionId = sessionIdFromTranscriptKey(window.session_key);
+      if (!sessionId) continue;
+      windowToSession.set(window.session_id, sessionId);
+      const existing = bySessionId.get(sessionId);
+      if (existing) {
+        existing.sessionStartMs = Math.min(
+          existing.sessionStartMs,
+          window.created_at,
+        );
+      } else {
+        bySessionId.set(sessionId, {
+          sessionId,
+          sessionStartMs: window.created_at,
+          records: [],
+        });
+      }
+    }
+
+    const events = db
+      .query(
+        "SELECT session_id, event_json FROM transcript_events ORDER BY session_id, seq",
+      )
+      .all() as Array<{ session_id: string; event_json: string }>;
+
+    for (const event of events) {
+      const sessionId = windowToSession.get(event.session_id);
+      if (!sessionId) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(event.event_json);
+      } catch {
+        // Corrupt row: skip it rather than abort the workspace. Its usage is
+        // simply not recoverable, and the reconciliation report will show the
+        // shortfall.
+        continue;
+      }
+      const record = parseTranscriptRecord(parsed);
+      if (record) bySessionId.get(sessionId)?.records.push(record);
+    }
+
+    return [...bySessionId.values()].filter((s) => s.records.length > 0);
+  } finally {
+    db.close();
+  }
+}
+
+function toCandidateRow(row: Field[]): CandidateRow {
+  return {
+    id: fieldNumber(row[0]),
+    sessionId: fieldString(row[1]),
+    createdAtMs: fieldNumber(row[2]),
+    inputTokens: fieldNumber(row[3]),
+    outputTokens: fieldNumber(row[4]),
+    cacheReadInputTokens: fieldNumber(row[5]),
+    cacheWriteInputTokens: fieldNumber(row[6]),
+    usageCaptureComplete: fieldNullableBoolean(row[7]),
+  };
+}
+
+/** One chunk's SELECT. Split out so the caller stays a simple loop. */
+async function loadCandidateChunk(
+  sessionIds: readonly string[],
+  sinceMs: number | null
+): Promise<CandidateRow[]> {
+  const placeholders = sessionIds.map((_, i) => `:s${i}`).join(", ");
+  const parameters = sessionIds.map((value, i) => text(`s${i}`, value));
+  let sinceClause = "";
+  if (sinceMs !== null) {
+    sinceClause =
+      " AND created_at >= to_timestamp((:since_ms)::bigint / 1000.0)";
+    parameters.push(text("since_ms", sinceMs));
+  }
+  // `placeholders` is built from the chunk INDEX (:s0, :s1, ...), never from
+  // session-id content, so this template carries no caller data. Every value is
+  // a bound parameter.
+  const sql =
+    "SELECT id, session_id, " +
+    "(EXTRACT(EPOCH FROM created_at) * 1000)::bigint AS created_ms, " +
+    "input_tokens, output_tokens, cache_read_input_tokens, " +
+    "cache_write_input_tokens, usage_capture_complete " +
+    `FROM agent_messages WHERE session_id IN (${placeholders})` +
+    sinceClause +
+    " ORDER BY session_id, created_at";
+
+  const rows = await query(sql, parameters);
+  // Only zero rows are candidates; a populated row must never be touched.
+  return rows.map(toCandidateRow).filter(isBackfillCandidate);
+}
+
+/** Load the zero-usage agent_messages rows for the given session ids. */
+async function loadCandidateRows(
+  sessionIds: readonly string[],
+  sinceMs: number | null
+): Promise<Map<string, CandidateRow[]>> {
+  const bySession = new Map<string, CandidateRow[]>();
+  // Chunked so a workspace with many sessions cannot exceed the statement's
+  // parameter limits.
+  const CHUNK = 50;
+  for (let index = 0; index < sessionIds.length; index += CHUNK) {
+    const candidates = await loadCandidateChunk(
+      sessionIds.slice(index, index + CHUNK),
+      sinceMs
+    );
+    for (const candidate of candidates) {
+      const list = bySession.get(candidate.sessionId) ?? [];
+      list.push(candidate);
+      bySession.set(candidate.sessionId, list);
+    }
+  }
+  return bySession;
+}
+
+/**
+ * Apply one planned update.
+ *
+ * The WHERE clause re-asserts the all-zero precondition, which is what makes
+ * the run idempotent and safe to interrupt: the guard is enforced by the
+ * database at write time, not by the plan that was computed earlier.
+ */
+async function applyUpdate(update: BackfillPlan["updates"][number]): Promise<boolean> {
+  const rows = await query(
+    `UPDATE agent_messages SET
+       input_tokens = (:input)::int,
+       output_tokens = (:output)::int,
+       cache_read_input_tokens = (:cache_read)::int,
+       cache_write_input_tokens = (:cache_write)::int,
+       usage_capture_complete = :complete
+     WHERE id = (:id)::bigint
+       AND input_tokens = 0
+       AND output_tokens = 0
+       AND cache_read_input_tokens = 0
+       AND cache_write_input_tokens = 0
+     RETURNING id`,
+    [
+      text("input", update.after.input),
+      text("output", update.after.output),
+      text("cache_read", update.after.cacheRead),
+      text("cache_write", update.after.cacheWrite),
+      flag("complete", update.after.usageCaptureComplete),
+      text("id", update.id),
+    ]
+  );
+  return rows.length > 0;
+}
+
+function requireEnvironment(): void {
+  const missing = [
+    ["AGENT_WORKSPACE_BUCKET", BUCKET],
+    ["DB_CLUSTER_ARN", CLUSTER_ARN],
+    ["DB_SECRET_ARN", SECRET_ARN],
+  ].filter(([, value]) => !value);
+  if (missing.length > 0) {
+    log.fail(
+      `Missing required environment: ${missing.map(([name]) => name).join(", ")}`
+    );
+    process.exit(1);
+  }
+}
+
+/** Plan one workspace prefix. Returns [] when it has no usable transcript. */
+async function planWorkspace(
+  prefix: string,
+  sinceMs: number | null
+): Promise<{ plans: BackfillPlan[]; hadTranscript: boolean }> {
+  const directory = validatedFs.mkdtempSync(
+    join(tmpdir(), "agent-usage-backfill-")
+  );
+  try {
+    const databasePath = await fetchTranscriptDatabase(prefix, directory);
+    if (!databasePath) return { plans: [], hadTranscript: false };
+
+    const transcripts = readSessionTranscripts(databasePath);
+    const rowsBySession = await loadCandidateRows(
+      transcripts.map((t) => t.sessionId),
+      sinceMs
+    );
+    const plans: BackfillPlan[] = [];
+    for (const transcript of transcripts) {
+      const rows = rowsBySession.get(transcript.sessionId) ?? [];
+      if (rows.length === 0) continue;
+      plans.push(
+        planSessionBackfill(rows, transcript.records, transcript.sessionStartMs)
+      );
+    }
+    return { plans, hadTranscript: true };
+  } finally {
+    validatedFs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function reportPlan(plan: BackfillPlan, workspacesWithTranscripts: number): void {
+  log.section("Per-row plan (before -> after)");
+  for (const update of plan.updates) {
+    log.info(`row ${update.id}`, {
+      session: update.sessionId,
+      window: `${new Date(update.windowStartMs).toISOString()} .. ${new Date(
+        update.windowEndMs
+      ).toISOString()}`,
+      modelCalls: update.modelCalls,
+      before: `in=${update.before.input} out=${update.before.output} cr=${update.before.cacheRead} cw=${update.before.cacheWrite} complete=${update.before.usageCaptureComplete}`,
+      after: `in=${update.after.input} out=${update.after.output} cr=${update.after.cacheRead} cw=${update.after.cacheWrite} complete=${update.after.usageCaptureComplete}`,
+    });
+  }
+
+  log.section("Totals");
+  log.info("Workspaces with a transcript database", {
+    count: workspacesWithTranscripts,
+  });
+  log.info("Rows to update", { count: plan.updates.length });
+  log.info("Rows with nothing recoverable", {
+    count: plan.unmatchedRowIds.length,
+    ids: plan.unmatchedRowIds.slice(0, 40),
+  });
+  log.info("Transcript totals (all model calls found)", {
+    ...plan.transcriptTotals,
+  });
+  log.info("Planned totals (what would be written)", { ...plan.plannedTotals });
+  if (plan.unattributedModelCalls > 0) {
+    log.warn(
+      "Model calls fell OUTSIDE every turn window — the plan under-counts. " +
+        "Investigate before executing.",
+      { unattributedModelCalls: plan.unattributedModelCalls }
+    );
+  }
+}
+
+/**
+ * Fail fast when migration 176 has not been applied.
+ *
+ * Without it the per-workspace query dies on a missing column, which would
+ * otherwise surface as one opaque SQL error per workspace — up to a hundred
+ * lines that never name the actual prerequisite.
+ */
+async function requireMigration176(): Promise<void> {
+  const rows = await query(
+    "SELECT 1 FROM information_schema.columns " +
+      "WHERE table_name = 'agent_messages' " +
+      "AND column_name = 'usage_capture_complete'"
+  );
+  if (rows.length === 0) {
+    log.fail(
+      "agent_messages.usage_capture_complete is missing — migration 176 has " +
+        "not been applied to this database. Deploy it first; nothing was read " +
+        "or written."
+    );
+    process.exit(1);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseBackfillArguments(process.argv.slice(2));
+  log.section("agent_messages usage backfill (JSONL -> SQLite transcript move)");
+  requireEnvironment();
+  await requireMigration176();
+  const willWrite = args.execute && args.confirmed;
+  log.info("Target", { bucket: BUCKET, database: DATABASE });
+  log.info("Mode", {
+    execute: willWrite,
+    dryRun: !willWrite,
+    prefix: args.prefix ?? "(all)",
+    since: args.sinceMs ? new Date(args.sinceMs).toISOString() : "(none)",
+  });
+
+  if (args.execute && !args.confirmed) {
+    log.fail(
+      `--execute requires --confirmation=${BACKFILL_CONFIRMATION}; nothing was changed.`
+    );
+    process.exit(1);
+  }
+
+  const prefixes = args.prefix ? [args.prefix] : await listWorkspacePrefixes();
+  log.info("Workspaces to scan", { count: prefixes.length });
+
+  const plans: BackfillPlan[] = [];
+  let workspacesWithTranscripts = 0;
+
+  for (const prefix of prefixes) {
+    try {
+      const result = await planWorkspace(prefix, args.sinceMs);
+      plans.push(...result.plans);
+      if (result.hadTranscript) workspacesWithTranscripts += 1;
+    } catch (error) {
+      // One unreadable workspace must not abandon the rest; surface it loudly.
+      log.error("Workspace failed — skipped", {
+        prefix,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const plan = mergePlans(plans);
+  reportPlan(plan, workspacesWithTranscripts);
+
+  if (!willWrite) {
+    log.success(
+      `Dry run complete. NOTHING was written. Re-run with --execute --confirmation=${BACKFILL_CONFIRMATION} to apply.`
+    );
+    return;
+  }
+
+  log.section("Applying");
+  let applied = 0;
+  let skipped = 0;
+  for (const update of plan.updates) {
+    if (await applyUpdate(update)) {
+      applied += 1;
+    } else {
+      // The all-zero guard rejected it: already backfilled, or the fixed live
+      // capture populated it between planning and writing. Both are correct
+      // outcomes, not errors.
+      skipped += 1;
+    }
+  }
+  log.success(`Applied ${applied} row(s); ${skipped} skipped by the zero-guard.`);
+}
+
+main().catch((error) => {
+  log.fail(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/db/backfill-agent-message-usage.ts
+++ b/scripts/db/backfill-agent-message-usage.ts
@@ -450,7 +450,7 @@ function reportPlan(plan: BackfillPlan, workspacesWithTranscripts: number): void
 }
 
 /**
- * Fail fast when migration 176 has not been applied.
+ * Fail fast when migration 177 has not been applied.
  *
  * Without it the per-workspace query dies on a missing column, which would
  * otherwise surface as one opaque SQL error per workspace — up to a hundred
@@ -464,7 +464,7 @@ async function requireMigration176(): Promise<void> {
   );
   if (rows.length === 0) {
     log.fail(
-      "agent_messages.usage_capture_complete is missing — migration 176 has " +
+      "agent_messages.usage_capture_complete is missing — migration 177 has " +
         "not been applied to this database. Deploy it first; nothing was read " +
         "or written."
     );

--- a/scripts/db/backfill-agent-message-usage.ts
+++ b/scripts/db/backfill-agent-message-usage.ts
@@ -53,12 +53,13 @@ import {
 import { validatedFs } from "../../lib/filesystem/validated-fs";
 import {
   BACKFILL_CONFIRMATION,
-  isBackfillCandidate,
   mergePlans,
   parseBackfillArguments,
   parseTranscriptRecord,
   planSessionBackfill,
+  restrictPlanToRowsSince,
   sessionIdFromTranscriptKey,
+  type BackfillArguments,
   type BackfillPlan,
   type CandidateRow,
   type TranscriptRecord,
@@ -284,17 +285,14 @@ function toCandidateRow(row: Field[]): CandidateRow {
 
 /** One chunk's SELECT. Split out so the caller stays a simple loop. */
 async function loadCandidateChunk(
-  sessionIds: readonly string[],
-  sinceMs: number | null
+  sessionIds: readonly string[]
 ): Promise<CandidateRow[]> {
   const placeholders = sessionIds.map((_, i) => `:s${i}`).join(", ");
   const parameters = sessionIds.map((value, i) => text(`s${i}`, value));
-  let sinceClause = "";
-  if (sinceMs !== null) {
-    sinceClause =
-      " AND created_at >= to_timestamp((:since_ms)::bigint / 1000.0)";
-    parameters.push(text("since_ms", sinceMs));
-  }
+  // NO date predicate here on purpose. --since must not remove rows before
+  // pairing: dropping a session's earlier turns would shift every later segment
+  // onto the wrong row. The filter is applied to the resulting UPDATES instead.
+  //
   // `placeholders` is built from the chunk INDEX (:s0, :s1, ...), never from
   // session-id content, so this template carries no caller data. Every value is
   // a bound parameter.
@@ -304,18 +302,19 @@ async function loadCandidateChunk(
     "input_tokens, output_tokens, cache_read_input_tokens, " +
     "cache_write_input_tokens, usage_capture_complete " +
     `FROM agent_messages WHERE session_id IN (${placeholders})` +
-    sinceClause +
     " ORDER BY session_id, created_at";
 
+  // EVERY row is returned, populated ones included. A populated row still
+  // consumes a turn segment, so filtering here would shift each later segment
+  // onto the wrong row and misprice the session (review finding). Only
+  // planSessionBackfill decides which rows are writable.
   const rows = await query(sql, parameters);
-  // Only zero rows are candidates; a populated row must never be touched.
-  return rows.map(toCandidateRow).filter(isBackfillCandidate);
+  return rows.map(toCandidateRow);
 }
 
-/** Load the zero-usage agent_messages rows for the given session ids. */
+/** Load ALL agent_messages rows for the given session ids. */
 async function loadCandidateRows(
-  sessionIds: readonly string[],
-  sinceMs: number | null
+  sessionIds: readonly string[]
 ): Promise<Map<string, CandidateRow[]>> {
   const bySession = new Map<string, CandidateRow[]>();
   // Chunked so a workspace with many sessions cannot exceed the statement's
@@ -323,8 +322,7 @@ async function loadCandidateRows(
   const CHUNK = 50;
   for (let index = 0; index < sessionIds.length; index += CHUNK) {
     const candidates = await loadCandidateChunk(
-      sessionIds.slice(index, index + CHUNK),
-      sinceMs
+      sessionIds.slice(index, index + CHUNK)
     );
     for (const candidate of candidates) {
       const list = bySession.get(candidate.sessionId) ?? [];
@@ -396,15 +394,20 @@ async function planWorkspace(
 
     const transcripts = readSessionTranscripts(databasePath);
     const rowsBySession = await loadCandidateRows(
-      transcripts.map((t) => t.sessionId),
-      sinceMs
+      transcripts.map((t) => t.sessionId)
     );
     const plans: BackfillPlan[] = [];
     for (const transcript of transcripts) {
       const rows = rowsBySession.get(transcript.sessionId) ?? [];
       if (rows.length === 0) continue;
+      // --since is applied AFTER pairing, never before: it selects which rows
+      // may be written, and must not remove the rows that establish the
+      // session's turn ordering.
       plans.push(
-        planSessionBackfill(rows, transcript.records, transcript.sessionStartMs)
+        restrictPlanToRowsSince(
+          planSessionBackfill(rows, transcript.records),
+          sinceMs
+        )
       );
     }
     return { plans, hadTranscript: true };
@@ -418,8 +421,9 @@ function reportPlan(plan: BackfillPlan, workspacesWithTranscripts: number): void
   for (const update of plan.updates) {
     log.info(`row ${update.id}`, {
       session: update.sessionId,
-      window: `${new Date(update.windowStartMs).toISOString()} .. ${new Date(
-        update.windowEndMs
+      turn: update.turnIndex,
+      calls: `${new Date(update.firstRecordMs).toISOString()} .. ${new Date(
+        update.lastRecordMs
       ).toISOString()}`,
       modelCalls: update.modelCalls,
       before: `in=${update.before.input} out=${update.before.output} cr=${update.before.cacheRead} cw=${update.before.cacheWrite} complete=${update.before.usageCaptureComplete}`,
@@ -440,10 +444,19 @@ function reportPlan(plan: BackfillPlan, workspacesWithTranscripts: number): void
     ...plan.transcriptTotals,
   });
   log.info("Planned totals (what would be written)", { ...plan.plannedTotals });
+  if (plan.turnCountMismatches > 0) {
+    log.warn(
+      "Sessions where the transcript's completed-turn count did not match the " +
+        "agent_messages row count — NOTHING was attributed for these, because " +
+        "pairing the wrong segment to the wrong row would silently misprice " +
+        "turns. Investigate before executing.",
+      { sessions: plan.turnCountMismatches }
+    );
+  }
   if (plan.unattributedModelCalls > 0) {
     log.warn(
-      "Model calls fell OUTSIDE every turn window — the plan under-counts. " +
-        "Investigate before executing.",
+      "Model calls no paired turn claimed (an in-flight trailing turn, or a " +
+        "skipped mismatched session) — the plan under-counts by this much.",
       { unattributedModelCalls: plan.unattributedModelCalls }
     );
   }
@@ -456,7 +469,7 @@ function reportPlan(plan: BackfillPlan, workspacesWithTranscripts: number): void
  * otherwise surface as one opaque SQL error per workspace — up to a hundred
  * lines that never name the actual prerequisite.
  */
-async function requireMigration176(): Promise<void> {
+async function requireMigration177(): Promise<void> {
   const rows = await query(
     "SELECT 1 FROM information_schema.columns " +
       "WHERE table_name = 'agent_messages' " +
@@ -472,11 +485,34 @@ async function requireMigration176(): Promise<void> {
   }
 }
 
+/**
+ * Abort unless the whole invocation was understood, BEFORE anything is read.
+ *
+ * Every unparsed argument is fatal. A mistyped `--since` that degraded to "no
+ * filter" would widen the run from the outage window to ALL history — the
+ * opposite of what the operator asked for — and `--execute` without the exact
+ * token is the same mistake pointing the other way. Both are checked ahead of
+ * the environment and migration probes so a malformed command never even
+ * connects.
+ */
+function requireUsableArguments(args: BackfillArguments): void {
+  const failures = [...args.errors];
+  if (args.execute && !args.confirmed) {
+    failures.push(
+      `--execute requires --confirmation=${BACKFILL_CONFIRMATION}; nothing was changed.`
+    );
+  }
+  if (failures.length === 0) return;
+  for (const failure of failures) log.fail(failure);
+  process.exit(1);
+}
+
 async function main(): Promise<void> {
   const args = parseBackfillArguments(process.argv.slice(2));
   log.section("agent_messages usage backfill (JSONL -> SQLite transcript move)");
+  requireUsableArguments(args);
   requireEnvironment();
-  await requireMigration176();
+  await requireMigration177();
   const willWrite = args.execute && args.confirmed;
   log.info("Target", { bucket: BUCKET, database: DATABASE });
   log.info("Mode", {
@@ -485,13 +521,6 @@ async function main(): Promise<void> {
     prefix: args.prefix ?? "(all)",
     since: args.sinceMs ? new Date(args.sinceMs).toISOString() : "(none)",
   });
-
-  if (args.execute && !args.confirmed) {
-    log.fail(
-      `--execute requires --confirmation=${BACKFILL_CONFIRMATION}; nothing was changed.`
-    );
-    process.exit(1);
-  }
 
   const prefixes = args.prefix ? [args.prefix] : await listWorkspacePrefixes();
   log.info("Workspaces to scan", { count: prefixes.length });

--- a/scripts/db/bun-sqlite.d.ts
+++ b/scripts/db/bun-sqlite.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Minimal ambient declaration for the Bun-only `bun:sqlite` module.
+ *
+ * Only backfill-agent-message-usage.ts needs it (to read a checkpointed OpenClaw
+ * transcript database), and it runs exclusively under `bun`.
+ *
+ * Declared narrowly here instead of adding `bun-types` to tsconfig `types`:
+ * that package's triple-slash reference overrides the global `fetch`/DOM types
+ * for the WHOLE tsc program and breaks unrelated DOM-typed tests. See
+ * docs/learnings/build-errors/2026-06-29-bun-types-triple-slash-tsc-dom-pollution.md
+ * — this file is the contained alternative that learning points to.
+ *
+ * Deliberately covers only the surface actually used: a read-only connection,
+ * parameterless SELECTs, and close(). Widen it only alongside a real caller.
+ */
+declare module "bun:sqlite" {
+  export class Database {
+    constructor(filename: string, options?: { readonly?: boolean });
+    query<Row = unknown>(sql: string): { all(): Row[] };
+    close(): void;
+  }
+}


### PR DESCRIPTION
## Summary

Agent token-usage telemetry has read **zero** on every turn since **2026-07-31 (dev)** / **2026-08-01 (prod)**. OpenClaw `2026.7.2-beta.5` moved per-session transcripts out of

```
/home/node/.openclaw/agents/<agentId>/sessions/<sessionId>.jsonl
```

into a per-agent SQLite database

```
agents/<agentId>/agent/openclaw-agent.sqlite
  transcript_events(session_id TEXT, seq INTEGER, event_json TEXT, created_at INTEGER)
```

and **deleted the JSONL files**. `harness_adapter._read_turn_usage()` — the only usage source on the post-#1384 SigV4 path — kept opening the JSONL path, found nothing, and returned honest zeros.

**Nothing failed.** A zero read is indistinguishable from a genuine zero once it lands in `agent_messages`, so `admin/agents` → Cost showed `$0` for **ten days** with no error, no alarm, and no failed turn.

**Caching was never broken.** A checkpointed workspace database shows the healthy steady state throughout: ~2 billable input tokens against a 54k–71k cache read per turn. Only the telemetry regressed.

## Changes

**1. Read the SQLite transcript** (`harness_adapter.py`)
- `_fold_usage_records()` now holds the whole accounting fold, shared by both stores (each supplies record JSON in append order), so the SQLite and JSONL paths cannot drift in windowing, completeness, or token extraction.
- `_sum_sqlite_transcript_usage()`: read-only `file:` URI (`mode=ro`, which also refuses to create a missing file), `session_id` **bound**, `created_at >= since_ms` prefilter, `ORDER BY seq`.
- `_settle_usage()` / `_contained_transcript_path()` extracted; `OperationalError` retries, `DatabaseError` (corrupt) breaks out immediately.
- Booleans no longer count as tokens (`bool` is an `int` subclass, so a JSON `true` previously added 1).
- JSONL remains a fallback; the database wins when both exist, so an archived JSONL cannot double-bill.

**2. Correct the recorded model id** (`platform-model.ts`)
`AGENT_MODEL_ID` → `us.anthropic.claude-sonnet-5`. #1227 moved the provider onto bedrock-runtime's native endpoint, which echoes the request's inference-profile id verbatim instead of rewriting it to the bare form. New `AGENT_MODEL_ID_ALIASES`; `getPricableModels()` excludes all three forms. This class of drift doesn't fail loudly — rows just stop joining `ai_models` and cost reads $0 (bug #1083).

**3. Make the next one loud** (migration 177 + `UsageCaptureZero`)
The wrapper *already computed* `usage_capture_complete` — but only the eval harness consumed it, so production turns threw the answer away. Now persisted on `agent_messages`, **nullable on purpose**: `true` = measured, `false` = the token columns are a floor not a total, `null` = unknown (row or image predates the column). A `DEFAULT TRUE` would assert ten days of zeros were measured; `DEFAULT FALSE` would brand all history suspect.

New `UsageCaptureZero` metric + `psd-agent-usage-capture-zero-<env>` alarm fires on the arithmetically impossible case: a **successful** turn that made ≥1 model call yet reports zero across all four counters.

**4. Backfill the history** (`scripts/db/backfill-agent-message-usage.ts`)
Dry-run-first, idempotent. **No write has been executed.**

## Verification

Re-run in full after the review fixes below:

| Gate | Result |
|---|---|
| `python3 -m unittest` (agent-image) | ✅ 171 tests OK (pytest is not installed locally; unittest counts cases rather than expanded subtests) |
| `bun run lint` (`--max-warnings 0`) | ✅ clean |
| `bun run typecheck` (full codebase) | ✅ clean |
| `bun run test:ci` (full suite) | ✅ 5,480 passed / 577 suites, 15 skipped. Two suites (`atrium-bulk-run`, `gemini-live-provider`) died on a jest **worker SIGSEGV** under parallel load; both pass in isolation (32/32), so this is a runner crash, not a failure |
| Full authenticated E2E suite (pre-push gate) | ✅ 319 passed, 41 skipped, 0 failed |
| `tests/e2e/admin-agents.spec.ts` | ✅ 11/11 passed authenticated — the admin suite **ran** rather than auto-skipping |
| `cdk synth --all` Dev + Prod | ✅ exit 0; `psd-agent-usage-capture-zero-dev` present in the Dev template |
| `infra` `tsc --noEmit` | ✅ clean |
| Migration 177 registered | ✅ `177-agent-usage-capture-complete.sql` in `migrationFiles` |
| Backfill migration guard (live, vs dev) | ✅ aborts: "migration 177 has not been applied … nothing was read or written" |
| Backfill argument guards (live) | ✅ bad `--since`, unknown flag, and `--execute` without the token each abort before any connection |

Note on infra jest: CI does not run it (the CDK job runs `tsc` + `cdk synth`), and it does not resolve ts-jest from this worktree. `tsc` and `synth` both pass, which is the gate CI actually applies.

### Verified against reality, not assumed

I pulled a real checkpointed `openclaw-agent.sqlite` from `psd-agents-dev-390844780692` and the dev database, rather than trusting the handoff:

- **Schema** confirmed exactly; `event_json` holds the same record objects the JSONL did, verbatim (`message.usage.{input,output,cacheRead,cacheWrite}`, `stopReason ∈ {toolUse, stop, error}`).
- **`created_at >= message.timestamp` always** — 488 records, **0 inversions**, skew 0–19,941 ms. That makes `created_at >= since_ms` a safe *superset* prefilter; the authoritative window test stays on the record timestamp.
- **`created_at` is NOT monotonic with `seq`** — **28 of 32 sessions** contain a row whose `created_at` precedes that of a lower `seq`. Completeness is decided by the *last* record, so `ORDER BY created_at` would misread it. This is why the scan orders by `seq`.
- **The JSONL→SQLite import preserved `created_at`** — the same database holds events from 2026-07-27 (before its 2026-07-30 import) and no row has a skew above 60 s. So migrated rows don't mis-window a turn.
- **Recorded model id** — every `agent_messages` row on/after 2026-07-31 carries `us.anthropic.claude-sonnet-5` (58 rows); the bare form appears only through 2026-07-29 (630 rows). All three aliases are priced and inactive.

### Backfill dry run — earlier numbers WITHDRAWN

An earlier revision of this PR quoted a dev dry run (57 rows to update, ~10.2M recovered `cacheRead`). **Those numbers are withdrawn.** They were produced under the row-timestamp attribution model that review then disproved (see below), so the per-row split cannot be trusted even where the aggregate looked plausible.

It cannot be re-run yet: `usage_capture_complete` does not exist on dev (confirmed by querying `information_schema`), and the script correctly refuses to read anything without it. **A fresh dry run is a post-deploy step, and its report must be read before anyone passes `--execute`.**

### Turn attribution — the row-timestamp model was WRONG

`agent_messages.session_id` is a PSD *sessionKey* (`agent-chat-<sha256>`), **not** the transcript UUID; the mapping (`session_windows.session_key = "agent:main:" + session_id`) was verified against the real database, and up to **8 turns share one sessionKey** with an append-only transcript across all of them.

The original fix reconstructed each turn as `( created_at[k-1], created_at[k] ]`. That is unsound. The router releases the session lock in the `finally` of its invocation wrapper but does not insert the telemetry row until **after** the Google Chat response is sent, so the next turn can begin and append transcript records *before* the previous turn's row is stamped. The windows overlap and model calls get billed to the wrong row — confidently wrong cost, which is worse than none.

Replaced with segmentation over the transcript's own turn structure, rows supplying only order and count:

1. Walk a session's records in append order, cutting a segment after each terminal `stopReason` (`stop` / `end_turn`). OpenClaw writes `toolUse` on every hand-off to a tool, so a terminal reason is exactly the end-of-turn marker.
2. Drop a trailing segment with no terminal reason — an in-flight or aborted turn, which has no row yet.
3. Pair segment *k* with row *k*, rows ordered by `created_at`.
4. **If the counts disagree, attribute nothing for that session and report it** (`turnCountMismatches`). A mismatch means the session model is wrong, and guessing would silently misprice turns.

Step 4 is also what contains the two remaining corruption routes, converting both into a *reported gap* rather than a bad number: a duplicate `agent_messages` row (the router's INSERT has no idempotency key, unlike its `agent_sessions` upsert), and a terminal record carrying no `usage` object (dropped at parse time, so its segment never gets cut).

Two consequences that changed call sites:

- Pairing needs **every** row of a session, populated ones included — a populated row still consumes a segment. The SELECT no longer filters to zero rows; `planSessionBackfill` alone decides what is writable, and a populated row is left strictly alone.
- `--since` now filters the resulting **updates**, never the query. Removing a session's earlier rows would delete the anchors that establish its turn order.

**Two bugs only a real run could find**, both fixed:
- `immutable=1` is **required** to open a checkpointed transcript — it's WAL-mode but arrives without its `-wal`/`-shm`, and a plain read-only open must build the `-shm`, which read-only forbids. Safe there (static snapshot, no writer) and deliberately **not** used by the live adapter.
- The `-wal` sidecar is intentionally never fetched: pairing a current `.sqlite` with a stale uploaded `-wal` can surface a torn state. Reading the main file alone under-counts rather than corrupting.

**One bug found in self-review:** the JSONL fallback was keyed on the database *file* existing rather than the `transcript_events` *table* existing. Those differ on every host older than 2026.7.2-beta.5 — which would have reintroduced the identical silent-zero bug for older/candidate images. Fixed with `TranscriptTableMissing` + a `sqlite_master` probe, because a missing table and a locked table both surface as `OperationalError` yet need opposite remedies.

## Review response — two more real defects in the adapter

Beyond the attribution rewrite above, review found two defects in the live read. Both are fixed with regression tests.

**1. Completeness was decided by the wrong record.** `_fold_usage_records` documented that completeness comes from the newest in-window assistant record with a terminal `stopReason`, but the code took it from the newest record carrying a **usage dict** — records without usage hit a `continue` placed *before* `stopReason` was read. So a turn whose terminal record has no usage object had its verdict set by the preceding `toolUse` call and reported incomplete despite having finished.

That is not cosmetic: it burns the full settle-retry budget on an already-finished turn, and writes `FALSE` into `usage_capture_complete`, which per migration 177 means "these token columns are a floor, not a total" — **manufacturing the exact broken-capture signature the new alarm exists to catch**, on turns that captured correctly.

Completeness is now decided independently of usage. Any in-window assistant record carrying a `stopReason` updates the verdict; a record with **no** `stopReason` leaves it untouched rather than clearing it, so a trailing non-model-call record cannot un-finish a finished turn either. The in-window test moved ahead of the usage test so an out-of-window record can never reach the verdict and report a previous turn's ending as this turn's. Token accumulation still requires a usage dict, so a usage-less record adds no tokens and is not counted as a model call.

**2. The success-path read sat outside every exception boundary.** `_read_turn_usage` promises zeros on any failure ("telemetry must never break a chat turn") but only handled `sqlite3.OperationalError` and `sqlite3.DatabaseError`. Its success-path call site runs *after* the WebSocket `try/except` has closed, and neither `process()` nor the wrapper's executor await wraps it — so any other exception would propagate and **discard a reply the model had already produced**. That turn's tool calls have run, so a retry at a higher layer would re-run their side effects, exactly what `_should_retry_upstream` is written to avoid.

Fixed on the callee, not the call site, so the guarantee is intrinsic and cannot be reintroduced by moving a call: the body is now `_read_turn_usage_unguarded` and `_read_turn_usage` is a thin wrapper catching `Exception`. Both call sites inherit it.

Also closed a facade gap this PR introduced: `mkdtemp`/`mkdtempSync` were in neither method set in `validated-fs.ts`, so `validatedFs` passed them through **unvalidated**. The backfill's temp-dir call is safe only because its prefix is hardcoded; both are now in `WRITE_METHODS`.

### Bot-review findings, both addressed

- **Stale `OperationalError` comment (CONFIRMED).** It claimed the branch also covers a host whose schema predates `transcript_events`; that case is raised as `TranscriptTableMissing` by the `sqlite_master` probe. Comment corrected, and it now states *why* the split exists.
- **`complete` not seeded before the settle loop (PLAUSIBLE).** Verified not live: the corrupt-database branch `break`s before `complete` is read, and the post-loop return uses a literal `False`. Seeded it anyway — one line to make the fast-break path self-contained rather than correct-by-coincidence, since a future edit returning the variable would fail on the hardest path to reach in testing.
- **Accepted, not fixed:** the reviewer notes `applyUpdate()`'s zero-guard has no automated regression test. Fair. It is an unexported function in an ops script gated behind `--execute` plus a confirmation token, and the guard is enforced by the database in the `WHERE` clause rather than by the plan; making it testable would mean restructuring the script, which I left out of this PR.

### Two findings deliberately not acted on

- **Router INSERT idempotency.** `insertTelemetrySummary` is a plain INSERT with no idempotency key, so a Lambda retry can double-write a turn. Real, but **pre-existing** and outside this PR; adding a uniqueness guard is new blocking behaviour I won't add unasked. The backfill's count-mismatch refusal (step 4) already converts a duplicate row from "silently mispriced turn" into "reported gap". Say the word and I'll do it as a follow-up.
- **Cold-boot alarm false positives.** Review suggested a fresh container's first turn could fail the read-only open before the WAL `-shm` exists, tripping the alarm on every scale-out. Ordering refutes it: this read happens strictly *after* the runtime appended this turn's transcript records, which requires the writer to have opened the database, so `-shm` necessarily exists by then. If it somehow failed, the settle loop retries and degrades. No change made.

### Known pre-existing limitation (verified, not fixed here — your call)

The realpath containment catches a symlinked transcript **file**, but not a symlinked containing **directory**. I confirmed empirically: if `agents/main/agent/` is itself a symlink pointing outside the workspace, the read follows it (a planted database returned its 31,337 tokens).

This is unchanged behaviour — the old JSONL path had the identical property for `agents/<id>/sessions/`, and the existing comment scopes the check to symlinked transcripts, with the dot-name component check being what stops traversal. Impact is telemetry **integrity**, not confidentiality: the sandboxed `node` agent already owns that tree, and the only thing it could achieve is having another database's token counts billed to its own turns. Nothing is exfiltrated — only aggregate numbers reach `agent_messages`.

I did not add a guard for it, since that would be new blocking behaviour outside this PR's scope. Happy to do it as a follow-up if you want it closed.

## Evidence

Agent Platform Dashboard → Cost tab, captured by the authenticated E2E run. Note the local fixture has no agent messages, so the figures are `$0.00` — this shows the tab renders correctly and the "Compare to" list no longer offers the harness model against itself. The **numeric** evidence is the dry run above.

![admin-agents-cache-cost](https://github.com/psd401/aistudio/blob/dfa89a4794f6c44a6564fb798bbca0de06a6be92/.verification/admin-agents-cache-cost-chromium.png?raw=true)

![admin-agents-iteration-telemetry](https://github.com/psd401/aistudio/blob/dfa89a4794f6c44a6564fb798bbca0de06a6be92/.verification/admin-agents-iteration-telemetry-chromium.png?raw=true)

## Deploy notes

1. **`agentImageDigest` OVERRIDES `agentImageTag`.** A stale digest silently deploys the wrong image — this caused a prod outage on 2026-08-10. The fix here lives in the agent image, so it does nothing until a rebuilt image is actually deployed. Rebuild via `infra/agent-image/build-and-push.sh` and confirm the digest is updated.
2. **Migration ordering is already enforced.** The router INSERT now names `usage_capture_complete` (migration 177), and `devAgentPlatformStack.addDependency(devDbStack)` puts the migration before the router. A deliberately partial router-only deploy would break inserts — don't partial-deploy.
3. **The alarm needs `--context alertEmail=<address>`.** Without it the topic isn't created and this alarm — like all 15 existing agent-platform alarms — evaluates correctly and notifies nobody. The stack emits a synth warning for that case.
4. **The backfill has not been run.** Dry-run only; it needs an explicit per-run OK, and migration 177 must be applied first (the script fails fast if not).

## Prod confirmed broken the same way (queried this session)

Read via the RDS Data API against `aistudio-prod-cluster`, daily totals on `agent_messages`:

| Day | Model | Msgs | input | output | cache_read | cache_write |
|---|---|---|---|---|---|---|
| 2026-08-10 | `us.anthropic.claude-sonnet-5` | 181 | 0 | 0 | 0 | 0 |
| 2026-08-05 | `us.anthropic.claude-sonnet-5` | 638 | 0 | 0 | 0 | 0 |
| 2026-08-01 | `us.anthropic.claude-sonnet-5` | 17 | 0 | 0 | 0 | 0 |
| 2026-07-31 | `claude-sonnet-5` | 39 | 280 | 71,043 | 9,681,047 | 1,147,776 |
| 2026-07-30 | `claude-sonnet-5` | 44 | 810 | 123,031 | 29,351,220 | 2,059,875 |
| 2026-07-29 | `claude-sonnet-5` | 89 | 222 | 37,079 | 9,319,427 | 928,548 |
| 2026-07-28 and earlier | `claude-sonnet-5` | — | 0 | 0 | 0 | 0 |

This pins the whole story: prod went dark **2026-08-01**, exactly when the recorded model id flipped to the inference-profile form, and healthy cache telemetry (29.3M `cache_read` against 810 billable input on 7/30) is what the dashboard *should* be showing. Schema note for anyone re-running this: the columns are `model`, `cache_read_input_tokens`, `cache_write_input_tokens` — not `model_id`/`cache_read_tokens`.

## Still to confirm post-deploy

- A real agent turn writes non-zero `input/output/cache_read` to `agent_messages`, and the Cost tab renders it.
- **Re-run the backfill dry run** (dev, then prod) and read its report — including `turnCountMismatches` — before anyone passes `--execute`. The withdrawn numbers above must not be used as the expectation.
- Prod rows for 2026-07-21→28 are all-zero under the old model id, so usage capture appears to have only started working ~2026-07-29; those are likely unrecoverable, and the dry run will say so per row rather than guess.
- 3 prod rows on 2026-08-10 carry model `'unknown'`.

