### PR TITLE
fix(scripts): name the session behind a backfill turn-count mismatch

### DIFF
--- a/scripts/db/backfill-agent-message-usage.ts
+++ b/scripts/db/backfill-agent-message-usage.ts
@@ -53,11 +53,13 @@ import {
 import { validatedFs } from "../../lib/filesystem/validated-fs";
 import {
   BACKFILL_CONFIRMATION,
+  isBackfillCandidate,
   mergePlans,
   parseBackfillArguments,
   parseTranscriptRecord,
   planSessionBackfill,
   restrictPlanToRowsSince,
+  segmentTurns,
   sessionIdFromTranscriptKey,
   type BackfillArguments,
   type BackfillPlan,
@@ -403,12 +405,23 @@ async function planWorkspace(
       // --since is applied AFTER pairing, never before: it selects which rows
       // may be written, and must not remove the rows that establish the
       // session's turn ordering.
-      plans.push(
-        restrictPlanToRowsSince(
-          planSessionBackfill(rows, transcript.records),
-          sinceMs
-        )
+      const plan = restrictPlanToRowsSince(
+        planSessionBackfill(rows, transcript.records),
+        sinceMs
       );
+      if (plan.turnCountMismatches > 0) {
+        // Name the session and both counts. The summary warning tells the
+        // operator to investigate before executing, which is not actionable
+        // without knowing WHICH session disagreed and by how much.
+        log.warn("Turn-count mismatch — nothing attributed for this session", {
+          session: transcript.sessionId,
+          completedTurnsInTranscript: segmentTurns(transcript.records).length,
+          agentMessagesRows: rows.length,
+          zeroRows: rows.filter(isBackfillCandidate).length,
+          transcriptRecords: transcript.records.length,
+        });
+      }
+      plans.push(plan);
     }
     return { plans, hadTranscript: true };
   } finally {


### PR DESCRIPTION
## Summary

The backfill's summary warning tells the operator to "investigate before executing" a turn-count mismatch, but reports only a **count**. There is nothing to investigate with — diagnosing the single dev mismatch required patching this script locally, which is exactly the friction this log line should have removed.

Now logs the session id plus both counts and the candidate breakdown:

```
Turn-count mismatch — nothing attributed for this session
  session=hagelk-db0f32b5-…-6f537f8e2258-4bb4ddfe
  completedTurnsInTranscript=3  agentMessagesRows=4
  zeroRows=1  transcriptRecords=6
```

That output alone settled the dev case: 3 of the 4 rows already held real pre-outage usage, and the single zero row was **already** classified unrecoverable because its transcript records aren't in the checkpoint. Skipping the session cost nothing.

## Scope

Diagnostic only. No change to attribution, planning, or the write path — `planSessionBackfill` and `applyUpdate` are untouched.

## Verification

- `bun run typecheck` clean (full codebase)
- `eslint scripts/db/backfill-agent-message-usage.ts --max-warnings 0` clean
- Exercised live against dev: produced the output above, and the dev backfill then applied **57 rows, 0 skipped** by the zero-guard, with a follow-up dry run reporting **0 rows to update** (idempotency confirmed)

## Context

This landed while executing the dev backfill from #1631. Low stakes — close it if you'd rather not carry the extra log line.