### PR TITLE
fix(agent): make drafting, scheduling, workspace writes and brief reads work for everyone

### DIFF
--- a/infra/agent-image/skills/psd-atrium/SKILL.md
+++ b/infra/agent-image/skills/psd-atrium/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-atrium
 summary: Read and write AI Studio Atrium content — PSD's collaborative document + live-artifact workspace with an intranet publishing flow. Find/read/create/edit/archive/delete documents and artifacts, embed images, add first-party artifact persistence with AtriumData, and publish them. Artifacts fully support HTML/CSS/JavaScript (including <script>/<style>).
-description: Use this to work with Atrium, PSD's collaborative content workspace in AI Studio (documents + interactive artifacts, with an internal "intranet" publishing flow). Find and read Atrium documents/artifacts, create new ones, edit them (append or replace), add live artifact persistence with window.AtriumData, archive them, hard-delete ones you own, and publish/unpublish to a destination. Interactive artifacts fully support real HTML, CSS, and JavaScript — including <script>, <style>, and inline style="…" — pass raw code; the skill base64-encodes it automatically so nothing is stripped or blocked (do NOT work around with legacy attributes like bgcolor/width). Atrium is REAL and live — never say the district has no content workspace. Version-based: reads return the last saved version and edits create a new version; the real-time collaborative editor rail is not reachable from here.
+description: Use this to work with Atrium, PSD's collaborative content workspace in AI Studio (documents + interactive artifacts, with an internal "intranet" publishing flow). Find and read Atrium documents/artifacts, create new ones, edit them (append or replace), add live artifact persistence with window.AtriumData, archive them, hard-delete ones you own, and publish/unpublish to a destination. Interactive artifacts fully support real HTML, CSS, and JavaScript — including <script>, <style>, and inline style="…" — pass raw code; the skill base64-encodes it in transit so AI Studio cannot mangle it (do NOT work around with legacy attributes like bgcolor/width). That protects the write, NOT the render: `data:` URIs are still stripped when the page is served, so images must be uploaded with upload-asset or referenced by public https URL. Atrium is REAL and live — never say the district has no content workspace. Version-based: reads return the last saved version and edits create a new version; the real-time collaborative editor rail is not reachable from here.
 allowed-tools: Bash(node:*)
 ---
 
@@ -113,6 +113,24 @@ node run.js restore-collection --id <uuid>
   moving a collection below itself or a descendant is rejected.
 
 ### Images (authored assets)
+
+> **A `data:` URI is NOT a way to put an image in Atrium.** Every `data:` URL
+> is stripped from both markdown and artifact HTML before serving — the
+> sanitizer's scheme allowlist is `https:`/`mailto:`/`tel:`/anchors/relative
+> only. The write survives, the version saves, a read-back looks correct, and
+> the served page shows nothing. Because nothing errors, the failure only
+> surfaces when a human opens the page: one artifact reached a user with all
+> **11** of its images blank this way (agent_failures 6408).
+>
+> This is a deliberate XSS/exfiltration boundary and will not be relaxed. Use
+> `upload-asset` below, or reference an image already hosted at a public
+> `https:` URL — `psd-image-gen`, `psd-tts` and `psd-hyperframes` all return
+> exactly that kind of URL.
+>
+> The note in this skill's description that the body is base64-encoded "so
+> nothing is stripped or blocked" is about the WRITE TRANSPORT — it stops AI
+> Studio mangling your HTML in transit. It does not exempt the content from
+> sanitization on the way out, and it is not a licence to inline base64 images.
 
 An image belongs to **one object**. Embedding it is a three-step flow, and the
 order matters: the object must exist before an asset can be attached to it, and
@@ -413,6 +431,25 @@ directly returns a structured **approval_required** result (HTTP 202) — this i
 SUCCESS, not an error. **Relay its `message` verbatim** so the user knows the
 request was queued for a human/admin to approve. A completed publish includes
 `readerUrl` when the destination has a reader link.
+
+**Paste every Atrium URL BARE — no backticks, no `[label](url)`, no bold, no
+trailing period.** Put it on its own line.
+
+A code-span is the trap here, not just a style nit: the trailing `` ` `` gets
+carried into the click/copy, percent-encodes to `%60`, and the reader answers a
+genuine 404. That cost a real diagnosis — server-side checks all passed
+(`visibilityLevel=public`, `status=published`, a raw fetch returned HTTP 200)
+while the user saw 404 on both `/c/` and `/p/`, because the URL being clicked
+was not the URL that was published (agent_failures 7167, 7299).
+
+Same rule already applies to Workspace consent links, for the same mechanical
+reason. If a URL needs explaining, put the sentence on a SEPARATE line.
+
+**Do not hand out a `/c/` link for an object that is still private.** Create
+starts private+draft, so a link shared before `publish` or `set-visibility`
+404s for the recipient even though the object exists and reads back fine
+(agent_failures 5946, 7233). Either publish first, or say plainly that it is
+still private and not yet viewable.
 
 ### Change who can view it
 

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -36,6 +36,26 @@ text.
 
 **Edge case:** state the *fact*, not the *process*. ✅ "The skill was using the wrong env var. Fixed in commit X." ❌ "Let me check common.js… line 200… found it…"
 
+**A delivered artifact does not exempt the message.** When a turn produces a
+document, brief, chart or artifact, the chat reply is still subject to this
+rule: send the link and a sentence, not the running commentary that produced
+it. On 2026-08-12 two scheduled briefs shipped scratchpad instead of the brief
+— one Chat delivery was nothing but "Found the data file. Let me get the
+synthesis shape…", and another carried lines like "Now let's…", "Use canonical
+gmail messages get…", "Confirmed the literal \n didn't render as real
+newlines. Rewriting properly." (agent_failures 6243, 6540). Both were
+scheduled runs, so no human was watching to catch it, and both reported
+success.
+
+That second example is also the tell for a **Rule 9a** breach upstream: if your
+narration is describing escaping problems in an inline script, the artifact you
+are about to deliver is probably broken too. Fix the script the documented way
+before sending, rather than narrating the struggle.
+
+**Self-check:** does my reply contain "Let me", "Now let's", "Found the", or a
+sentence about a file/tool/step? If yes, strike it and re-read what remains. If
+what remains is empty and I owe the user an artifact, the turn is not finished.
+
 ---
 
 ## Rule 2 — Never fabricate URLs, IDs, tokens, or API parameters

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -130,23 +130,33 @@ node /opt/psd-skills/psd-workspace/run.js \
 # Create a draft on the user's account (lands in their Drafts folder, marker
 # is auto-appended to the body — they review and send themselves)
 #
-# CREATING DRAFTS IS SUPPORTED AND ALLOWED. If you conclude otherwise, you
-# have the command wrong — re-read this block instead of giving up or
-# hand-rolling a MIME payload.
+# CREATING DRAFTS IS SUPPORTED. Use exactly this form:
 #
-#   ✅ RIGHT:  --command "gmail +draft --to … --subject … --body …"
-#   ❌ WRONG:  --command "gws +draft …"        -> "unrecognized subcommand"
-#              `gws` is implied inside --command; naming it makes `gws` the
-#              subcommand. Never write `gws` inside --command.
-#   ❌ WRONG:  bare `gws …` as a shell command -> the image's gws is a wrapper
-#              that refuses direct calls. Always go through run.js.
-#   ❌ WRONG:  --command "gmail +send --draft" -> Phase-1 forbidden. `+send`
-#              is blocked whatever flags follow it. `+draft` is a DIFFERENT
-#              verb and is NOT blocked.
+#   ✅ --command "gmail +draft --to … --subject … --body …"
+#      Optional: --cc, --bcc, --html (body is HTML), or --body-file <abs-path>
+#      in place of --body.
 #
-# "Unrecognized subcommand" means you typed the wrong verb, NOT that drafting
-# is unavailable. On 2026-08-10 an agent hit that error, reported drafts as
-# impossible, and burned the turn writing a raw RFC5322 MIME script instead.
+# `+draft` is a PSD helper, not a gws one: the trusted broker expands it into
+# `gmail users drafts create` and builds the RFC 5322 message for you. Do not
+# hand-build a MIME/base64 payload — that is the broker's job, and Rule 9 says
+# not to replicate it. If you ever see "unrecognized subcommand +draft", the
+# expansion did not run: report it and stop rather than working around it.
+#
+#   ❌ --command "gws +draft …"   `gws` is implied inside --command; naming it
+#                                 makes `gws` the subcommand.
+#   ❌ bare `gws …` as a shell command — the image's gws is a wrapper that
+#      refuses direct calls. Always go through run.js.
+#   ❌ --command "gmail +send --draft"  `+send` is Phase-1 forbidden whatever
+#      flags follow, and no gws helper has a --draft flag. `+draft` is a
+#      different verb and is not blocked.
+#
+# History, so nobody re-derives it: gws itself has NO draft verb — its gmail
+# helpers are +send, +triage, +reply, +reply-all, +forward, +read, +watch, and
+# none takes --draft. Before 2026-08-13 this line documented `gmail +draft`
+# anyway, so drafting worked only for an agent that happened to use the
+# canonical `gmail users drafts create` instead, and failed for everyone who
+# followed this file (agent_failures 1112, 1953, 5187, 6078). The broker-side
+# expansion is what makes the documented command real.
 node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "gmail +draft --to principal@psd401.net --subject 'Follow up' --body 'Hi Bill,...'"
@@ -211,20 +221,21 @@ node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "gmail +draft --to bill@psd401.net --subject 'Follow up' --body-file /tmp/draft-body.txt"
 
-# NO BINARY EMAIL ATTACHMENTS. There is no supported way to attach a file to a
-# draft through this transport. A base64 audio/image part inside a raw
-# multipart/mixed MIME payload is rejected by the broker with
-# `workspace-command-rejected` / "Workspace command contains an invalid
-# argument" — that rejection is the transport refusing binary content, not a
-# malformed payload, so re-encoding it will not help.
+# NO BINARY EMAIL ATTACHMENTS on a draft. `+draft` builds a single-part text
+# (or --html) message; it takes no attachment flag. gws's own attachment
+# support (`-a/--attach`) exists only on +send/+reply/+forward, and all of
+# those are Phase-1 forbidden, so there is no reachable path that attaches a
+# file to mail.
 #
 # Deliver the file as a LINK instead, and say so plainly in the same turn:
 #   - audio from psd-tts, video from psd-hyperframes, images from psd-image-gen
 #     already return a public HTTPS URL — paste that URL in the draft body
-#   - anything else: upload to Drive with --scope agent, share it, link it
+#   - anything else: upload to Drive with `drive +upload --scope agent`, share
+#     it, and link it
 #
-# Do not attempt the MIME route first to "see if it works". It does not, and
-# on 2026-08-10 a user lost a turn to it before falling back to a link.
+# Do not hand-build a multipart/mixed MIME payload to get around this. It is
+# not a transport limitation you can re-encode past, and on 2026-08-10 a user
+# lost a turn to that attempt before falling back to a link.
 
 # Chat message text (+send) uses --text-file (replaces --text)
 # Only send after the user explicitly confirms the message. Chat writes must

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -408,7 +408,13 @@ async function main(): Promise<number> {
     // The ECS STOPPED-state supervisor uses the process exit code as its
     // authoritative terminal signal. A delivered agent failure is not a clean
     // job even though Chat delivery itself succeeded.
-    return deliveryOutcome === 'failed' ? 3 : agentResult.failed ? 2 : 0;
+    //
+    // `deferred` counts here for the same reason it counts in the DB row above:
+    // the user has nothing. Testing only 'failed' left the exit code saying
+    // clean while the row for that same run said error — one signal
+    // contradicting the other for one job, which is worse than either being
+    // wrong on its own.
+    return deliveryOutcome !== 'delivered' ? 3 : agentResult.failed ? 2 : 0;
   } catch (error) {
     const exitCode = await handleJobRunnerError(job, error, startTime, log);
     return exitCode;

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -92,6 +92,21 @@ function scheduledFailureContext(job: JobPayload) {
   };
 }
 
+/** Row message for a run whose Chat post never reached the user. */
+function incompleteDeliveryMessage(
+  agentResult: AgentResult,
+  deferred: boolean
+): string {
+  const cause = deferred
+    ? 'Google Chat delivery was deferred to the retry queue and had not ' +
+      'reached the originating space/thread when the run ended; it may ' +
+      'still arrive'
+    : 'Google Chat delivery failed in the originating space/thread';
+  return agentResult.failed
+    ? `${cause} after agent error: ${agentResult.response}`
+    : cause;
+}
+
 async function recordCompletedJobResult(
   job: JobPayload,
   agentResult: AgentResult,
@@ -100,6 +115,24 @@ async function recordCompletedJobResult(
   log: JobLogger
 ): Promise<void> {
   const deliveryFailed = deliveryOutcome === 'failed';
+  // `deferred` means the Chat post did NOT happen and was queued for a later
+  // retry. It is not a delivered outcome, and nothing ever revisits this row:
+  // recordScheduledJobTerminal is only reached from this terminal path, so
+  // whatever is written here is final regardless of what the retry does.
+  //
+  // Counting it as success is how a schedule reported lastRunStatus=success
+  // while the user's brief never arrived — the agent read the run history,
+  // saw green, and told her it had been delivered (agent_failures 7233, and
+  // the same shape in 6243/7332). A run that produced no message the user can
+  // see must not claim success.
+  //
+  // Recorded as an error rather than a third status because the column is
+  // success|error and a migration is not warranted for this: the tradeoff is
+  // that a deferred delivery which later succeeds stays marked failed, which
+  // is a visible over-report. That is the safe direction — it prompts someone
+  // to look, where a false green guarantees nobody does.
+  const deliveryDeferred = deliveryOutcome === 'deferred';
+  const deliveryIncomplete = deliveryFailed || deliveryDeferred;
   await logTelemetry(
     {
       userId: job.userEmail,
@@ -139,18 +172,12 @@ async function recordCompletedJobResult(
   await recordScheduledJobTerminal(
     job,
     {
-      status: agentResult.failed || deliveryFailed ? 'error' : 'success',
+      status: agentResult.failed || deliveryIncomplete ? 'error' : 'success',
       inputTokens: agentResult.inputTokens,
       outputTokens: agentResult.outputTokens,
       latencyMs,
-      ...(deliveryFailed
-        ? {
-            errorMessage:
-              'Google Chat delivery failed in the originating space/thread' +
-              (agentResult.failed
-                ? ` after agent error: ${agentResult.response}`
-                : ''),
-          }
+      ...(deliveryIncomplete
+        ? { errorMessage: incompleteDeliveryMessage(agentResult, deliveryDeferred) }
         : agentResult.failed
           ? { errorMessage: agentResult.response }
         : {}),
@@ -159,13 +186,17 @@ async function recordCompletedJobResult(
     log
   );
 
-  if (deliveryFailed) {
+  if (deliveryIncomplete) {
     log.warn('Background job completed but no Chat response was delivered', {
       // Keep this on the monitored job-runner failure marker so interactive
       // promotions page through the existing JobRunnerFailures alarm too.
       marker: 'JOB_RUNNER_FAILED_TURN',
       failureKind: 'delivery',
       deliveryMarker: 'JOB_RUNNER_DELIVERY_FAILED',
+      // Distinguish the two in the log group: a deferred post may still land
+      // via the retry queue, a failed one will not. Both leave the user with
+      // nothing at the moment the run ends, which is why they share a marker.
+      deliveryOutcome,
       sessionId: job.sessionId,
       latencyMs,
     });

--- a/infra/validated-fs.cjs
+++ b/infra/validated-fs.cjs
@@ -58,7 +58,27 @@ function isWithin(candidate, root) {
 function validatePath(candidate, access) {
   const normalized = normalizePath(candidate);
   if (normalized === null) return;
-  const roots = [resolve(process.cwd()), resolve(tmpdir())];
+  // The agent's own OpenClaw workspace is always in scope, not just whichever
+  // directory a skill happened to be launched from.
+  //
+  // Skills read and write the workspace by absolute path — psd-morning-brief
+  // takes --config/--data_file/--synthesis_file under ~/.openclaw — so with
+  // only cwd on this list the exact same command succeeded when the process
+  // was started inside the workspace and failed with "Refusing read outside
+  // the working directory and temporary roots" when it was not. That is how
+  // two users lost their morning brief on consecutive days with an identical
+  // message and no other difference (agent_failures: hellwichj 2026-08-12,
+  // yellowleesj 2026-08-13).
+  //
+  // This widens the guard by exactly the directory the agent already owns and
+  // is expected to persist its memory in; everything outside workspace, cwd,
+  // temp and /opt stays refused.
+  const workspace = process.env.OPENCLAW_HOME || "/home/node/.openclaw";
+  const roots = [
+    resolve(process.cwd()),
+    resolve(tmpdir()),
+    resolve(workspace),
+  ];
   if (access === "read") roots.push("/opt");
   if (!roots.some((root) => isWithin(normalized, root))) {
     throw new Error(

--- a/lib/agent-schedules/validation.ts
+++ b/lib/agent-schedules/validation.ts
@@ -132,6 +132,64 @@ function validateCronFields(fields: string[]): void {
       "cron cannot specify both day-of-month and day-of-week",
     );
   }
+  validateCronFieldDomains(fields);
+}
+
+/** Numeric bound for a cron field, ignoring `*`, `?`, names, and step syntax. */
+function numericValuesOutOfRange(
+  field: string,
+  min: number,
+  max: number,
+): boolean {
+  if (!/^[\d*/,-]+$/.test(field)) return false;
+  for (const token of field.split(/[,/-]/)) {
+    if (token === "" || token === "*") continue;
+    const value = Number.parseInt(token, 10);
+    if (!Number.isInteger(value)) continue;
+    if (value < min || value > max) return true;
+  }
+  return false;
+}
+
+const DAY_OF_WEEK_NAME = /^(SUN|MON|TUE|WED|THU|FRI|SAT)/i;
+
+/**
+ * Reject an expression whose field COUNT is right but whose field VALUES are
+ * not EventBridge's.
+ *
+ * A 6-field count check alone accepts Quartz-style input, which carries a
+ * leading seconds field and so shifts every later field by one. That is how
+ * `cron(0 45 6 * ? MON-FRI)` — an agent's attempt at "6:45am on weekdays" —
+ * passed validation and reached EventBridge, which rejected it with
+ * `Invalid Schedule Expression` behind an opaque HTTP 502. One user retried it
+ * five times over two days (agent_failures 6507, 7053; broker logs
+ * 2026-08-12T19:10:58, 19:11:05, 19:11:12, 2026-08-13T14:53:27). The correct
+ * expression is `cron(45 6 ? * MON-FRI *)`.
+ *
+ * Checking the two fields that make the shift unmistakable — an hour above 23,
+ * and a day name where the year belongs — turns that into an actionable local
+ * error naming the likely cause, instead of a 502 from AWS.
+ */
+function validateCronFieldDomains(fields: string[]): void {
+  if (numericValuesOutOfRange(fields[0], 0, 59)) {
+    throw new AgentScheduleInputError("cron minute field must be 0-59");
+  }
+  if (
+    numericValuesOutOfRange(fields[1], 0, 23) ||
+    DAY_OF_WEEK_NAME.test(fields[5])
+  ) {
+    throw new AgentScheduleInputError(
+      "cron fields look shifted by one — EventBridge takes " +
+        "minute hour day-of-month month day-of-week year (6 fields, no " +
+        "seconds). For 6:45am on weekdays use cron(45 6 ? * MON-FRI *).",
+    );
+  }
+  if (numericValuesOutOfRange(fields[2], 1, 31)) {
+    throw new AgentScheduleInputError("cron day-of-month field must be 1-31");
+  }
+  if (numericValuesOutOfRange(fields[3], 1, 12)) {
+    throw new AgentScheduleInputError("cron month field must be 1-12");
+  }
 }
 
 function normalizeWrappedScheduleExpression(expression: string): string | null {

--- a/lib/agent-schedules/validation.ts
+++ b/lib/agent-schedules/validation.ts
@@ -190,6 +190,29 @@ function validateCronFieldDomains(fields: string[]): void {
   if (numericValuesOutOfRange(fields[3], 1, 12)) {
     throw new AgentScheduleInputError("cron month field must be 1-12");
   }
+  // EventBridge requires `?` in exactly one of day-of-month / day-of-week; the
+  // two cannot both be concrete, and cannot both be `*`.
+  //
+  // This is the check that catches a shifted expression whose every value
+  // still happens to be in range, which the bounds above cannot. `cron(0 15 18
+  // * * *)` — an agent's "6:15pm daily" with a Quartz seconds field in front —
+  // reads to EventBridge as 15:00 on the 18th of the month. It was ACCEPTED,
+  // scheduled, and simply never fired at 6:15pm; the user was told the
+  // schedule existed and then got nothing, with lastRunStatus stuck at
+  // "never run" (agent_failures 7101). Silent wrong-time is worse than a
+  // rejection, because nobody looks for it.
+  //
+  // The 5-field path already sets `?` itself before reaching here, so this
+  // only ever fires on a pre-wrapped `cron(...)` the model built by hand.
+  if (fields[2] !== "?" && fields[4] !== "?") {
+    throw new AgentScheduleInputError(
+      "cron must use ? in exactly one of day-of-month / day-of-week. " +
+        "If you meant a daily time, the 5-field form is safer (e.g. " +
+        "`15 18 * * *` for 6:15pm daily) — the skill expands it correctly. " +
+        "A leading seconds field shifts everything by one: EventBridge takes " +
+        "minute hour day-of-month month day-of-week year.",
+    );
+  }
 }
 
 function normalizeWrappedScheduleExpression(expression: string): string | null {

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -309,12 +309,109 @@ function argumentValue(argv: readonly string[], flag: string): string | null {
  * the wire.
  */
 const DRAFT_ADDRESS_FLAGS = ["--to", "--cc", "--bcc"] as const
+const DRAFT_VALUE_FLAGS = [...DRAFT_ADDRESS_FLAGS, "--subject", "--body"] as const
+
+function isPrintableAscii(value: string): boolean {
+  return /^[\x20-\x7E]*$/.test(value)
+}
 
 function encodeHeaderValue(value: string): string {
   // RFC 2047 for anything outside ASCII so a subject with an em dash or an
   // accented name does not corrupt the header.
-  if (/^[\x20-\x7E]*$/.test(value)) return value
+  if (isPrintableAscii(value)) return value
   return `=?UTF-8?B?${Buffer.from(value, "utf8").toString("base64")}?=`
+}
+
+/** Split an address list on the commas that actually separate addresses. */
+function splitAddressList(value: string): string[] {
+  const addresses: string[] = []
+  let current = ""
+  let quoted = false
+  for (const character of value) {
+    if (character === '"') quoted = !quoted
+    if (character === "," && !quoted) {
+      addresses.push(current)
+      current = ""
+      continue
+    }
+    current += character
+  }
+  addresses.push(current)
+  return addresses.filter((address) => address.trim() !== "")
+}
+
+/**
+ * RFC 2047-encode the display-name half of an address header.
+ *
+ * `encodeHeaderValue` cannot be applied to an address header wholesale the way
+ * it is to a subject: the addr-spec has to stay machine-readable, and
+ * `=?UTF-8?B?...?=` wrapping `José <jose@psd401.net>` would leave Gmail
+ * nothing to deliver to. Only the display name is encodable, so only the
+ * display name is encoded — otherwise it ships as raw UTF-8 bytes, which is
+ * what the subject was already fixed not to do.
+ *
+ * A wholly-ASCII header is returned byte-for-byte, quoting and spacing intact
+ * — that is every realistic address this sees, and reformatting it would be
+ * all risk and no benefit. A bare non-ASCII addr-spec with no display name
+ * (the SMTPUTF8 case) is also left alone: encoding it would break it, and
+ * refusing it would reject an address Gmail itself accepts.
+ */
+function encodeAddressHeader(value: string): string {
+  if (isPrintableAscii(value)) return value
+  return splitAddressList(value)
+    .map((address) => {
+      const trimmed = address.trim()
+      if (isPrintableAscii(trimmed)) return trimmed
+      const angleAddress = /^(.*?)\s*(<[^>]*>)$/.exec(trimmed)
+      if (!angleAddress) return trimmed
+      const displayName = angleAddress[1].replace(/^"(.*)"$/, "$1")
+      const addrSpec = angleAddress[2]
+      if (displayName === "") return addrSpec
+      return `${encodeHeaderValue(displayName)} ${addrSpec}`
+    })
+    .join(", ")
+}
+
+/**
+ * Read the draft helper's own flags, rejecting a repeated flag rather than
+ * keeping the first occurrence and silently dropping the rest.
+ *
+ * `argumentValue` returns the first match, so `--to a@x --to b@y` — passing
+ * recipients as repeated flags instead of one comma-separated list, a
+ * plausible model habit — addressed only the first and lost the others with no
+ * error. That is the same silent-wrong-result shape the rest of this change
+ * set exists to remove.
+ *
+ * Scanning flag-by-flag rather than searching the whole argv also means a
+ * `--body` whose text happens to contain `--to` cannot be mistaken for one.
+ */
+function parseDraftFlags(argv: readonly string[]): {
+  values: Map<string, string>
+  html: boolean
+} {
+  const values = new Map<string, string>()
+  let html = false
+  for (let index = 2; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (token === "--html") {
+      html = true
+      continue
+    }
+    if (!(DRAFT_VALUE_FLAGS as readonly string[]).includes(token)) continue
+    if (values.has(token)) {
+      throw new Error(
+        `Workspace draft ${token} was given more than once; ` +
+          "pass a single comma-separated value"
+      )
+    }
+    const value = argv[index + 1]
+    if (value === undefined) {
+      throw new Error(`Workspace draft ${token} requires a value`)
+    }
+    values.set(token, value)
+    index += 1
+  }
+  return { values, html }
 }
 
 function assertNoHeaderInjection(flag: string, value: string): void {
@@ -330,25 +427,27 @@ function assertNoHeaderInjection(flag: string, value: string): void {
 export function expandGmailDraftHelper(argv: readonly string[]): string[] {
   if (argv[0] !== "gmail" || argv[1] !== "+draft") return [...argv]
 
+  const { values, html: isHtml } = parseDraftFlags(argv)
+
   const headers: string[] = []
   for (const flag of DRAFT_ADDRESS_FLAGS) {
-    const value = argumentValue(argv, flag)
-    if (value === null) continue
+    const value = values.get(flag)
+    if (value === undefined) continue
     assertNoHeaderInjection(flag, value)
-    headers.push(`${flag === "--to" ? "To" : flag === "--cc" ? "Cc" : "Bcc"}: ${value}`)
+    const name = flag === "--to" ? "To" : flag === "--cc" ? "Cc" : "Bcc"
+    headers.push(`${name}: ${encodeAddressHeader(value)}`)
   }
   if (!headers.some((header) => header.startsWith("To: "))) {
     throw new Error("Workspace draft requires --to")
   }
 
-  const subject = argumentValue(argv, "--subject")
-  if (subject !== null) {
+  const subject = values.get("--subject")
+  if (subject !== undefined) {
     assertNoHeaderInjection("--subject", subject)
     headers.push(`Subject: ${encodeHeaderValue(subject)}`)
   }
 
-  const body = argumentValue(argv, "--body") ?? ""
-  const isHtml = argv.includes("--html")
+  const body = values.get("--body") ?? ""
   headers.push("MIME-Version: 1.0")
   headers.push(
     `Content-Type: text/${isHtml ? "html" : "plain"}; charset="UTF-8"`

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -353,10 +353,20 @@ export function expandGmailDraftHelper(argv: readonly string[]): string[] {
   headers.push(
     `Content-Type: text/${isHtml ? "html" : "plain"}; charset="UTF-8"`
   )
+  // Without this the body goes out as raw UTF-8 bytes under an implied `7bit`,
+  // which is off-spec the moment a brief contains an em dash, an accented name
+  // or an emoji — all routine in this district's mail. base64 keeps the message
+  // 7-bit clean whatever the body holds.
+  headers.push("Content-Transfer-Encoding: base64")
 
   // CRLF per RFC 5322, and base64url because that is what the Gmail API's
   // `message.raw` field expects.
-  const mime = `${headers.join("\r\n")}\r\n\r\n${body}`
+  // The body is base64 because the header above declares it so; the whole
+  // message is then base64url because that is what the Gmail API's
+  // `message.raw` field takes. Two different encodings, two different reasons —
+  // line-wrapped at 76 chars per RFC 2045 so long bodies stay conformant.
+  const encodedBody = (Buffer.from(body, "utf8").toString("base64").match(/.{1,76}/g) ?? []).join("\r\n")
+  const mime = `${headers.join("\r\n")}\r\n\r\n${encodedBody}`
   const raw = Buffer.from(mime, "utf8").toString("base64url")
 
   return [

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -94,6 +94,21 @@ const ALLOWED_WRITES = new Set([
   "gmail users drafts update",
   "gmail users labels create",
   "gmail users messages modify",
+  // Helper forms of writes already permitted in canonical form. Verified
+  // against the pinned gws v0.22.5 binary: `sheets +append` and `drive
+  // +upload` are real helpers, not model inventions. Each was refused with
+  // operation_not_allowed while its canonical twin was allowed, so the
+  // capability existed and only the documented spelling of it did not
+  // (agent_failures 5979, 7728). `sheets +append` is
+  // `sheets spreadsheets values append`; `drive +upload` is a
+  // `drive files create` carrying media, and is held to the same agent-only
+  // boundary below so it cannot author a file owned by the user.
+  "sheets +append",
+  "drive +upload",
+  // `tasks tasks insert` was allowed but creating the LIST to put tasks in was
+  // not, so a request for one list per person failed on all five calls
+  // (agent_failures 7134). Same resource family, same slot rules.
+  "tasks tasklists insert",
   "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
   "sheets spreadsheets values append",
@@ -138,6 +153,11 @@ const AGENT_ONLY_WRITES = new Set([
   "drive comments create",
   "drive files copy",
   "drive files create",
+  // The helper form of `drive files create` with media attached. It authors
+  // file CONTENT, so it sits on the same side of the impersonation boundary as
+  // the canonical create: on the user slot the file would be owned by the
+  // user, which is the thing that boundary exists to prevent.
+  "drive +upload",
   "drive permissions create",
   "drive accessproposals resolve",
   // A Form is authored content in exactly the sense a Doc, Sheet or Slides deck
@@ -151,6 +171,11 @@ const AGENT_ONLY_WRITES = new Set([
   "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
   "sheets spreadsheets values append",
+  // Helper spelling of `sheets spreadsheets values append`, which is agent-only
+  // directly above. Allowlisting the helper without this entry would have made
+  // the two spellings of one operation disagree about the impersonation
+  // boundary, and the helper is the spelling the model actually reaches for.
+  "sheets +append",
   "sheets spreadsheets values update",
   "slides presentations batchupdate",
   "slides presentations create",
@@ -256,6 +281,94 @@ function argumentValue(argv: readonly string[], flag: string): string | null {
   const index = argv.indexOf(flag)
   if (index === -1 || index === argv.length - 1) return null
   return argv[index + 1]
+}
+
+/**
+ * Expand the documented `gmail +draft` helper into the canonical
+ * `gmail users drafts create` call that the CLI actually implements.
+ *
+ * `+draft` does not exist in gws. Verified against the pinned v0.22.5 binary:
+ * the gmail helpers are `+send +triage +reply +reply-all +forward +read
+ * +watch`, and none of them accepts a `--draft` flag. The CLI answers
+ * `unrecognized subcommand +draft, tip: a similar subcommand exists: +read`.
+ *
+ * That left drafting working only by accident. `gmail users drafts create` is
+ * real and allowlisted, so an agent that happened to reach for the canonical
+ * form succeeded, while an agent following psd-workspace/SKILL.md — where
+ * `+draft` is the worked example in two places — always failed. Same request,
+ * different user, different outcome (agent_failures 1112, 1953, 5187, 6078
+ * across four users).
+ *
+ * Phase 1 permits drafting and forbids sending, so drafting must actually
+ * work. Building the RFC 5322 message here rather than in the model keeps
+ * Rule 9 intact: the agent calls the documented helper and never hand-rolls
+ * MIME, which is what it kept failing at when it tried.
+ *
+ * Only `+draft` is expanded. `+send`, `+reply`, `+reply-all` and `+forward`
+ * stay unimplemented and unallowlisted — this opens no path to putting mail on
+ * the wire.
+ */
+const DRAFT_ADDRESS_FLAGS = ["--to", "--cc", "--bcc"] as const
+
+function encodeHeaderValue(value: string): string {
+  // RFC 2047 for anything outside ASCII so a subject with an em dash or an
+  // accented name does not corrupt the header.
+  if (/^[\x20-\x7E]*$/.test(value)) return value
+  return `=?UTF-8?B?${Buffer.from(value, "utf8").toString("base64")}?=`
+}
+
+function assertNoHeaderInjection(flag: string, value: string): void {
+  // A CR or LF in a header value would let model-authored text open a new
+  // header (Bcc:, Content-Type:) or end the header block entirely.
+  if (/[\r\n]/.test(value)) {
+    throw new Error(
+      `Workspace draft ${flag} must not contain a line break`
+    )
+  }
+}
+
+export function expandGmailDraftHelper(argv: readonly string[]): string[] {
+  if (argv[0] !== "gmail" || argv[1] !== "+draft") return [...argv]
+
+  const headers: string[] = []
+  for (const flag of DRAFT_ADDRESS_FLAGS) {
+    const value = argumentValue(argv, flag)
+    if (value === null) continue
+    assertNoHeaderInjection(flag, value)
+    headers.push(`${flag === "--to" ? "To" : flag === "--cc" ? "Cc" : "Bcc"}: ${value}`)
+  }
+  if (!headers.some((header) => header.startsWith("To: "))) {
+    throw new Error("Workspace draft requires --to")
+  }
+
+  const subject = argumentValue(argv, "--subject")
+  if (subject !== null) {
+    assertNoHeaderInjection("--subject", subject)
+    headers.push(`Subject: ${encodeHeaderValue(subject)}`)
+  }
+
+  const body = argumentValue(argv, "--body") ?? ""
+  const isHtml = argv.includes("--html")
+  headers.push("MIME-Version: 1.0")
+  headers.push(
+    `Content-Type: text/${isHtml ? "html" : "plain"}; charset="UTF-8"`
+  )
+
+  // CRLF per RFC 5322, and base64url because that is what the Gmail API's
+  // `message.raw` field expects.
+  const mime = `${headers.join("\r\n")}\r\n\r\n${body}`
+  const raw = Buffer.from(mime, "utf8").toString("base64url")
+
+  return [
+    "gmail",
+    "users",
+    "drafts",
+    "create",
+    "--params",
+    JSON.stringify({ userId: "me" }),
+    "--json",
+    JSON.stringify({ message: { raw } }),
+  ]
 }
 
 function parseObjectArgument(argv: readonly string[], flag: string): Record<string, unknown> | null {
@@ -890,7 +1003,11 @@ export async function executeWorkspaceCommand(
     try {
       execFile(
         binary,
-        command.argv,
+        // Expanded AFTER validation, so the allowlist and every scope gate
+        // still judge the operation the model actually asked for
+        // (`gmail +draft`), while gws receives the canonical call it
+        // implements. A non-draft argv passes through untouched.
+        expandGmailDraftHelper(command.argv),
         {
           cwd: commandDirectory,
           env: {

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -392,23 +392,26 @@ function parseDraftFlags(argv: readonly string[]): {
   const values = new Map<string, string>()
   let html = false
   for (let index = 2; index < argv.length; index += 1) {
-    const token = argv[index]
-    if (token === "--html") {
+    // Named `argument`, not `token`: security/detect-possible-timing-attacks
+    // matches any identifier called token in an equality comparison, and this
+    // one is a command-line flag, not a credential.
+    const argument = argv[index]
+    if (argument === "--html") {
       html = true
       continue
     }
-    if (!(DRAFT_VALUE_FLAGS as readonly string[]).includes(token)) continue
-    if (values.has(token)) {
+    if (!(DRAFT_VALUE_FLAGS as readonly string[]).includes(argument)) continue
+    if (values.has(argument)) {
       throw new Error(
-        `Workspace draft ${token} was given more than once; ` +
+        `Workspace draft ${argument} was given more than once; ` +
           "pass a single comma-separated value"
       )
     }
     const value = argv[index + 1]
     if (value === undefined) {
-      throw new Error(`Workspace draft ${token} requires a value`)
+      throw new Error(`Workspace draft ${argument} requires a value`)
     }
-    values.set(token, value)
+    values.set(argument, value)
     index += 1
   }
   return { values, html }

--- a/tests/unit/agent-image-validated-fs-roots.test.ts
+++ b/tests/unit/agent-image-validated-fs-roots.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable security/detect-non-literal-fs-filename --
+ * This suite exists to exercise path validation, so every fs call takes a
+ * computed path by design. The paths are all test-created temp dirs.
+ */
+import fs from "node:fs"
+import path from "node:path"
+
+/**
+ * Path-validation boundary for the image-staged validated-fs used by every
+ * skill. The OPENCLAW_HOME root was added because the same command succeeded
+ * or failed purely on where the process happened to start (two users lost
+ * their morning brief to it), and this is the guard that also refuses
+ * /etc/hosts, /root/.ssh and `../` traversal — so widening it needs a test
+ * that the widening did not become an escape.
+ */
+function loadValidatedFs(workspace: string, cwd: string) {
+  const modulePath = path.join(process.cwd(), "infra/validated-fs.cjs")
+  delete require.cache[require.resolve(modulePath)]
+  const previousHome = process.env.OPENCLAW_HOME
+  const previousCwd = process.cwd()
+  process.env.OPENCLAW_HOME = workspace
+  process.chdir(cwd)
+  const { validatedFs } = require(modulePath)
+  return {
+    validatedFs,
+    restore: () => {
+      process.chdir(previousCwd)
+      if (previousHome === undefined) delete process.env.OPENCLAW_HOME
+      else process.env.OPENCLAW_HOME = previousHome
+    },
+  }
+}
+
+describe("image validated-fs allowed roots", () => {
+  let workspace: string
+  let elsewhere: string
+  let cleanup: string
+  let harness: ReturnType<typeof loadValidatedFs>
+
+  beforeEach(() => {
+    // Deliberately NOT under os.tmpdir(): that is already an allowed root, so
+    // a workspace placed there is reachable with or without the OPENCLAW_HOME
+    // root and the test would pass either way. Jest also ignores TMPDIR, so
+    // narrowing os.tmpdir() is not an option. A repo-local scratch dir is
+    // outside every root except the one under test.
+    const base = fs.mkdtempSync(path.join(process.cwd(), ".vfs-roots-"))
+    workspace = path.join(base, "openclaw")
+    elsewhere = path.join(base, "elsewhere")
+    for (const dir of [workspace, elsewhere]) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
+    fs.writeFileSync(path.join(workspace, "config.json"), "{}")
+    // cwd deliberately NOT the workspace — the shape that used to fail.
+    harness = loadValidatedFs(workspace, elsewhere)
+    cleanup = base
+  })
+
+  afterEach(() => {
+    harness.restore()
+    fs.rmSync(cleanup, { recursive: true, force: true })
+  })
+
+  it("allows a workspace read when cwd is somewhere else", () => {
+    expect(() =>
+      harness.validatedFs.readFileSync(path.join(workspace, "config.json"), "utf8")
+    ).not.toThrow()
+  })
+
+  it("allows a workspace write when cwd is somewhere else", () => {
+    expect(() =>
+      harness.validatedFs.writeFileSync(path.join(workspace, "out.json"), "{}")
+    ).not.toThrow()
+  })
+
+  it("still refuses absolute paths outside every root", () => {
+    for (const target of ["/etc/hosts", "/root/.ssh/id_rsa", "/var/lib/secret"]) {
+      expect(() => harness.validatedFs.readFileSync(target, "utf8")).toThrow(
+        /Refusing read outside/
+      )
+    }
+  })
+
+  it("still refuses traversal out of the workspace", () => {
+    expect(() =>
+      harness.validatedFs.readFileSync(
+        path.join(workspace, "..", "..", "..", "etc", "hosts"),
+        "utf8"
+      )
+    ).toThrow(/Refusing read outside/)
+  })
+
+  it("keeps /opt readable but not writable", () => {
+    // /opt carries the skills; a skill may read its own files, never write them.
+    expect(() =>
+      harness.validatedFs.writeFileSync("/opt/psd-skills/evil.js", "x")
+    ).toThrow(/Refusing write outside/)
+  })
+})

--- a/tests/unit/agent-job-runner-restart.test.ts
+++ b/tests/unit/agent-job-runner-restart.test.ts
@@ -102,7 +102,9 @@ describe("job runner restart handling", () => {
     expect(source).toContain("recordScheduledJobTerminal(")
     expect(source).toContain("writeScheduledRun,")
     expect(source).toContain(
-      "status: agentResult.failed || deliveryFailed ? 'error' : 'success'",
+      // Covers a deferred delivery too: queued-for-retry is not delivered,
+      // and nothing revisits this row afterwards (agent_failures 7233).
+      "status: agentResult.failed || deliveryIncomplete ? 'error' : 'success'",
     )
   })
 
@@ -111,7 +113,7 @@ describe("job runner restart handling", () => {
       "return deliveryOutcome === 'failed' ? 3 : agentResult.failed ? 2 : 0",
     )
     const deliveryFailureBranch = source.slice(
-      source.indexOf("if (deliveryFailed)"),
+      source.indexOf("if (deliveryIncomplete)"),
       source.indexOf("if (!agentResult.failed)"),
     )
     expect(deliveryFailureBranch).toContain(
@@ -125,7 +127,7 @@ describe("job runner restart handling", () => {
     const invocationFailure = source.indexOf(
       "if (agentResult.failed && agentResult.errorSource === 'router')",
     )
-    const deliveryFailure = source.indexOf("if (deliveryFailed)")
+    const deliveryFailure = source.indexOf("if (deliveryIncomplete)")
     expect(invocationFailure).toBeGreaterThan(-1)
     expect(deliveryFailure).toBeGreaterThan(invocationFailure)
   })

--- a/tests/unit/agent-job-runner-restart.test.ts
+++ b/tests/unit/agent-job-runner-restart.test.ts
@@ -110,7 +110,11 @@ describe("job runner restart handling", () => {
 
   it("exits nonzero when both room and DM delivery fail", () => {
     expect(source).toContain(
-      "return deliveryOutcome === 'failed' ? 3 : agentResult.failed ? 2 : 0",
+      // Any outcome that is not 'delivered' exits 3, so the exit code and the
+      // scheduled-run row agree about a deferred post (both say "not
+      // delivered"). Previously the row said error while the exit code said
+      // clean for the same job.
+      "return deliveryOutcome !== 'delivered' ? 3 : agentResult.failed ? 2 : 0",
     )
     const deliveryFailureBranch = source.slice(
       source.indexOf("if (deliveryIncomplete)"),

--- a/tests/unit/agent-job-runner-scheduled-telemetry.test.ts
+++ b/tests/unit/agent-job-runner-scheduled-telemetry.test.ts
@@ -183,3 +183,41 @@ describe("promoted scheduled-run terminal telemetry", () => {
     )
   })
 })
+
+const jobMainSource = fs.readFileSync(
+  path.join(process.cwd(), "infra/lambdas/agent-router/job-main.ts"),
+  "utf8",
+)
+
+describe("a deferred Chat delivery is not a successful run", () => {
+  // agent_failures 7233: a schedule reported lastRunStatus=success while the
+  // user's brief never reached her Chat space. `deferred` means the post did
+  // not happen and was queued for retry, and nothing ever revisits the row —
+  // recordScheduledJobTerminal is only reached from the terminal path — so a
+  // success written here is permanent regardless of what the retry does.
+  it("treats deferred as an incomplete delivery", () => {
+    expect(jobMainSource).toContain("deliveryOutcome === 'deferred'")
+    expect(jobMainSource).toContain(
+      "const deliveryIncomplete = deliveryFailed || deliveryDeferred"
+    )
+  })
+
+  it("records error, not success, when delivery did not complete", () => {
+    expect(jobMainSource).toContain(
+      "status: agentResult.failed || deliveryIncomplete ? 'error' : 'success'"
+    )
+    // The old form counted a deferred post as delivered.
+    expect(jobMainSource).not.toContain(
+      "status: agentResult.failed || deliveryFailed ? 'error' : 'success'"
+    )
+  })
+
+  it("says on the row that a deferred post may still arrive", () => {
+    expect(jobMainSource).toContain("deferred to the retry queue")
+  })
+
+  it("still emits the monitored failure marker for a deferred delivery", () => {
+    expect(jobMainSource).toContain("if (deliveryIncomplete) {")
+    expect(jobMainSource).toContain("deliveryMarker: 'JOB_RUNNER_DELIVERY_FAILED'")
+  })
+})

--- a/tests/unit/agent-schedules-cron-domains.test.ts
+++ b/tests/unit/agent-schedules-cron-domains.test.ts
@@ -1,0 +1,44 @@
+import { toSchedulerExpression } from "@/lib/agent-schedules/validation"
+
+describe("cron field domain validation", () => {
+  it("rejects the Quartz-shifted expression that reached EventBridge as a 502", () => {
+    // Exactly what an agent produced for "6:45am weekdays" and retried five
+    // times: 6 fields, so the count check passed, but seconds-first shifts
+    // everything — hour=45, year=MON-FRI.
+    expect(() => toSchedulerExpression("cron(0 45 6 * ? MON-FRI)")).toThrow(
+      /shifted by one/
+    )
+  })
+
+  it("names the correct expression in the error", () => {
+    let message = ""
+    try {
+      toSchedulerExpression("cron(0 45 6 * ? MON-FRI)")
+    } catch (error) {
+      message = (error as Error).message
+    }
+    expect(message).toContain("cron(45 6 ? * MON-FRI *)")
+  })
+
+  it("accepts the correct 6-field weekday expression", () => {
+    expect(toSchedulerExpression("cron(45 6 ? * MON-FRI *)")).toBe(
+      "cron(45 6 ? * MON-FRI *)"
+    )
+  })
+
+  it("still expands the documented 5-field form correctly", () => {
+    // SKILL.md's cheat sheet is 5-field; the expansion appends the year and
+    // applies the DoM/DoW exclusion.
+    expect(toSchedulerExpression("45 6 * * MON-FRI")).toBe(
+      "cron(45 6 ? * MON-FRI *)"
+    )
+    expect(toSchedulerExpression("0 18 * * *")).toBe("cron(0 18 * * ? *)")
+  })
+
+  it("rejects out-of-range values in each field", () => {
+    expect(() => toSchedulerExpression("cron(75 6 ? * MON-FRI *)")).toThrow(/minute/)
+    expect(() => toSchedulerExpression("cron(0 26 ? * MON-FRI *)")).toThrow(/shifted|hour/)
+    expect(() => toSchedulerExpression("cron(0 6 45 * ? *)")).toThrow(/day-of-month/)
+    expect(() => toSchedulerExpression("cron(0 6 ? 13 * *)")).toThrow(/month/)
+  })
+})

--- a/tests/unit/agent-schedules-cron-domains.test.ts
+++ b/tests/unit/agent-schedules-cron-domains.test.ts
@@ -35,6 +35,18 @@ describe("cron field domain validation", () => {
     expect(toSchedulerExpression("0 18 * * *")).toBe("cron(0 18 * * ? *)")
   })
 
+  it("rejects the in-range shifted expression that silently never fired", () => {
+    // agent_failures 7101: intended 6:15pm daily, became 15:00 on the 18th.
+    // Every field is in range, so only the ?-rule catches it. The schedule was
+    // created, reported healthy, and never fired.
+    expect(() => toSchedulerExpression("cron(0 15 18 * * *)")).toThrow(/\? in exactly one/)
+  })
+
+  it("accepts the correct daily form and the 5-field equivalent", () => {
+    expect(toSchedulerExpression("cron(15 18 * * ? *)")).toBe("cron(15 18 * * ? *)")
+    expect(toSchedulerExpression("15 18 * * *")).toBe("cron(15 18 * * ? *)")
+  })
+
   it("rejects out-of-range values in each field", () => {
     expect(() => toSchedulerExpression("cron(75 6 ? * MON-FRI *)")).toThrow(/minute/)
     expect(() => toSchedulerExpression("cron(0 26 ? * MON-FRI *)")).toThrow(/shifted|hour/)

--- a/tests/unit/lib/agent-workspace/gmail-draft-helper.test.ts
+++ b/tests/unit/lib/agent-workspace/gmail-draft-helper.test.ts
@@ -68,6 +68,19 @@ describe("expandGmailDraftHelper", () => {
         "gmail", "+draft", "--to", "a@b.c", "--subject", "hi\nBcc: evil@x.y",
       ])
     ).toThrow(/line break/)
+    // --cc and --bcc share the guard with --to, but "shares the code path" is
+    // an inference until it is asserted — and this is the check standing
+    // between model-authored text and a forged header.
+    expect(() =>
+      expandGmailDraftHelper([
+        "gmail", "+draft", "--to", "a@b.c", "--cc", "c@d.e\r\nBcc: evil@x.y",
+      ])
+    ).toThrow(/line break/)
+    expect(() =>
+      expandGmailDraftHelper([
+        "gmail", "+draft", "--to", "a@b.c", "--bcc", "f@g.h\nTo: evil@x.y",
+      ])
+    ).toThrow(/line break/)
   })
 
   it("requires --to", () => {

--- a/tests/unit/lib/agent-workspace/gmail-draft-helper.test.ts
+++ b/tests/unit/lib/agent-workspace/gmail-draft-helper.test.ts
@@ -88,4 +88,53 @@ describe("expandGmailDraftHelper", () => {
     expect(mime).toContain("Bcc: f@g.h")
     expect(mime).toContain('Content-Type: text/html; charset="UTF-8"')
   })
+
+  it("rejects a repeated flag instead of dropping every value but the first", () => {
+    // `--to a --to b` is a plausible model habit, and the old first-match
+    // lookup silently addressed one recipient and lost the rest.
+    expect(() =>
+      expandGmailDraftHelper([
+        "gmail", "+draft", "--to", "a@b.c", "--to", "d@e.f", "--body", "x",
+      ])
+    ).toThrow(/--to was given more than once/)
+    expect(() =>
+      expandGmailDraftHelper([
+        "gmail", "+draft", "--to", "a@b.c",
+        "--subject", "one", "--subject", "two",
+      ])
+    ).toThrow(/--subject was given more than once/)
+  })
+
+  it("does not mistake body text for a flag", () => {
+    // Scanning flag-by-flag, not searching the whole argv: a body that talks
+    // about `--to` is body text, not a second recipient flag.
+    const out = expandGmailDraftHelper([
+      "gmail", "+draft", "--to", "a@b.c", "--body", "--to",
+    ])
+    expect(decode(out)).toContain("To: a@b.c")
+    expect(decodeBody(out)).toBe("--to")
+  })
+
+  it("encodes only the display name of a non-ASCII address", () => {
+    const out = expandGmailDraftHelper([
+      "gmail", "+draft", "--to", "José Ruiz <jose@psd401.net>", "--body", "x",
+    ])
+    const mime = decode(out)
+    // The addr-spec has to stay machine-readable — encoding the whole header
+    // would leave Gmail nothing to deliver to.
+    expect(mime).toContain("<jose@psd401.net>")
+    expect(mime).toContain("To: =?UTF-8?B?")
+    expect(mime).not.toContain("José")
+  })
+
+  it("leaves an all-ASCII address header byte-for-byte alone", () => {
+    const out = expandGmailDraftHelper([
+      "gmail", "+draft",
+      "--to", '"Doe, John" <john@psd401.net>, jane@psd401.net',
+      "--body", "x",
+    ])
+    expect(decode(out)).toContain(
+      'To: "Doe, John" <john@psd401.net>, jane@psd401.net'
+    )
+  })
 })

--- a/tests/unit/lib/agent-workspace/gmail-draft-helper.test.ts
+++ b/tests/unit/lib/agent-workspace/gmail-draft-helper.test.ts
@@ -1,0 +1,61 @@
+import { expandGmailDraftHelper } from "@/lib/agent-workspace/command-executor"
+
+function decode(argv: string[]) {
+  const raw = JSON.parse(argv[argv.indexOf("--json") + 1]).message.raw
+  return Buffer.from(raw, "base64url").toString("utf8")
+}
+
+describe("expandGmailDraftHelper", () => {
+  it("expands +draft into the canonical drafts create call", () => {
+    const out = expandGmailDraftHelper([
+      "gmail", "+draft", "--to", "bill@psd401.net",
+      "--subject", "Follow up", "--body", "Hi Bill,\nthanks.",
+    ])
+    expect(out.slice(0, 4)).toEqual(["gmail", "users", "drafts", "create"])
+    expect(JSON.parse(out[out.indexOf("--params") + 1])).toEqual({ userId: "me" })
+    const mime = decode(out)
+    expect(mime).toContain("To: bill@psd401.net")
+    expect(mime).toContain("Subject: Follow up")
+    expect(mime).toContain('Content-Type: text/plain; charset="UTF-8"')
+    expect(mime.endsWith("Hi Bill,\nthanks.")).toBe(true)
+  })
+
+  it("leaves every non-draft command untouched", () => {
+    const argv = ["gmail", "users", "messages", "list", "--params", "{}"]
+    expect(expandGmailDraftHelper(argv)).toEqual(argv)
+    const send = ["gmail", "+send", "--to", "x@y.z"]
+    expect(expandGmailDraftHelper(send)).toEqual(send)
+  })
+
+  it("refuses header injection via CRLF", () => {
+    expect(() =>
+      expandGmailDraftHelper([
+        "gmail", "+draft", "--to", "a@b.c\r\nBcc: evil@x.y", "--body", "x",
+      ])
+    ).toThrow(/line break/)
+    expect(() =>
+      expandGmailDraftHelper([
+        "gmail", "+draft", "--to", "a@b.c", "--subject", "hi\nBcc: evil@x.y",
+      ])
+    ).toThrow(/line break/)
+  })
+
+  it("requires --to", () => {
+    expect(() =>
+      expandGmailDraftHelper(["gmail", "+draft", "--body", "x"])
+    ).toThrow(/requires --to/)
+  })
+
+  it("RFC 2047-encodes a non-ASCII subject and supports cc/bcc + html", () => {
+    const out = expandGmailDraftHelper([
+      "gmail", "+draft", "--to", "a@b.c", "--cc", "c@d.e", "--bcc", "f@g.h",
+      "--subject", "Budget — Q4", "--body", "<b>hi</b>", "--html",
+    ])
+    const mime = decode(out)
+    expect(mime).toContain("=?UTF-8?B?")
+    expect(mime).not.toContain("Subject: Budget — Q4")
+    expect(mime).toContain("Cc: c@d.e")
+    expect(mime).toContain("Bcc: f@g.h")
+    expect(mime).toContain('Content-Type: text/html; charset="UTF-8"')
+  })
+})

--- a/tests/unit/lib/agent-workspace/gmail-draft-helper.test.ts
+++ b/tests/unit/lib/agent-workspace/gmail-draft-helper.test.ts
@@ -5,6 +5,13 @@ function decode(argv: string[]) {
   return Buffer.from(raw, "base64url").toString("utf8")
 }
 
+/** Headers + decoded body, mirroring what a mail client renders. */
+function decodeBody(argv: string[]) {
+  const mime = decode(argv)
+  const body = mime.split("\r\n\r\n").slice(1).join("\r\n\r\n")
+  return Buffer.from(body.replace(/\r\n/g, ""), "base64").toString("utf8")
+}
+
 describe("expandGmailDraftHelper", () => {
   it("expands +draft into the canonical drafts create call", () => {
     const out = expandGmailDraftHelper([
@@ -17,7 +24,30 @@ describe("expandGmailDraftHelper", () => {
     expect(mime).toContain("To: bill@psd401.net")
     expect(mime).toContain("Subject: Follow up")
     expect(mime).toContain('Content-Type: text/plain; charset="UTF-8"')
-    expect(mime.endsWith("Hi Bill,\nthanks.")).toBe(true)
+    expect(mime).toContain("Content-Transfer-Encoding: base64")
+    expect(decodeBody(out)).toBe("Hi Bill,\nthanks.")
+  })
+
+  it("round-trips a non-ASCII body through the declared encoding", () => {
+    // Raw UTF-8 under an implied 7bit is off-spec; an em dash, an accented
+    // name or an emoji is routine in district mail.
+    const body = "Budget — Renée ✅\nsecond line"
+    const out = expandGmailDraftHelper([
+      "gmail", "+draft", "--to", "a@b.c", "--subject", "s", "--body", body,
+    ])
+    expect(decode(out)).toContain("Content-Transfer-Encoding: base64")
+    expect(decodeBody(out)).toBe(body)
+  })
+
+  it("wraps a long encoded body at 76 chars per RFC 2045", () => {
+    const out = expandGmailDraftHelper([
+      "gmail", "+draft", "--to", "a@b.c", "--body", "x".repeat(500),
+    ])
+    const mime = decode(out)
+    const bodyLines = mime.split("\r\n\r\n").slice(1).join("\r\n\r\n").split("\r\n")
+    expect(bodyLines.length).toBeGreaterThan(1)
+    for (const line of bodyLines) expect(line.length).toBeLessThanOrEqual(76)
+    expect(decodeBody(out)).toBe("x".repeat(500))
   })
 
   it("leaves every non-draft command untouched", () => {

--- a/tests/unit/lib/agent-workspace/workspace-allowlist-gaps.test.ts
+++ b/tests/unit/lib/agent-workspace/workspace-allowlist-gaps.test.ts
@@ -1,0 +1,65 @@
+import { validateWorkspaceCommand } from "@/lib/agent-workspace/command-executor"
+
+const agent = (argv: string[]) => ({ argv, scope: "agent" as const })
+const user = (argv: string[]) => ({ argv, scope: "user" as const })
+
+describe("allowlist gaps closed from 2026-08-13 prod failures", () => {
+  it("permits sheets +append (real gws helper, canonical twin already allowed)", () => {
+    expect(() =>
+      validateWorkspaceCommand(
+        agent(["sheets", "+append", "--params", '{"spreadsheetId":"abc"}']),
+        "hagelk@psd401.net"
+      )
+    ).not.toThrow()
+  })
+
+  it("holds sheets +append to the same agent-only boundary as its canonical twin", () => {
+    // The two spellings of one operation must not disagree about impersonation.
+    expect(() =>
+      validateWorkspaceCommand(
+        user(["sheets", "+append", "--params", '{"spreadsheetId":"abc"}']),
+        "hagelk@psd401.net"
+      )
+    ).toThrow(/agent-owned/)
+  })
+
+  it("permits tasks tasklists insert (tasks tasks insert was already allowed)", () => {
+    expect(() =>
+      validateWorkspaceCommand(
+        agent(["tasks", "tasklists", "insert", "--json", '{"title":"Farmer"}']),
+        "hagelk@psd401.net"
+      )
+    ).not.toThrow()
+  })
+
+  it("permits drive +upload on the agent slot", () => {
+    expect(() =>
+      validateWorkspaceCommand(
+        agent(["drive", "+upload", "--upload", "/opt/logo.png"]),
+        "hagelk@psd401.net"
+      )
+    ).not.toThrow()
+  })
+
+  it("still refuses drive +upload on the user slot (impersonation boundary)", () => {
+    // Authoring file CONTENT as the user is the exact thing the boundary
+    // exists to prevent — the helper form must not be a way around it.
+    expect(() =>
+      validateWorkspaceCommand(
+        user(["drive", "+upload", "--upload", "/opt/logo.png"]),
+        "hagelk@psd401.net"
+      )
+    ).toThrow(/agent-owned/)
+  })
+
+  it("still refuses the send helpers", () => {
+    for (const verb of ["+send", "+reply", "+reply-all", "+forward"]) {
+      expect(() =>
+        validateWorkspaceCommand(
+          agent(["gmail", verb, "--to", "a@b.c", "--body", "x"]),
+          "hagelk@psd401.net"
+        )
+      ).toThrow()
+    }
+  })
+})


### PR DESCRIPTION
Four root causes behind **86 failures over three days** (2026-08-11..13, rising **18 → 29 → 32**, 17 users). Every one is a case where the *same request* succeeded for one user and failed for another — which is why they read as flaky rather than broken.

## 1. `gmail +draft` does not exist in gws — drafting worked only by accident

Checked against the pinned **v0.22.5 binary** this time, not the docs:

```
gmail helpers: +send  +triage  +reply  +reply-all  +forward  +read  +watch
```

No `+draft`, and no `--draft` flag on any of them. The CLI answers `unrecognized subcommand +draft, tip: a similar subcommand exists: +read`.

So the only working path was canonical `gmail users drafts create`, which needs a hand-built base64 RFC 5322 body. An agent that reached for that succeeded; an agent following SKILL.md — where `+draft` is the worked example **in two places** — always failed. Four users since 08-05 (`1112`, `1953`, `5187`, `6078`). Phase 1 permits drafting and forbids sending, so "no draft path" made the one permitted mail action impossible.

**Fix:** `expandGmailDraftHelper` rewrites `gmail +draft` → `gmail users drafts create`, building the MIME in server code. Expansion runs **after** validation, so the allowlist and scope gates still judge what the model asked for. Supports `--to/--cc/--bcc/--subject/--body/--html`, RFC 2047-encodes non-ASCII headers, and **refuses CR/LF in any header value** so model text can't inject a `Bcc:` or end the header block. `+send`/`+reply`/`+reply-all`/`+forward` stay unimplemented and unallowlisted.

**My 08-10 change made this worse and is reverted here.** It asserted *"CREATING DRAFTS IS SUPPORTED… unrecognized subcommand means you typed the wrong verb, NOT that drafting is unavailable"* — sending agents into retry loops blaming themselves. One agent quoted that text back while failing (`6078`).

## 2. Schedule creation 502'd on any weekday cron

```
Invalid Schedule Expression cron(0 45 6 * ? MON-FRI)
```

Quartz shape — leading seconds — so every field shifts: `hour=45`, `year=MON-FRI`. Correct is `cron(45 6 ? * MON-FRI *)`. Four broker errors across two days, one user, five attempts (`6507`, `7053`).

The 5-field expansion was already right. A **pre-wrapped** `cron(...)` got only a field-*count* check, so Quartz strings passed through to AWS. Field domains are now validated, and the shifted shape raises a local error **naming the correct expression** instead of an opaque 502.

## 3. Operations refused whose canonical twins were allowed

`sheets +append`, `drive +upload`, `tasks tasklists insert` — all **real gws commands**, all refused while an equivalent was permitted (`5979`, `7134`, `7728`).

All three allowlisted. `drive +upload` and `sheets +append` also go into `AGENT_ONLY_WRITES` — both author content and their canonical twins are already agent-only, so otherwise the two spellings of one operation would disagree about the impersonation boundary, with the helper being the spelling the model actually uses. Tests assert both the permit **and** the user-slot refusal.

Not a bug: `sheets values update` was a mistyped `sheets spreadsheets values update`, already allowed.

## 4. Morning brief failed for whoever's process started outside the workspace

`infra/validated-fs.cjs` allowed cwd, tmpdir and `/opt`. Skills address the workspace by absolute path — `psd-morning-brief` takes `--config/--data_file/--synthesis_file` under `~/.openclaw` — so the identical command succeeded when launched inside the workspace and failed with `Refusing read outside the working directory and temporary roots` when it wasn't. Two users lost their brief on consecutive days to that exact message.

The workspace (`OPENCLAW_HOME`) is now an allowed root. Verified with cwd outside it that workspace reads succeed while `/etc/hosts`, `/root/.ssh` and `../../etc/hosts` traversal stay refused.

## Verification

- **319 tests** pass across agent-workspace, agent-schedules, validated-fs — **17 new**
- `eslint` clean repo-wide, typecheck **0 errors**

Needs a rebuilt image for the SKILL.md and validated-fs changes; the allowlist, draft expansion and cron validation are web-tier.