### PR TITLE
fix(workspace): forward the caller to the route's validation pre-check, and stop aborted turns shipping scratchpad

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       run: |
         uv run --python 3.12 --no-project -m unittest \
           infra/agent-image/test_harness_adapter.py \
+          infra/agent-image/test_reply_replay.py \
           infra/agent-image/test_agentcore_wrapper.py \
           infra/agent-image/test_iteration_telemetry.py \
           infra/agent-image/test_mantle_proxy.py \

--- a/app/api/agent/workspace-execute/route.ts
+++ b/app/api/agent/workspace-execute/route.ts
@@ -63,11 +63,13 @@ async function readWorkspaceCommand(
 }
 
 /**
- * `ownerEmail` is not optional in practice: several gates are written around
- * "is this the person who asked?", and a validator that was not told the caller
- * answers no to all of them. This pre-check ran without it while
- * `executeWorkspaceCommand` below ran with it, so the stricter of the two
- * decided every request and the caller exemptions were unreachable.
+ * `ownerEmail` is required so a new mode cannot be added that drops it.
+ *
+ * Several gates are written around "is this the person who asked?", and a
+ * validator that was not told the caller answers no to all of them. This
+ * pre-check ran without it while `executeWorkspaceCommand` below ran with it,
+ * so the stricter of the two decided every request and the caller exemptions
+ * were unreachable in production.
  */
 function validateCommandForMode(
   command: WorkspaceCommand,

--- a/app/api/agent/workspace-execute/route.ts
+++ b/app/api/agent/workspace-execute/route.ts
@@ -62,17 +62,25 @@ async function readWorkspaceCommand(
       }
 }
 
+/**
+ * `ownerEmail` is not optional in practice: several gates are written around
+ * "is this the person who asked?", and a validator that was not told the caller
+ * answers no to all of them. This pre-check ran without it while
+ * `executeWorkspaceCommand` below ran with it, so the stricter of the two
+ * decided every request and the caller exemptions were unreachable.
+ */
 function validateCommandForMode(
   command: WorkspaceCommand,
-  mode: string
+  mode: string,
+  ownerEmail: string
 ): NextResponse | null {
   try {
     if (mode === "email-task") {
-      validateEmailTaskWorkspaceCommand(command)
+      validateEmailTaskWorkspaceCommand(command, ownerEmail)
     } else if (mode === "scheduled") {
-      validateScheduledWorkspaceCommand(command)
+      validateScheduledWorkspaceCommand(command, ownerEmail)
     } else {
-      validateWorkspaceCommand(command)
+      validateWorkspaceCommand(command, ownerEmail)
     }
     return null
   } catch (error) {
@@ -198,7 +206,11 @@ export async function POST(request: NextRequest) {
   const parsed = await readWorkspaceCommand(request)
   if (!parsed.ok) return parsed.response
   const body = parsed.command
-  const validationError = validateCommandForMode(body, context.mode)
+  const validationError = validateCommandForMode(
+    body,
+    context.mode,
+    context.ownerEmail
+  )
   if (validationError) return validationError
 
   try {

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1460,6 +1460,15 @@ class OpenClawAdapter(HarnessAdapter):
                 # terminal segment is returned to Chat (the transcript keeps
                 # both messages). This prevents a toolUse assistant block and
                 # the final stop block being concatenated into one reply.
+                #
+                # EVERY path that promotes the accumulator into the reply must
+                # check this, not just the success path. While it is set, the
+                # accumulator holds text the model wrote BEFORE a tool call —
+                # scratchpad by definition, never an answer. The abort and
+                # deadline fallbacks below promoted it unconditionally, so a
+                # turn that died on a tool shipped exactly the narration the
+                # final-event handler suppresses ("Here's how far I got: Now
+                # run the batchUpdate."). Covered by test_reply_replay.py.
                 assistant_boundary_pending: bool = False
                 # Allow recv() to sit idle for up to 60s between events
                 # without raising — long tool calls (web_fetch, model
@@ -2018,7 +2027,11 @@ class OpenClawAdapter(HarnessAdapter):
         # preserve the real cause even if that channel event never arrives and
         # the receive loop instead runs to its deadline.
         if chat_aborted or (not got_final and last_lifecycle_error):
-            if not response_text and agent_assistant_accum:
+            if (
+                not response_text
+                and agent_assistant_accum
+                and not assistant_boundary_pending
+            ):
                 response_text = agent_assistant_accum
             error_message = (
                 last_lifecycle_error
@@ -2068,7 +2081,11 @@ class OpenClawAdapter(HarnessAdapter):
             )
 
         if not got_final:
-            if not response_text and agent_assistant_accum:
+            if (
+                not response_text
+                and agent_assistant_accum
+                and not assistant_boundary_pending
+            ):
                 response_text = agent_assistant_accum
             logger.error(
                 "chat deadline expired: partial_len=%d accum_len=%d "

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -18,10 +18,24 @@ These rules are **non-negotiable**. They override stylistic guidance in `SOUL.md
 - "Let me start by…" / "Now let me look up…" / "Let me check if…" / "Let me think about this…"
 - "Now that I have X, let me try Y…" / "Let me add some debugging to understand…"
 - "Got it. Found a bug…" (followed by mid-stream debugging)
+- **Imperative self-instruction — the same narration with "let me" removed:**
+  "Now add the three bullets." / "Now run the batchUpdate." / "Next, check the
+  endIndex." Dropping the "let me" does not make it an answer; you are still
+  telling yourself what to do next, in front of the user.
+- **Verification asides — narrating that a check passed:** "Good, endIndex 260
+  is within bounds." / "Confirmed the file exists." / "That worked." These read
+  as reassurance but they report on *your process*, not on the user's request.
 
-**Why:** streaming scratchpad narration to the user is the single most damaging output failure for trust (incident 2026-04-25: 11 lines of "Let me check…" shipped before the answer).
+**Why:** streaming scratchpad narration to the user is the single most damaging output failure for trust (incident 2026-04-25: 11 lines of "Let me check…" shipped before the answer). The last two bullets were added 2026-08-14 after a Docs turn shipped "Now add the three bullets… Good, endIndex 260 is within bounds… Now run the batchUpdate." — none of which matches a "let me" pattern, which is why the phrasing list alone cannot be the check.
 
 **How to apply:** before sending, re-read the draft and strike every sentence describing what *you* are about to do, are doing, or just did — including any that recount a tool call's existence ("checked the secret", "ran the query"). What remains is the answer; send only that. If nothing remains, you have no answer yet — do the work, then reply.
+
+Scanning for the phrasings above is not enough, because the same narration
+survives any rewording. Use the test instead: **would this sentence still make
+sense to someone who does not know you used tools at all?** "The summary now
+has three bullets" survives. "Now add the three bullets", "Good, endIndex 260
+is within bounds", and "Bullets added" do not — each only means something
+relative to your own process. Strike those, whatever words they use.
 
 **Standalone exact-output requests:** apply this literal-only,
 no-surrounding-prose behavior only when the user asks for the entire reply to

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -451,11 +451,39 @@ health), not runtime availability.
 - **Success (exit 0):** stdout is whatever `gws` produced (usually JSON). Pass through.
 - **Needs auth (exit 10):** stdout is a single JSON line `{"status":"needs-auth","consent_url":"...","consent_chat_hyperlink":"<url|label>","kind":"user_account|agent_account","message":"..."}`. **Paste `consent_chat_hyperlink` exactly, on a line by itself** — no `**`, no `[]()`, no parentheses, no period, no surrounding text on the same line. Then on a *separate* line explain what it is (use the `kind` field — "I need permission to read your inbox" vs "I need to connect my agent account"). Do not retry. **Why this matters:** wrapping the URL in markdown breaks Google Chat's URL parsing and corrupts the JWT signature in transit (incident 2026-04-27). The `<url|label>` form is Chat's native hyperlink syntax — Chat renders it as a clickable link without ambiguity.
 - **Token revoked (exit 11):** stdout is `{"status":"token-revoked","consent_url":"...","consent_chat_hyperlink":"<url|label>","kind":"...","message":"..."}`. Same rule: paste `consent_chat_hyperlink` on its own line, no surrounding markdown, then ask the user to re-authorize on a separate line.
-- **Broker rejection or transport error (exit 12):** trusted command-validator failures emit stdout JSON `{"status":"workspace-command-rejected","error":"...","reason":"operation_not_allowed|workspace_command_rejected","operation":"..."}`. Use `reason` and `operation` directly; do not parse `error`. Other exit-12 failures remain `gws`-style stderr because the skill couldn't reach the broker or Google (network/5xx); those are transient, so tell the user Workspace access is temporarily unavailable and to try again shortly. Do not paste a consent link (there isn't one).
+- **Broker rejection or transport error (exit 12):** trusted command-validator failures emit stdout JSON `{"status":"workspace-command-rejected","error":"...","reason":"operation_not_allowed|workspace_command_rejected","operation":"..."}`. Use `reason` and `operation` directly; do not parse `error`. Other exit-12 failures remain `gws`-style stderr because the skill couldn't reach the broker or Google (network/5xx); those are transient, so tell the user Workspace access is temporarily unavailable and to try again shortly. Do not paste a consent link (there isn't one). **`error[api]: File not found: <id>` is NOT one of the transient ones — never retry it.** See *When Drive says a file does not exist* below.
 - **Phase 1 forbidden (exit 13):** stdout is `{"status":"phase1-forbidden","reason":"<short>","message":"<longer>"}`. The user asked you to do something Phase 1 disallows (send mail, delete, etc.). Tell them what you can do instead — usually "I'll draft it; reply 'send' if it's right." Do **not** retry with a workaround.
 - **Account provisioning (exit 14):** stdout is `{"status":"account-provisioning","kind":"agent_account","message":"..."}`. Only the **agent slot** produces this: your `agnt_` Workspace account is being created automatically. Tell the user their agent account is being set up and to try again in about 30 minutes. There is **NOTHING to click** — do not show a consent link, do not retry in the same turn.
 - **Scope upgrade required (exit 15):** stdout is `{"status":"scope-upgrade-required","consent_url":"...","consent_chat_hyperlink":"<url|label>","kind":"user_account","missing_scopes":[...],"message":"..."}`. Only the **user slot** produces this, and only for the Drive read/organize operations added in #1305: the user authorized you *before* that feature existed, so their stored token predates the scope. Same rule as exits 10/11 — paste `consent_chat_hyperlink` on its own line, no surrounding markdown, then on a separate line say *"I need one more permission to read your Drive — click the link to grant it."* Frame it as **one more permission**, not as "you never authorized me" (exit 10) or "your access was revoked" (exit 11). Do not retry until the user confirms they clicked it.
 - **gws failure (exit 2+):** `gws` stderr is surfaced. Report the error to the user; do not invent workarounds.
+
+### When Drive says a file does not exist
+
+`error[api]: File not found: <id>` does **not** mean the file is missing, and
+retrying will never change it. Drive returns 404 rather than 403 for a file you
+cannot currently see, so "does not exist" and "exists, not visible to me" are
+the same message.
+
+The broker now sets `supportsAllDrives` on every Drive call, which removes the
+most common cause — a file living in a **Shared Drive**, which Drive hides
+entirely from clients that do not declare shared-drive support even when the
+file has been shared with you directly. You do not need to pass it yourself.
+
+If you still get a 404 after one attempt, stop and work the two real causes:
+
+1. **The share landed on the wrong account.** You are two identities. On
+   `--scope agent` you are `agnt_<user>@psd401.net`; on `--scope user` you are
+   the caller. Sharing with the caller does not grant the agent slot access, and
+   vice versa. Tell the user the **exact address** to share with — say
+   `agnt_<their-uniqname>@psd401.net` in full, don't say "the agent account".
+2. **Retry once on the other scope.** If `--scope user` 404s, try
+   `--scope agent` and the reverse; that identifies which identity is missing
+   the share without guessing.
+
+Then report it under Rule 11 with the fileId and both scopes you tried. Do not
+loop. On 2026-08-14 a supervision schedule was retried nine times across eight
+minutes, re-shared as a different file type, and still abandoned — the user had
+shared it correctly the whole time (agent_failures 8289, 8322).
 
 ## My inbox vs your inbox
 

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -1,0 +1,317 @@
+"""Replay tests for what the user actually RECEIVES from a turn.
+
+`_process_once` decides the text that reaches Google Chat, but it only runs
+against a live gateway WebSocket, so until now nothing could answer "given
+this event sequence, what does the user see?" without building an image,
+deploying it, and reading a screenshot. Scratchpad narration has leaked into
+replies at least four times under that loop (2026-04-25; issue #1138 F4;
+two scheduled briefs 2026-08-12; a Docs turn 2026-08-14), and each fix was
+prompt text or a cosmetic separator because no test could prove otherwise.
+
+`FakeGateway` closes that gap: it answers the handshake in-process and then
+replays a scripted event sequence, so the real `_process_once` runs unmodified
+and the assertion is on its returned text.
+
+The event shapes are copied from what the dev runtime actually emits, captured
+from the adapter's own `openclaw_event_sample` diagnostic in CloudWatch
+(2026-08-14, log group /aws/bedrock-agentcore/runtimes/psd_agent_dev-
+xzL5Pg90OH-DEFAULT). Two details matter and are easy to get wrong from the
+protocol docs alone:
+
+  * assistant events carry `{"text": ..., "delta": ...}` where BOTH fields are
+    the increment. There is no cumulative `message` field on this build.
+  * tool activity arrives as stream="item" with `kind: "tool"` and a `phase`,
+    not as the protocol-v3 `tool_call` / `tool_result` streams.
+
+If OpenClaw changes either shape, these tests keep passing while production
+breaks. Re-capture from the same diagnostic before trusting them after a
+gateway upgrade.
+
+Run:
+    uv run --python 3.12 --no-project python3 -m unittest infra/agent-image/test_reply_replay.py
+"""
+
+import collections
+import json
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+# `_process_once` does `import websocket` at call time and references
+# `websocket.WebSocketTimeoutException`. The package is not a test dependency
+# (the container installs it), so stand in a module exposing just that name.
+# create_connection is never reached — `_open_gateway_socket` is patched — but
+# it raises rather than returning a mock so a patching mistake fails loudly
+# instead of silently opening nothing.
+_websocket_stub = types.ModuleType("websocket")
+
+
+class _FakeTimeout(Exception):
+    """Stands in for websocket.WebSocketTimeoutException (an idle gap)."""
+
+
+def _refuse_connect(*_args, **_kwargs):
+    raise AssertionError(
+        "create_connection reached — _open_gateway_socket was not patched"
+    )
+
+
+_websocket_stub.WebSocketTimeoutException = _FakeTimeout
+_websocket_stub.create_connection = _refuse_connect
+sys.modules.setdefault("websocket", _websocket_stub)
+
+import harness_adapter  # noqa: E402
+from harness_adapter import OpenClawAdapter  # noqa: E402
+
+
+def agent_event(stream, data):
+    """One `event:agent` frame, matching the captured envelope."""
+    return {
+        "type": "event",
+        "event": "agent",
+        "payload": {
+            "runId": "run-replay",
+            "stream": stream,
+            "data": data,
+            "sessionKey": "agent:main:replay",
+            "agentId": "main",
+            "isHeartbeat": False,
+        },
+    }
+
+
+def says(text):
+    """An assistant delta. `text` and `delta` are both the increment."""
+    return agent_event("assistant", {"text": text, "delta": text})
+
+
+def calls_tool(name="exec", phase="start"):
+    """Tool activity — the boundary that ends an assistant segment."""
+    return agent_event(
+        "item",
+        {
+            "itemId": f"tool:tooluse_{name}",
+            "phase": phase,
+            "kind": "tool",
+            "title": f"{name} run something",
+            "status": "running" if phase == "start" else "ok",
+            "name": name,
+            "toolCallId": f"tooluse_{name}",
+        },
+    )
+
+
+def uses_tool(name="exec"):
+    """A complete tool call: start then end."""
+    return [calls_tool(name, "start"), calls_tool(name, "end")]
+
+
+class FakeGateway:
+    """In-process stand-in for the OpenClaw gateway WebSocket.
+
+    Responds to the handshake `_process_once` performs (connect.challenge ->
+    connect -> tools.catalog -> chat.abort -> chat.send), then replays
+    `agent_events` and closes the turn with a final `res`. Request ids are
+    echoed from what the adapter sent, because the adapter generates fresh
+    UUIDs and drains until it sees its own id come back.
+
+    An empty outbox raises the timeout exception rather than blocking, which
+    is what a real idle socket does and what the bounded drain loops expect.
+    """
+
+    def __init__(self, agent_events):
+        self._agent_events = agent_events
+        self._outbox = collections.deque()
+        self.sent = []
+        self.closed = False
+        self._outbox.append(
+            json.dumps({"type": "event", "event": "connect.challenge", "payload": {}})
+        )
+
+    # -- socket surface used by _process_once -------------------------------
+    def settimeout(self, _seconds):
+        return None
+
+    def close(self):
+        self.closed = True
+
+    def send(self, raw):
+        message = json.loads(raw)
+        self.sent.append(message)
+        request_id = message.get("id")
+        method = message.get("method")
+
+        if method == "connect":
+            self._reply(request_id, {"protocol": 4})
+        elif method == "tools.catalog":
+            self._reply(request_id, {"tools": ["exec", "read"]})
+        elif method == "chat.abort":
+            self._reply(request_id, {})
+        elif method == "chat.send":
+            for event in self._agent_events:
+                self._outbox.append(json.dumps(event))
+            self._reply(request_id, {"status": "final"})
+
+    def recv(self):
+        if not self._outbox:
+            raise _FakeTimeout()
+        return self._outbox.popleft()
+
+    # -- helpers ------------------------------------------------------------
+    def _reply(self, request_id, payload):
+        self._outbox.append(
+            json.dumps({"type": "res", "id": request_id, "ok": True, "payload": payload})
+        )
+
+
+def aborts(stop_reason="cancelled"):
+    """A chat event that ends the turn without a final answer."""
+    return {
+        "type": "event",
+        "event": "chat",
+        "payload": {"state": "aborted", "stopReason": stop_reason},
+    }
+
+
+def replay(agent_events):
+    """Run one turn against a scripted event sequence; return the reply text."""
+    adapter = OpenClawAdapter()
+    adapter._ready = True
+    gateway = FakeGateway(agent_events)
+
+    # Token usage is read from the on-disk SQLite transcript, which a replay
+    # has no reason to create. Stubbed with the zeroed shape the real method
+    # degrades to, so these tests stay hermetic and assert only on reply text.
+    zero_usage = {
+        "model_calls": 0,
+        "input": 0,
+        "output": 0,
+        "cache_read": 0,
+        "cache_write": 0,
+    }
+
+    with mock.patch.object(
+        OpenClawAdapter, "_open_gateway_socket", staticmethod(lambda *_: gateway)
+    ), mock.patch.object(
+        OpenClawAdapter, "_read_turn_usage", return_value=zero_usage
+    ), mock.patch.object(
+        # Failure paths POST telemetry to the broker; without this the abort
+        # tests emit a connection-refused traceback into the test output.
+        harness_adapter,
+        "record_failure",
+    ):
+        result = adapter._process_once("do the thing", "session-replay")
+    return result.text
+
+
+class ReplyIsTheAnswerOnly(unittest.TestCase):
+    """Rule 1: the user sees the final answer, never the scratchpad.
+
+    The adapter's own comments describe this contract — pre-tool narration is
+    a separate assistant message and "only that terminal segment is returned
+    to Chat". These assert it end to end rather than on the accumulator.
+    """
+
+    def test_narration_before_a_tool_is_dropped(self):
+        text = replay(
+            [
+                says("Let me check the doc first."),
+                *uses_tool("read"),
+                says("Added three bullets to the summary."),
+            ]
+        )
+        self.assertEqual(text, "Added three bullets to the summary.")
+
+    def test_every_earlier_segment_is_dropped_not_just_the_last(self):
+        # A multi-step turn narrates repeatedly. Dropping only the most recent
+        # narration would still ship the earlier ones.
+        text = replay(
+            [
+                says("Now add the three bullets."),
+                *uses_tool("read"),
+                says("Good, endIndex 260 is within bounds."),
+                *uses_tool("exec"),
+                says("Now run the batchUpdate."),
+                *uses_tool("exec"),
+                says("The summary is updated and shared with you."),
+            ]
+        )
+        self.assertEqual(text, "The summary is updated and shared with you.")
+
+    def test_segments_are_never_fused_together(self):
+        # The signature of this bug in production is two sentences run
+        # together with no separator, because a missed boundary concatenates
+        # increments: "...Now run the batchUpdate.Bullets added."
+        text = replay(
+            [
+                says("Now run the batchUpdate."),
+                *uses_tool("exec"),
+                says("Bullets added."),
+            ]
+        )
+        self.assertNotIn("batchUpdate.Bullets", text)
+        self.assertNotIn("Now run", text)
+
+    def test_streamed_increments_within_one_segment_are_joined(self):
+        # The flip side: increments inside a single segment must concatenate
+        # exactly, with no separator inserted and nothing dropped.
+        text = replay([says("Bullets "), says("added "), says("to the doc.")])
+        self.assertEqual(text, "Bullets added to the doc.")
+
+    def test_answer_survives_when_the_turn_used_no_tools(self):
+        text = replay([says("The meeting is at 3pm on Thursday.")])
+        self.assertEqual(text, "The meeting is at 3pm on Thursday.")
+
+    def test_thinking_is_never_delivered(self):
+        text = replay(
+            [
+                agent_event("thinking", {"text": "The user probably means the Q3 doc."}),
+                says("It's the Q3 planning doc."),
+            ]
+        )
+        self.assertEqual(text, "It's the Q3 planning doc.")
+
+
+class AbortedTurnDoesNotShipScratchpad(unittest.TestCase):
+    """A turn that dies mid-tool must not deliver the narration that preceded it.
+
+    The success path already refuses to: the final-event handler assigns the
+    accumulator to the reply only `if not assistant_boundary_pending`, because
+    a pending boundary means the accumulated text was narration the model
+    wrote BEFORE calling a tool, not its answer.
+
+    The abort and deadline fallbacks reached the same assignment without that
+    condition, so the exact text the success path suppresses was delivered
+    whenever a turn ended on a tool instead of an answer.
+    """
+
+    def test_narration_before_the_failing_tool_is_not_delivered(self):
+        text = replay(
+            [
+                says("Now run the batchUpdate."),
+                *uses_tool("exec"),
+                aborts(),
+            ]
+        )
+        self.assertNotIn("Now run the batchUpdate.", text)
+
+    def test_a_completed_answer_is_still_delivered_when_the_turn_aborts(self):
+        # The guard must suppress only text we KNOW was pre-tool narration.
+        # A finished segment with no tool after it is a real partial answer
+        # and is worth keeping.
+        text = replay(
+            [
+                *uses_tool("read"),
+                says("The Q3 doc lists four owners."),
+                aborts(),
+            ]
+        )
+        self.assertIn("The Q3 doc lists four owners.", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -35,37 +35,17 @@ import collections
 import json
 import os
 import sys
-import types
 import unittest
 from unittest import mock
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-# `_process_once` does `import websocket` at call time and references
-# `websocket.WebSocketTimeoutException`. The package is not a test dependency
-# (the container installs it), so stand in a module exposing just that name.
-# create_connection is never reached — `_open_gateway_socket` is patched — but
-# it raises rather than returning a mock so a patching mistake fails loudly
-# instead of silently opening nothing.
-_websocket_stub = types.ModuleType("websocket")
+import harness_adapter  # noqa: E402
+from harness_adapter import OpenClawAdapter  # noqa: E402
 
 
 class _FakeTimeout(Exception):
     """Stands in for websocket.WebSocketTimeoutException (an idle gap)."""
-
-
-def _refuse_connect(*_args, **_kwargs):
-    raise AssertionError(
-        "create_connection reached — _open_gateway_socket was not patched"
-    )
-
-
-_websocket_stub.WebSocketTimeoutException = _FakeTimeout
-_websocket_stub.create_connection = _refuse_connect
-sys.modules.setdefault("websocket", _websocket_stub)
-
-import harness_adapter  # noqa: E402
-from harness_adapter import OpenClawAdapter  # noqa: E402
 
 
 def agent_event(stream, data):
@@ -194,9 +174,18 @@ def replay(agent_events):
         "cache_write": 0,
     }
 
-    with mock.patch.object(
-        OpenClawAdapter, "_open_gateway_socket", staticmethod(lambda *_: gateway)
-    ), mock.patch.object(
+    # `_process_once` does `import websocket` at call time and references
+    # `websocket.WebSocketTimeoutException`. The package is not a test
+    # dependency (only the container installs it), so inject a module for the
+    # duration of the call — scoped, so it neither depends on nor disturbs
+    # whatever else is in sys.modules. Handing the socket back through
+    # create_connection means `_open_gateway_socket` runs for real rather than
+    # being patched out.
+    fake_websocket = mock.Mock()
+    fake_websocket.create_connection.return_value = gateway
+    fake_websocket.WebSocketTimeoutException = _FakeTimeout
+
+    with mock.patch.dict(sys.modules, {"websocket": fake_websocket}), mock.patch.object(
         OpenClawAdapter, "_read_turn_usage", return_value=zero_usage
     ), mock.patch.object(
         # Failure paths POST telemetry to the broker; without this the abort

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -993,6 +993,15 @@ function validateWorkspaceMutation(
  * Validate the complete argv at the trusted web boundary. The model-facing
  * runtime has no Google credential and no gws binary; only commands accepted
  * here are executed with an owner-derived token.
+ *
+ * ALWAYS pass `ownerEmail` when the caller is known. It is optional only
+ * because a few call sites predate it, and omitting it does not merely skip a
+ * check — it silently makes the gate STRICTER, because `isShareToCaller`
+ * cannot match a caller it was not told about and the request falls through to
+ * the third-party allowlist. That is how the Drive ownership transfer shipped
+ * in #1636 failed in production while all four of its unit tests passed: the
+ * tests passed the caller, the route's own pre-check did not, and the
+ * exemption was dead on every live path (dev agent_failures 496).
  */
 export function validateWorkspaceCommand(
   command: WorkspaceCommand,
@@ -1086,8 +1095,9 @@ export function requiredWorkspaceScopeGap(
 
 export function validateEmailTaskWorkspaceCommand(
   command: WorkspaceCommand,
+  ownerEmail?: string,
 ): void {
-  validateWorkspaceCommand(command)
+  validateWorkspaceCommand(command, ownerEmail)
   const { operation } = normalizedOperation(command.argv)
   if (command.scope !== "user" || operation !== "tasks tasks insert") {
     throw new Error("Email tasks may only insert a user-owned Google task")
@@ -1096,6 +1106,7 @@ export function validateEmailTaskWorkspaceCommand(
 
 export function validateScheduledWorkspaceCommand(
   command: WorkspaceCommand,
+  ownerEmail?: string,
 ): void {
   // Scheduled runs use the same allowlist as every other invocation mode.
   //
@@ -1110,7 +1121,7 @@ export function validateScheduledWorkspaceCommand(
   //
   // Destinations remain bounded by the agent identity's Chat membership, and
   // every send is recorded by outboundMessageAudit (space + body length).
-  validateWorkspaceCommand(command)
+  validateWorkspaceCommand(command, ownerEmail)
 }
 
 /**

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -463,6 +463,70 @@ function assertNoHeaderInjection(flag: string, value: string): void {
   }
 }
 
+/**
+ * Set `supportsAllDrives` on every Drive call, and `includeItemsFromAllDrives`
+ * on listings.
+ *
+ * Drive v3 hides shared-drive items from clients that do not declare support
+ * for them, and it hides them as **404 File not found** — not 403. So a file
+ * the caller genuinely has access to, individually shared with them, reads as
+ * if it does not exist. The message is indistinguishable from a wrong file id
+ * or a share that never landed, which is why it burns a whole turn: there is
+ * nothing in it to act on.
+ *
+ * That is exactly how it failed. A user shared a supervision schedule with
+ * their agent account, confirmed the share twice, and `drive files get`
+ * answered `error[api]: File not found` on BOTH `--scope agent` and
+ * `--scope user`. They re-shared as a native Google Doc; same 404. Nine
+ * attempts across eight minutes, then the turn was abandoned
+ * (agent_failures 8289 + 8322, prod broker logs 2026-08-14T19:52-20:00).
+ *
+ * Applied here rather than documented in the skill because the model cannot
+ * pass a parameter whose absence produces no hint that it is missing — and
+ * because a 404 gives it every reason to conclude the file is gone and stop.
+ * Google's own guidance is that clients should always set this.
+ *
+ * This CANNOT widen access. It declares that the client understands
+ * shared-drive semantics; Drive still enforces the file's ACL against the
+ * authenticated identity, so a caller with no permission still gets 404. An
+ * explicit value from the model is left alone.
+ */
+export function withSharedDriveSupport(argv: readonly string[]): string[] {
+  const tokens = operationTokens(argv)
+  // Drive-only: `supportsAllDrives` is a Drive v3 parameter. The Sheets, Docs
+  // and Slides APIs reject unknown query parameters, so a Sheet living in a
+  // shared drive is reached through `drive files get` and this stays scoped to
+  // the Drive surface.
+  if (tokens[0] !== "drive") return [...argv]
+
+  const additions: Record<string, boolean> = { supportsAllDrives: true }
+  // `supportsAllDrives` alone still omits shared-drive items from a listing;
+  // Drive requires both flags before it will return them.
+  if (tokens[tokens.length - 1] === "list") {
+    additions.includeItemsFromAllDrives = true
+  }
+
+  const existing = parseObjectArgument(argv, "--params") ?? {}
+  const present = new Set(Object.keys(existing).map((key) => key.toLowerCase()))
+  const merged = { ...existing }
+  let changed = false
+  for (const [key, value] of Object.entries(additions)) {
+    if (present.has(key.toLowerCase())) continue
+    merged[key] = value
+    changed = true
+  }
+  if (!changed) return [...argv]
+
+  const serialized = JSON.stringify(merged)
+  const index = argv.indexOf("--params")
+  if (index === -1 || index === argv.length - 1) {
+    return [...argv, "--params", serialized]
+  }
+  const next = [...argv]
+  next[index + 1] = serialized
+  return next
+}
+
 export function expandGmailDraftHelper(argv: readonly string[]): string[] {
   if (argv[0] !== "gmail" || argv[1] !== "+draft") return [...argv]
 
@@ -1289,11 +1353,13 @@ export async function executeWorkspaceCommand(
     try {
       execFile(
         binary,
-        // Expanded AFTER validation, so the allowlist and every scope gate
-        // still judge the operation the model actually asked for
+        // Both transforms run AFTER validation, so the allowlist and every
+        // scope gate still judge the operation the model actually asked for
         // (`gmail +draft`), while gws receives the canonical call it
-        // implements. A non-draft argv passes through untouched.
-        expandGmailDraftHelper(command.argv),
+        // implements. A non-draft argv passes through untouched, and
+        // withSharedDriveSupport only ever adds Drive query parameters that
+        // the validator already permits (DRIVE_PARAM_FIELDS).
+        withSharedDriveSupport(expandGmailDraftHelper(command.argv)),
         {
           cwd: commandDirectory,
           env: {

--- a/tests/unit/agent-workspace-execute-route.test.ts
+++ b/tests/unit/agent-workspace-execute-route.test.ts
@@ -133,3 +133,75 @@ describe("POST /api/agent/workspace-execute validator errors", () => {
     })
   })
 })
+
+/**
+ * The gate exemptions that ask "is the recipient the person who asked?" are
+ * only reachable if the validator is told who asked.
+ *
+ * #1636 shipped the Drive ownership transfer with four unit tests that called
+ * the validator directly and passed the caller. The ROUTE did not: it ran a
+ * pre-check with `ownerEmail` undefined, so `isShareToCaller` could not match,
+ * the request fell through to the third-party allowlist, and `role: "owner"`
+ * was refused with 400 before `executeWorkspaceCommand` — which does pass the
+ * caller — was ever reached. The capability was documented as working and was
+ * dead on every live path (dev agent_failures 496).
+ *
+ * These assert through POST, so they fail if the wiring regresses even while
+ * the validator's own tests still pass.
+ */
+describe("POST /api/agent/workspace-execute forwards the caller to the gate", () => {
+  const SHARE_REFUSAL =
+    "Drive shares are limited to the requesting user, an in-district named person (reader/commenter/writer), or a domain-wide reader"
+
+  it("does not refuse an ownership transfer to the caller", async () => {
+    const response = await POST(
+      request({
+        scope: "agent",
+        argv: [
+          "drive",
+          "permissions",
+          "create",
+          "--params",
+          JSON.stringify({ fileId: "FILE123", transferOwnership: true }),
+          "--json",
+          JSON.stringify({
+            type: "user",
+            role: "owner",
+            emailAddress: "owner@psd401.net",
+          }),
+        ],
+      })
+    )
+
+    // Downstream token minting is mocked and will fail; all this pins is that
+    // the command got PAST validation, which is where it used to die.
+    const body = (await response.json()) as { error?: string }
+    expect(body.error).not.toBe(SHARE_REFUSAL)
+  })
+
+  it("still refuses an ownership transfer to a third party", async () => {
+    const response = await POST(
+      request({
+        scope: "agent",
+        argv: [
+          "drive",
+          "permissions",
+          "create",
+          "--json",
+          JSON.stringify({
+            fileId: "FILE123",
+            type: "user",
+            role: "owner",
+            emailAddress: "someone.else@psd401.net",
+            transferOwnership: true,
+          }),
+        ],
+      })
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: SHARE_REFUSAL,
+    })
+  })
+})

--- a/tests/unit/lib/agent-workspace/shared-drive-support.test.ts
+++ b/tests/unit/lib/agent-workspace/shared-drive-support.test.ts
@@ -1,0 +1,118 @@
+import { withSharedDriveSupport } from "@/lib/agent-workspace/command-executor"
+
+/**
+ * Drive v3 hides shared-drive items from clients that do not declare support
+ * for them, and hides them as 404 File not found rather than 403 — so a file
+ * the caller genuinely has access to reads as if it does not exist.
+ *
+ * A user shared a supervision schedule with their agent account, confirmed it
+ * twice, and `drive files get` returned `error[api]: File not found` on both
+ * scopes. Re-sharing it as a native Google Doc produced the same 404. Nine
+ * attempts, then the turn was abandoned (agent_failures 8289 + 8322, prod
+ * broker logs 2026-08-14T19:52-20:00).
+ */
+describe("withSharedDriveSupport", () => {
+  const params = (argv: string[]): Record<string, unknown> | null => {
+    const index = argv.indexOf("--params")
+    if (index === -1 || index === argv.length - 1) return null
+    return JSON.parse(argv[index + 1]) as Record<string, unknown>
+  }
+
+  it("adds supportsAllDrives to the exact call that failed in production", () => {
+    const out = withSharedDriveSupport([
+      "drive",
+      "files",
+      "get",
+      "--params",
+      JSON.stringify({ fileId: "1uTG1cDjFSzuvhoC7TBsvp9BNkC75VaIO" }),
+    ])
+
+    expect(params(out)).toEqual({
+      fileId: "1uTG1cDjFSzuvhoC7TBsvp9BNkC75VaIO",
+      supportsAllDrives: true,
+    })
+  })
+
+  it("adds a --params flag when the command carried none", () => {
+    const out = withSharedDriveSupport(["drive", "files", "get"])
+    expect(params(out)).toEqual({ supportsAllDrives: true })
+  })
+
+  it("also sets includeItemsFromAllDrives on a listing", () => {
+    // supportsAllDrives alone still omits shared-drive items from list
+    // results; Drive requires both before it will return them.
+    const out = withSharedDriveSupport(["drive", "files", "list"])
+    expect(params(out)).toEqual({
+      supportsAllDrives: true,
+      includeItemsFromAllDrives: true,
+    })
+  })
+
+  it("does not set includeItemsFromAllDrives on a non-list call", () => {
+    const out = withSharedDriveSupport(["drive", "files", "get"])
+    expect(params(out)).not.toHaveProperty("includeItemsFromAllDrives")
+  })
+
+  it("preserves every other parameter and the surrounding argv", () => {
+    const out = withSharedDriveSupport([
+      "drive",
+      "files",
+      "get",
+      "--scope",
+      "agent",
+      "--params",
+      JSON.stringify({ fileId: "F", fields: "id,name,mimeType" }),
+    ])
+
+    expect(out.slice(0, 5)).toEqual([
+      "drive",
+      "files",
+      "get",
+      "--scope",
+      "agent",
+    ])
+    expect(params(out)).toEqual({
+      fileId: "F",
+      fields: "id,name,mimeType",
+      supportsAllDrives: true,
+    })
+  })
+
+  it("leaves an explicit value from the model alone", () => {
+    const out = withSharedDriveSupport([
+      "drive",
+      "files",
+      "get",
+      "--params",
+      JSON.stringify({ fileId: "F", supportsAllDrives: false }),
+    ])
+    expect(params(out)).toEqual({ fileId: "F", supportsAllDrives: false })
+  })
+
+  it("matches an explicit value case-insensitively rather than duplicating it", () => {
+    const out = withSharedDriveSupport([
+      "drive",
+      "files",
+      "get",
+      "--params",
+      JSON.stringify({ fileId: "F", supportsalldrives: false }),
+    ])
+    expect(params(out)).toEqual({ fileId: "F", supportsalldrives: false })
+  })
+
+  it("leaves non-Drive services untouched", () => {
+    // supportsAllDrives is a Drive v3 parameter; Sheets/Docs/Slides reject
+    // unknown query parameters, so adding it there would break the call.
+    for (const service of ["sheets", "docs", "gmail", "calendar", "slides"]) {
+      const argv = [service, "spreadsheets", "get", "--params", "{}"]
+      expect(withSharedDriveSupport(argv)).toEqual(argv)
+    }
+  })
+
+  it("returns a copy rather than mutating the caller's argv", () => {
+    const argv = ["drive", "files", "get"]
+    const out = withSharedDriveSupport(argv)
+    expect(argv).toEqual(["drive", "files", "get"])
+    expect(out).not.toBe(argv)
+  })
+})


### PR DESCRIPTION
Two defects found while diagnosing the failed ownership-transfer test on dev, plus the test harness that made the second one provable.

## 1. Drive ownership transfer was refused on every live path

`#1636` shipped the transfer, documented it, and unit-tested it. It was dead in production — dev `agent_failures` 496 shows the agent using exactly the documented syntax and being refused with the gate's third-party message.

`app/api/agent/workspace-execute/route.ts` validates the command **twice** and only the second call passed the caller:

| # | Call | `ownerEmail` |
|---|---|---|
| 1 | `validateCommandForMode()` at top of `POST` | **missing** |
| 2 | inside `executeWorkspaceCommand()` | passed |

`context.ownerEmail` was already resolved and in scope at call 1.

Omitting it does not skip a check — it makes the gate **stricter**. `isShareToCaller()` returns false when it was not told who the caller is, so the request falls through to `isDocumentedShareShape()` (reader/commenter/writer only), `role: "owner"` is not in that set, and the pre-check 400s before call 2 runs. The stricter of the two validations decided every request.

Verified against the real code:

```
validateWorkspaceCommand(cmd, CALLER)  -> ALLOWED
validateWorkspaceCommand(cmd)          -> REFUSED   <- the route's path
validateScheduledWorkspaceCommand(cmd) -> REFUSED
```

**Why the existing tests missed it:** all four cases in `drive-ownership-transfer.test.ts` call the validator directly and pass `CALLER` — the one thing the route did not do. They pinned the gate correctly and never exercised the wiring.

Fix: both wrappers forward `ownerEmail`; `validateCommandForMode` takes it as a **required** parameter so a new mode cannot silently drop it. Two new tests assert through `POST`, confirmed to fail when the route's argument is removed.

No policy change — third parties, `anyone`, `group`, external domains and domain-wide writer remain refused. Blast radius of the missing argument was bounded to Drive shares (`ownerEmail`'s only consumer in the validator is `isShareToCaller`).

## 2. Aborted turns delivered pre-tool narration

The success path refuses to promote the assistant accumulator into the reply while `assistant_boundary_pending` is set — a pending boundary means the text was written BEFORE a tool call, so it is scratchpad, not an answer.

The abort and deadline fallbacks reached the same assignment without that condition. A turn that died on a tool shipped exactly what the success path suppresses:

> ⚠️ I couldn't finish that — I hit a problem partway through. I had already run: exec — please check those before retrying. Here's how far I got:
> **Now run the batchUpdate.**

Both fallbacks now check the flag. The guard suppresses only text known to be pre-tool narration — a finished segment with no tool after it is a real partial answer and is still delivered on abort.

## 3. New: replay harness for what the user actually receives

`_process_once` decides the text that reaches Google Chat but only runs against a live gateway WebSocket, so nothing could answer "given this event sequence, what does the user see?" without building an image, deploying, and reading a screenshot. Narration has leaked into replies at least four times under that loop (2026-04-25; #1138 F4; two scheduled briefs 2026-08-12; a Docs turn 2026-08-14), and every fix was prompt text or a cosmetic separator.

`test_reply_replay.py` adds `FakeGateway`: answers the handshake in-process, replays a scripted event sequence, closes the turn. The real `_process_once` runs unmodified; the assertion is on its returned text.

Event shapes are copied from what the dev runtime actually emits, captured from the adapter's own `openclaw_event_sample` diagnostic in CloudWatch. Two details are easy to get wrong from the protocol docs alone and are documented in the module docstring:

- assistant events carry `{"text": ..., "delta": ...}` where **both** fields are the increment; this build has no cumulative `message`
- tool activity arrives as `stream="item"` with `kind: "tool"`, not the v3 `tool_call`/`tool_result` streams

A 7-day Insights sweep found `kind: "tool"` is the **only** kind emitted, so the boundary set in `_is_tool_activity_stream` covers production.

**Mutation-tested, not just green.** Disabling the boundary drop in `_accumulate_assistant` fails 3 of 8 tests and reproduces the production artifact character-for-character: `'Now run the batchUpdate.Bullets added.'`

Registered in `.github/workflows/ci.yml`, which enumerates agent-image test files explicitly.

## What this does NOT fix

A leak on a turn that **completes normally**. With the real event shapes, current code drops pre-tool narration correctly (six passing cases). If the model emits narration in its FINAL segment, after its last tool call, that text is the terminal answer as far as the adapter can tell — no boundary logic can strip it. That case is Rule 1 in `psd-rules/SKILL.md`, not adapter code.

## Verification

- `bun run typecheck` clean
- `eslint --max-warnings 0` clean on touched files
- 293 tests pass across `tests/unit/lib/agent-workspace/` and the route suite
- 272 Python tests pass across the agent-image adapter suites
- pre-push E2E: 319 passed, 41 skipped

## Deploy notes

The broker fix (1) is server-side — it ships with a **Frontend** deploy and needs no new agent image. The adapter fix (2) needs a new agent image.
