### PR TITLE
feat(atrium): library triage facets, shareable personal collections, section hero art, and per-collection publish review

### DIFF
--- a/actions/db/atrium/approvals.ts
+++ b/actions/db/atrium/approvals.ts
@@ -102,17 +102,20 @@ async function approvableCollectionIds(
 }
 
 /**
- * Resolve the session into someone allowed to DECIDE this specific request:
- * a district administrator, or an approver of the collection the request's
- * object lives in.
+ * Coarse eligibility, checked BEFORE any request row is loaded.
  *
- * Also enforces segregation of duties — nobody decides their own request, not
- * even an administrator. This cannot strand a request: the person who raised it
- * was, by definition, not an approver at raise time (an approver's publish is
- * never queued), so someone else always exists who can act on it.
+ * Migration 178 made the per-request decider set depend on the request's
+ * collection, which means the row has to be read before the precise check can
+ * run. Done naively that hands an unauthorized caller an existence oracle: a
+ * bad id 404s while a real id they cannot decide returns "forbidden", so they
+ * can enumerate valid request ids. This restores the old uniform rejection for
+ * anyone who cannot decide ANYTHING, without giving up the per-collection
+ * roster.
+ *
+ * Callers who clear this still cannot learn about requests outside their own
+ * sections — `assertMayDecide` folds that case into the not-found response.
  */
-async function requireDeciderFor(
-  request: ContentPublishRequestRow,
+async function requireEligibleDecider(
   requestId: string,
   operation: string
 ): Promise<AdminRequester> {
@@ -120,7 +123,34 @@ async function requireDeciderFor(
   if (requester.kind !== "user") {
     throw ErrorFactories.authzAdminRequired(operation);
   }
+  const approvable = await approvableCollectionIds(requester);
+  // `null` = administrator (decides anything). An empty set = approves nothing.
+  if (approvable != null && approvable.size === 0) {
+    throw ErrorFactories.authzAdminRequired(operation);
+  }
+  return requester;
+}
 
+/**
+ * The precise per-request check, run once the row is loaded.
+ *
+ * An eligible caller who may not decide THIS request is answered exactly like
+ * one asking about a request that does not exist — same error, same shape — so
+ * clearing the coarse gate does not turn into an oracle for other sections'
+ * queues.
+ *
+ * Self-approval is the one deliberate exception to that masking: the requester
+ * obviously knows their own request exists, so a specific message costs nothing
+ * and a generic "not found" would just be baffling. It enforces segregation of
+ * duties and cannot strand anything — whoever raised a request was by
+ * definition not an approver at raise time, since an approver's publish is
+ * never queued.
+ */
+async function assertMayDecide(
+  requester: AdminRequester,
+  request: ContentPublishRequestRow,
+  id: string
+): Promise<void> {
   if (
     request.requestedByUserId != null &&
     request.requestedByUserId === requester.userId
@@ -130,31 +160,29 @@ async function requireDeciderFor(
     );
   }
 
-  if (requester.isAdmin) return requester;
+  if (requester.isAdmin) return;
 
-  // Non-admin: must be an approver of THIS request's collection. An
+  // Non-admin: must approve the collection THIS request's object lives in. An
   // object-less request (`export`) has no collection to derive a roster from,
   // so it stays administrator-only.
   const objectId = request.objectId;
-  if (!objectId) throw ErrorFactories.authzAdminRequired(operation);
-  const [obj] = await executeQuery(
-    (db) =>
-      db
-        .select({ collectionId: contentObjects.collectionId })
-        .from(contentObjects)
-        .where(eq(contentObjects.id, objectId))
-        .limit(1),
-    "atrium.approvals.loadRequestCollection"
-  );
+  const [obj] = objectId
+    ? await executeQuery(
+        (db) =>
+          db
+            .select({ collectionId: contentObjects.collectionId })
+            .from(contentObjects)
+            .where(eq(contentObjects.id, objectId))
+            .limit(1),
+        "atrium.approvals.loadRequestCollection"
+      )
+    : [undefined];
+
   const allowed = await approvableCollectionIds(requester);
-  if (
-    allowed == null ||
-    !obj?.collectionId ||
-    !allowed.has(obj.collectionId)
-  ) {
-    throw ErrorFactories.authzAdminRequired(operation);
+  if (allowed == null || !obj?.collectionId || !allowed.has(obj.collectionId)) {
+    // Deliberately the NOT-FOUND error, not a forbidden one — see the docblock.
+    throw ErrorFactories.dbRecordNotFound("content_publish_requests", id);
   }
-  return requester;
 }
 
 /**
@@ -436,15 +464,18 @@ export async function approvePublishRequestAction(
       id,
       hasNote: Boolean(note),
     });
-    // Load BEFORE the authorization check: who may decide depends on which
-    // collection the request's object sits in, so the row is an input to the
-    // gate rather than something read after passing it.
-    const request = await loadRequest(id);
-    const requester = await requireDeciderFor(
-      request,
+    // Coarse gate FIRST, so a caller who can decide nothing is rejected without
+    // the row load ever happening — otherwise "bad id" and "real id I may not
+    // touch" answer differently and become an enumeration oracle.
+    const requester = await requireEligibleDecider(
       requestId,
       "approvePublishRequest"
     );
+    // Then the row, then the precise per-request check: who may decide depends
+    // on which collection the object sits in, so the row is an INPUT to that
+    // gate rather than something read after passing it.
+    const request = await loadRequest(id);
+    await assertMayDecide(requester, request, id);
 
     if (request.status !== "pending") {
       throw ErrorFactories.invalidInput(
@@ -551,14 +582,13 @@ export async function denyPublishRequestAction(
 
   try {
     log.info("Action started: deny publish request", { id });
-    // Loaded before the gate for the same reason as approve: the decider set
-    // is derived from the request's collection.
-    const request = await loadRequest(id);
-    const requester = await requireDeciderFor(
-      request,
+    // Same ordering as approve, for the same reason — see there.
+    const requester = await requireEligibleDecider(
       requestId,
       "denyPublishRequest"
     );
+    const request = await loadRequest(id);
+    await assertMayDecide(requester, request, id);
 
     if (!note?.trim()) {
       throw ErrorFactories.missingRequiredField("note");

--- a/actions/db/atrium/approvals.ts
+++ b/actions/db/atrium/approvals.ts
@@ -30,7 +30,7 @@
  * `pending` so the decision can be retried later.
  */
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import {
   createLogger,
   generateRequestId,
@@ -55,6 +55,10 @@ import { visibilityService } from "@/lib/content/visibility-service";
 import { isPublishDestination } from "@/lib/content/validators";
 import type { PublishDestination } from "@/lib/content/publish-adapters/types";
 import type { Requester } from "@/lib/content/types";
+import {
+  collectionAccessSnapshot,
+  isCollectionApprover,
+} from "@/lib/content/collection-access";
 import type { ActionState } from "@/types";
 import { getUserRequester } from "./requester";
 
@@ -76,16 +80,78 @@ export interface PendingApprovalDTO {
 type AdminRequester = Extract<Requester, { kind: "user" }>;
 
 /**
- * Resolve the session into an admin `user` Requester or throw. The requester is
- * returned (not just checked) because approve REPLAYS the blocked action AS
- * this admin — the same object that gates the action authorizes the replay.
+ * The set of collection ids this requester may approve publishes out of, or
+ * `null` for an administrator (who may approve anything).
+ *
+ * Migration 178 made the approver roster per-collection and configurable — a
+ * section can name its own approvers by role, group, or person — so the queue
+ * is no longer an admin-only surface. A department's SOP owner should clear
+ * their own section's queue without district admin involvement.
  */
-async function requireAdminRequester(
+async function approvableCollectionIds(
+  req: Requester
+): Promise<Set<string> | null> {
+  if (req.kind === "user" && req.isAdmin) return null;
+  const access = await collectionAccessSnapshot(req);
+  const ids = new Set<string>();
+  for (const collection of access.collections) {
+    if (!collection.requiresApproval) continue;
+    if (isCollectionApprover(req, collection, access)) ids.add(collection.id);
+  }
+  return ids;
+}
+
+/**
+ * Resolve the session into someone allowed to DECIDE this specific request:
+ * a district administrator, or an approver of the collection the request's
+ * object lives in.
+ *
+ * Also enforces segregation of duties — nobody decides their own request, not
+ * even an administrator. This cannot strand a request: the person who raised it
+ * was, by definition, not an approver at raise time (an approver's publish is
+ * never queued), so someone else always exists who can act on it.
+ */
+async function requireDeciderFor(
+  request: ContentPublishRequestRow,
   requestId: string,
   operation: string
 ): Promise<AdminRequester> {
   const requester = await getUserRequester(requestId);
-  if (requester.kind !== "user" || !requester.isAdmin) {
+  if (requester.kind !== "user") {
+    throw ErrorFactories.authzAdminRequired(operation);
+  }
+
+  if (
+    request.requestedByUserId != null &&
+    request.requestedByUserId === requester.userId
+  ) {
+    throw ErrorFactories.authzToolAccessDenied(
+      "Approving your own request is not permitted — another approver must review it"
+    );
+  }
+
+  if (requester.isAdmin) return requester;
+
+  // Non-admin: must be an approver of THIS request's collection. An
+  // object-less request (`export`) has no collection to derive a roster from,
+  // so it stays administrator-only.
+  const objectId = request.objectId;
+  if (!objectId) throw ErrorFactories.authzAdminRequired(operation);
+  const [obj] = await executeQuery(
+    (db) =>
+      db
+        .select({ collectionId: contentObjects.collectionId })
+        .from(contentObjects)
+        .where(eq(contentObjects.id, objectId))
+        .limit(1),
+    "atrium.approvals.loadRequestCollection"
+  );
+  const allowed = await approvableCollectionIds(requester);
+  if (
+    allowed == null ||
+    !obj?.collectionId ||
+    !allowed.has(obj.collectionId)
+  ) {
     throw ErrorFactories.authzAdminRequired(operation);
   }
   return requester;
@@ -238,6 +304,31 @@ async function loadRequest(id: string): Promise<ContentPublishRequestRow> {
  * List the pending §26.4 approval queue (admin only), newest first, with the
  * object's title/slug and the requesting user's email joined in for display.
  */
+/**
+ * Whether the caller approves publishes for at least one collection — the
+ * entry check for /admin/atrium's non-admin path.
+ *
+ * Returns a boolean rather than throwing so the page can 404 (mask the
+ * surface's existence) instead of surfacing an authorization error.
+ */
+export async function isCollectionApproverAction(): Promise<
+  ActionState<boolean>
+> {
+  const requestId = generateRequestId();
+  try {
+    const requester = await getUserRequester(requestId);
+    const approvable = await approvableCollectionIds(requester);
+    // `null` = administrator (approves everything).
+    return createSuccess(approvable == null || approvable.size > 0, "Checked");
+  } catch (error) {
+    return handleError(error, "Failed to check approver status", {
+      context: "isCollectionApproverAction",
+      requestId,
+      operation: "isCollectionApproverAction",
+    });
+  }
+}
+
 export async function listPendingApprovalsAction(): Promise<
   ActionState<PendingApprovalDTO[]>
 > {
@@ -246,7 +337,16 @@ export async function listPendingApprovalsAction(): Promise<
   const log = createLogger({ requestId, action: "listPendingApprovalsAction" });
 
   try {
-    await requireAdminRequester(requestId, "listPendingApprovals");
+    // Admins see the whole queue; a collection approver sees only the requests
+    // they can actually act on. `null` means "no restriction" (administrator);
+    // an EMPTY set means this caller approves nothing, which must yield an
+    // empty list rather than the unfiltered queue — the difference between the
+    // two is why this is `Set | null` and not a bare set.
+    const viewer = await getUserRequester(requestId);
+    const approvable = await approvableCollectionIds(viewer);
+    if (approvable != null && approvable.size === 0) {
+      throw ErrorFactories.authzAdminRequired("listPendingApprovals");
+    }
 
     const rows = await executeQuery(
       (db) =>
@@ -273,7 +373,17 @@ export async function listPendingApprovalsAction(): Promise<
             users,
             eq(contentPublishRequests.requestedByUserId, users.id)
           )
-          .where(eq(contentPublishRequests.status, "pending"))
+          .where(
+            approvable == null
+              ? eq(contentPublishRequests.status, "pending")
+              : and(
+                  eq(contentPublishRequests.status, "pending"),
+                  // Non-admin approvers see only their own sections' requests.
+                  // Object-less (`export`) rows have no collection and so are
+                  // excluded here — they stay administrator-only.
+                  inArray(contentObjects.collectionId, [...approvable])
+                )
+          )
           .orderBy(desc(contentPublishRequests.createdAt)),
       "atrium.approvals.listPending"
     );
@@ -326,12 +436,16 @@ export async function approvePublishRequestAction(
       id,
       hasNote: Boolean(note),
     });
-    const requester = await requireAdminRequester(
+    // Load BEFORE the authorization check: who may decide depends on which
+    // collection the request's object sits in, so the row is an input to the
+    // gate rather than something read after passing it.
+    const request = await loadRequest(id);
+    const requester = await requireDeciderFor(
+      request,
       requestId,
       "approvePublishRequest"
     );
 
-    const request = await loadRequest(id);
     if (request.status !== "pending") {
       throw ErrorFactories.invalidInput(
         "id",
@@ -437,7 +551,11 @@ export async function denyPublishRequestAction(
 
   try {
     log.info("Action started: deny publish request", { id });
-    const requester = await requireAdminRequester(
+    // Loaded before the gate for the same reason as approve: the decider set
+    // is derived from the request's collection.
+    const request = await loadRequest(id);
+    const requester = await requireDeciderFor(
+      request,
       requestId,
       "denyPublishRequest"
     );
@@ -446,7 +564,6 @@ export async function denyPublishRequestAction(
       throw ErrorFactories.missingRequiredField("note");
     }
 
-    const request = await loadRequest(id);
     if (request.status !== "pending") {
       throw ErrorFactories.invalidInput(
         "id",

--- a/actions/db/atrium/collection-hero.ts
+++ b/actions/db/atrium/collection-hero.ts
@@ -10,11 +10,17 @@
  * a section they contribute to — the same rule that already governs the
  * section description. A personal collection's owner may set them on their own.
  *
- * The image bytes are stored BEFORE the update call, so a rejected update
- * leaves an orphaned object rather than a collection row pointing at bytes that
- * were never written. Orphans are inert (nothing serves a key no row
- * references) and are reaped by the bucket lifecycle rule; the inverse — a row
- * pointing at a missing key — would render a broken hero on a live page.
+ * Ordering, which matters twice over:
+ *
+ *  1. AUTHORIZE, then spend. `assertMaySetSectionCopy` runs before any S3 write
+ *     or image-generation call. Relying on `update`'s own check afterwards let
+ *     any signed-in account burn storage and paid generation against any
+ *     collectionId; the rejection arrived after the cost.
+ *  2. WRITE the row, then delete the old object. Each hero write uses a new
+ *     key, so the previous object is the live image until the row points at
+ *     its replacement — deleting first would break a live section if the
+ *     update then failed. The reverse leak (a row pointing at bytes that were
+ *     never written) cannot happen, because the store completes first.
  */
 
 import {
@@ -24,6 +30,7 @@ import {
 } from "@/lib/logger";
 import { createSuccess, handleError } from "@/lib/error-utils";
 import { collectionManagementService } from "@/lib/content/collection-management-service";
+import { s3Store } from "@/lib/content/storage/s3-store";
 import {
   generateHeroImage,
   storeHeroImageFromDataUrl,
@@ -67,6 +74,36 @@ function requesterUserId(req: Requester): number {
   );
 }
 
+/**
+ * Delete the hero image a change just superseded.
+ *
+ * Called only AFTER the collection row has been updated, never before. Every
+ * hero write stores a NEW key rather than overwriting, so until the row points
+ * at the replacement the old object is still the live image — deleting first
+ * would leave a broken hero on a live section if the update then failed.
+ *
+ * Best-effort: a failed delete leaks one S3 object, which is strictly better
+ * than failing a change the user already sees as applied. The bucket's
+ * lifecycle rules are storage-class TRANSITIONS and multi-year retention, not
+ * orphan cleanup, so without this every replace and clear would leak
+ * indefinitely.
+ */
+async function deleteSupersededHero(
+  key: string | null,
+  collectionId: string,
+  log: ReturnType<typeof createLogger>
+): Promise<void> {
+  if (!key) return;
+  try {
+    await s3Store.deleteKey(key);
+  } catch (error) {
+    log.warn("Could not delete the superseded hero image", {
+      collectionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 export async function setCollectionHeroImageAction(
   collectionId: string,
   input: {
@@ -95,12 +132,18 @@ export async function setCollectionHeroImageAction(
     const requester = await getUserRequester(requestId);
 
     if (parsed.clear) {
+      const { previousHeroImageKey } =
+        await collectionManagementService.assertMaySetSectionCopy(
+          requester,
+          collectionId
+        );
       // Clearing the key also clears the alt text — see `collectionUpdateValues`.
       const cleared = await collectionManagementService.update(
         requester,
         collectionId,
         { heroImageKey: null }
       );
+      await deleteSupersededHero(previousHeroImageKey, collectionId, log);
       timer({ status: "success" });
       return createSuccess(cleared, "Header image removed");
     }
@@ -113,6 +156,24 @@ export async function setCollectionHeroImageAction(
         "Describe the image for people using a screen reader."
       );
     }
+
+    // AUTHORIZE BEFORE SPENDING ANYTHING.
+    //
+    // The store/generate below writes up to 8MB to S3 or calls a paid image
+    // model. `collectionManagementService.update` further down does enforce
+    // permission — but only AFTER that work has happened, which left any
+    // signed-in account able to burn storage and generation spend against any
+    // collectionId at all, including ones they cannot edit and ones that do not
+    // exist. The rejection came too late to prevent the cost.
+    //
+    // This is a pre-flight, not the authority: `update` still re-asserts
+    // against the FOR-UPDATE-locked row, so a permission revoked in between
+    // still blocks the write.
+    const { previousHeroImageKey } =
+      await collectionManagementService.assertMaySetSectionCopy(
+        requester,
+        collectionId
+      );
 
     const stored = parsed.dataUrl
       ? await storeHeroImageFromDataUrl(collectionId, parsed.dataUrl)
@@ -132,6 +193,7 @@ export async function setCollectionHeroImageAction(
       collectionId,
       { heroImageKey: stored.key, heroImageAlt: alt }
     );
+    await deleteSupersededHero(previousHeroImageKey, collectionId, log);
 
     timer({ status: "success" });
     log.info("Collection hero image set", {

--- a/actions/db/atrium/collection-hero.ts
+++ b/actions/db/atrium/collection-hero.ts
@@ -1,0 +1,150 @@
+"use server"
+
+/**
+ * Atrium collection hero-image server action (migration 178).
+ *
+ * Sets, generates, or clears a section's header image. Authorization is
+ * delegated entirely to `collectionManagementService.update`: the hero fields
+ * are part of the section-editor carve-out, so an administrator may set them on
+ * any district section and a non-admin holding `create` access may set them on
+ * a section they contribute to — the same rule that already governs the
+ * section description. A personal collection's owner may set them on their own.
+ *
+ * The image bytes are stored BEFORE the update call, so a rejected update
+ * leaves an orphaned object rather than a collection row pointing at bytes that
+ * were never written. Orphans are inert (nothing serves a key no row
+ * references) and are reaped by the bucket lifecycle rule; the inverse — a row
+ * pointing at a missing key — would render a broken hero on a live page.
+ */
+
+import {
+  createLogger,
+  generateRequestId,
+  startTimer,
+} from "@/lib/logger";
+import { createSuccess, handleError } from "@/lib/error-utils";
+import { collectionManagementService } from "@/lib/content/collection-management-service";
+import {
+  generateHeroImage,
+  storeHeroImageFromDataUrl,
+} from "@/lib/content/collection-hero-service";
+import { ValidationError } from "@/lib/content/errors";
+import type { CollectionDTO, Requester } from "@/lib/content";
+import type { ActionState } from "@/types";
+import { getUserRequester } from "./requester";
+import { z } from "zod";
+
+const heroInputSchema = z
+  .object({
+    /** A `data:` URL from the file picker. Mutually exclusive with `prompt`. */
+    dataUrl: z.string().min(1).optional(),
+    /** A description to generate from. Mutually exclusive with `dataUrl`. */
+    prompt: z.string().min(1).max(1000).optional(),
+    /** Required whenever an image is being set; ignored when clearing. */
+    alt: z.string().max(300).optional(),
+    /** Remove the current hero image. */
+    clear: z.boolean().optional(),
+  })
+  .refine(
+    (v) =>
+      [v.dataUrl, v.prompt, v.clear ? "clear" : undefined].filter(Boolean)
+        .length === 1,
+    { message: "Provide exactly one of: an uploaded image, a prompt, or clear" }
+  );
+
+/**
+ * The human user id behind a requester, for attributing a generated image.
+ * `getUserRequester` only ever returns the `user` variant, so the other branch
+ * is a contract violation rather than a runtime case to handle gracefully.
+ */
+function requesterUserId(req: Requester): number {
+  // `user` covers the guest shape too, whose id is null — hence the explicit
+  // null check rather than trusting the variant tag alone.
+  if (req.kind === "user" && req.userId != null) return req.userId;
+  if (req.kind === "agent-delegated") return req.actingForUserId;
+  throw new ValidationError(
+    "Generating a header image requires a signed-in person"
+  );
+}
+
+export async function setCollectionHeroImageAction(
+  collectionId: string,
+  input: {
+    dataUrl?: string;
+    prompt?: string;
+    alt?: string;
+    clear?: boolean;
+  }
+): Promise<ActionState<CollectionDTO>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("setCollectionHeroImageAction");
+  const log = createLogger({
+    requestId,
+    action: "setCollectionHeroImageAction",
+  });
+
+  try {
+    const parsed = heroInputSchema.parse(input);
+    // The prompt is user-authored free text describing district content; log
+    // only its shape, never its content.
+    log.info("Action started: set collection hero image", {
+      collectionId,
+      mode: parsed.clear ? "clear" : parsed.prompt ? "generate" : "upload",
+    });
+
+    const requester = await getUserRequester(requestId);
+
+    if (parsed.clear) {
+      // Clearing the key also clears the alt text — see `collectionUpdateValues`.
+      const cleared = await collectionManagementService.update(
+        requester,
+        collectionId,
+        { heroImageKey: null }
+      );
+      timer({ status: "success" });
+      return createSuccess(cleared, "Header image removed");
+    }
+
+    const alt = parsed.alt?.trim() ?? "";
+    if (alt.length === 0) {
+      // Enforced here rather than in the schema so it applies only to the two
+      // set paths — a clear has no image left to describe.
+      throw new ValidationError(
+        "Describe the image for people using a screen reader."
+      );
+    }
+
+    const stored = parsed.dataUrl
+      ? await storeHeroImageFromDataUrl(collectionId, parsed.dataUrl)
+      : await generateHeroImage(
+          collectionId,
+          parsed.prompt as string,
+          // `getUserRequester` resolves a human session, so this is always the
+          // `user` variant. Narrowed explicitly rather than cast: the id is
+          // passed to the generation service as the attributed actor, and an
+          // agent-delegated requester reaching here should be a type error
+          // rather than a silently mis-attributed image.
+          requesterUserId(requester)
+        );
+
+    const updated = await collectionManagementService.update(
+      requester,
+      collectionId,
+      { heroImageKey: stored.key, heroImageAlt: alt }
+    );
+
+    timer({ status: "success" });
+    log.info("Collection hero image set", {
+      collectionId,
+      byteLength: stored.byteLength,
+    });
+    return createSuccess(updated, "Header image updated");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to update the header image", {
+      context: "setCollectionHeroImageAction",
+      requestId,
+      operation: "setCollectionHeroImageAction",
+    });
+  }
+}

--- a/actions/db/atrium/get-visibility.ts
+++ b/actions/db/atrium/get-visibility.ts
@@ -21,6 +21,7 @@ import { createSuccess, handleError } from "@/lib/error-utils";
 import { contentService } from "@/lib/content/content-service";
 import { visibilityService } from "@/lib/content/visibility-service";
 import { canEdit } from "@/lib/content/helpers";
+import { resolveGrantLabels } from "@/lib/content/grant-labels";
 import { hasCapabilityAccess } from "@/utils/roles";
 import { NotFoundError } from "@/lib/content/errors";
 import type { VisibilityGrant, VisibilityLevel } from "@/lib/content/types";
@@ -31,6 +32,15 @@ import { getOptionalRequester } from "./requester";
 export interface VisibilityState {
   visibilityLevel: VisibilityLevel;
   grants: VisibilityGrant[];
+  /**
+   * Display labels for the grants above, keyed `${kind}:${value}`.
+   *
+   * Only `user` grants appear — every other kind already stores readable text.
+   * Empty for non-editors, who receive no grants at all. A grant whose target
+   * no longer exists is simply absent, so the UI falls back rather than
+   * rendering a raw id.
+   */
+  grantLabels: Record<string, string>;
   /** Whether the current requester may change the visibility (owner/admin). */
   canEdit: boolean;
 }
@@ -85,6 +95,10 @@ export async function getVisibilityAction(
     // for a `group` object; load them (cheap, indexed) so the editor can show the
     // prior selection if the level was toggled away from group and back.
     const grants = editable ? await visibilityService.grantsFor(obj.id) : [];
+    // Resolve `user` grants to names for display. Gated on the SAME `editable`
+    // flag as the grants themselves — a non-editor gets neither, so this can
+    // never widen who learns a grantee's identity.
+    const grantLabels = editable ? await resolveGrantLabels(grants) : {};
 
     timer({ status: "success" });
     log.info("Visibility loaded", {
@@ -96,6 +110,7 @@ export async function getVisibilityAction(
       {
         visibilityLevel: obj.visibilityLevel,
         grants,
+        grantLabels,
         canEdit: editable,
       },
       "Visibility loaded"

--- a/actions/db/atrium/list-tags.ts
+++ b/actions/db/atrium/list-tags.ts
@@ -1,0 +1,69 @@
+"use server"
+
+/**
+ * Atrium tag-suggestion server action
+ *
+ * Backs the typeahead under the library's tag box. Tags were effectively
+ * undiscoverable before this: the filter demanded a whole tag, and nothing in
+ * the UI told you which whole tags existed, so the only way to use the control
+ * was to already know the answer.
+ *
+ * Like `listContentAction`, this is NOT capability-gated — and for the same
+ * reason it does not need to be. `visibilityService.listVisibleTags` runs the
+ * suggestion query behind the identical permission-pushed predicates as
+ * `listVisible`, so a caller can only ever be suggested a tag that appears on
+ * an object they could already have listed. A guest sees tags on `public`
+ * content and nothing else.
+ *
+ * See docs/features/atrium-design-spec.md §12.3.
+ */
+
+import {
+  createLogger,
+  generateRequestId,
+  startTimer,
+} from "@/lib/logger";
+import { createSuccess, handleError } from "@/lib/error-utils";
+import { visibilityService } from "@/lib/content";
+import type { ActionState } from "@/types";
+import { getOptionalRequester } from "./requester";
+import { z } from "zod";
+
+const tagQuerySchema = z.object({
+  /**
+   * The partially-typed tag. Empty is legal and returns the first page of
+   * visible tags, which is what the box shows on focus before any typing.
+   */
+  prefix: z.string().max(100).default(""),
+  limit: z.number().int().min(1).max(50).optional(),
+});
+
+export async function listContentTagsAction(
+  input: { prefix?: string; limit?: number } = {}
+): Promise<ActionState<string[]>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("listContentTagsAction");
+  const log = createLogger({ requestId, action: "listContentTagsAction" });
+
+  try {
+    const { prefix, limit } = tagQuerySchema.parse(input);
+    // The prefix itself is user-typed search text and is NOT logged: it is a
+    // fragment of whatever the person is looking for, and the tag corpus
+    // includes personnel and student-support topics.
+    log.info("Action started: list content tags", { prefixLength: prefix.length });
+
+    const requester = await getOptionalRequester(requestId);
+    const tags = await visibilityService.listVisibleTags(requester, prefix, limit);
+
+    timer({ status: "success" });
+    log.info("Content tags listed", { count: tags.length });
+    return createSuccess(tags, "Tags listed");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to list tags", {
+      context: "listContentTagsAction",
+      requestId,
+      operation: "listContentTagsAction",
+    });
+  }
+}

--- a/app/(protected)/admin/atrium/page.tsx
+++ b/app/(protected)/admin/atrium/page.tsx
@@ -1,45 +1,111 @@
+import { notFound } from "next/navigation"
 import { adminPageMetadata } from "../_lib/admin-pages"
-import { requireRole } from "@/lib/auth/role-helpers"
+import { hasRole } from "@/lib/auth/role-helpers"
 import { PageBranding } from "@/components/ui/page-branding"
-import { listPendingApprovalsAction } from "@/actions/db/atrium/approvals"
-import { listContentAuditAction } from "@/actions/db/atrium/audit-log"
+import {
+  listPendingApprovalsAction,
+  isCollectionApproverAction,
+  type PendingApprovalDTO,
+} from "@/actions/db/atrium/approvals"
+import {
+  listContentAuditAction,
+  type ContentAuditPage,
+} from "@/actions/db/atrium/audit-log"
+import type { CollectionDTO } from "@/lib/content"
 import { AtriumAdminTabs } from "@/components/atrium/admin/atrium-admin-tabs"
 import { listManageableCollectionsAction } from "@/actions/db/atrium/collection-management"
 
 /**
- * Atrium oversight (Epic #1059 completion) — the admin surface for the §26.4
- * public-publish approval queue (`content_publish_requests`, migration 096) and
- * the content audit trail (`content_audit_logs`, migration 090). Follows the
- * admin page convention (e.g. /admin/connectors): `requireRole` gate in the
- * server component, initial data fetched here, interactivity in a client child.
+ * Atrium oversight (Epic #1059 completion) — the surface for the publish
+ * approval queue (`content_publish_requests`, migration 096), district
+ * collection management, and the content audit trail (`content_audit_logs`,
+ * migration 090).
+ *
+ * ## Why this is no longer a plain `requireRole("administrator")` page
+ *
+ * Migration 178 made the approver roster per-collection and configurable, so a
+ * department's SOP owner can clear their own section's queue without district
+ * admin involvement. Gating the whole page on the administrator role would
+ * have made that configurability unreachable — there would be a roster and
+ * nowhere for the people on it to act.
+ *
+ * The widening is entry ONLY. A non-admin approver sees the Approvals tab and
+ * nothing else (`isAdmin` is threaded to the tab strip), the queue itself is
+ * filtered to the collections they actually approve, and every decision action
+ * re-checks authority server-side. Collection management and the audit trail
+ * remain administrator-only in both the UI and their own actions.
  */
 export const metadata = adminPageMetadata("/admin/atrium")
 
-export default async function AtriumAdminPage() {
-  await requireRole("administrator")
+/**
+ * Unwrap one panel's `ActionState` into a value + error message.
+ *
+ * `null` means the action was deliberately NOT called (an administrator-only
+ * panel for a collection approver), which is not an error — the tab is not
+ * rendered, so surfacing "failed to load" for it would be a lie.
+ */
+function unwrap<T>(
+  result: { isSuccess: boolean; data?: T; message?: string | null } | null,
+  fallback: T,
+  errorLabel: string
+): { value: T; error: string | null } {
+  if (result == null) return { value: fallback, error: null }
+  if (result.isSuccess) return { value: result.data ?? fallback, error: null }
+  return { value: fallback, error: result.message ?? errorLabel }
+}
 
+/**
+ * Load the three panels' initial data.
+ *
+ * The audit trail and collection management are administrator-only, so for a
+ * collection approver they are not fetched at all rather than fetched and
+ * discarded — their own actions would refuse the call, and issuing it would
+ * mean a guaranteed error round-trip on every page load.
+ *
+ * Extracted from the page component to keep it under the complexity lint.
+ */
+async function loadPanels(isAdmin: boolean) {
   const [approvalsResult, auditResult, collectionsResult] = await Promise.all([
     listPendingApprovalsAction(),
-    listContentAuditAction({}),
-    listManageableCollectionsAction(),
+    isAdmin ? listContentAuditAction({}) : null,
+    isAdmin ? listManageableCollectionsAction() : null,
   ])
 
-  const approvals = approvalsResult.isSuccess ? (approvalsResult.data ?? []) : []
-  const approvalsError = !approvalsResult.isSuccess
-    ? (approvalsResult.message ?? "Failed to load pending approvals")
-    : null
-  const audit = auditResult.isSuccess
-    ? auditResult.data
-    : { rows: [], total: 0, page: 1, pageSize: 50 }
-  const auditError = !auditResult.isSuccess
-    ? (auditResult.message ?? "Failed to load the audit log")
-    : null
-  const collections = collectionsResult.isSuccess
-    ? (collectionsResult.data ?? [])
-    : []
-  const collectionsError = !collectionsResult.isSuccess
-    ? (collectionsResult.message ?? "Failed to load collections")
-    : null
+  const approvals = unwrap(approvalsResult, [] as PendingApprovalDTO[], "Failed to load pending approvals")
+  const audit = unwrap(
+    auditResult,
+    { rows: [], total: 0, page: 1, pageSize: 50 } as ContentAuditPage,
+    "Failed to load the audit log"
+  )
+  const collections = unwrap(collectionsResult, [] as CollectionDTO[], "Failed to load collections")
+
+  return {
+    approvals: approvals.value,
+    approvalsError: approvals.error,
+    audit: audit.value,
+    auditError: audit.error,
+    collections: collections.value,
+    collectionsError: collections.error,
+  }
+}
+
+export default async function AtriumAdminPage() {
+  const isAdmin = await hasRole("administrator")
+  // 404, not 403: a non-approver must not learn this page exists, matching the
+  // existence-masking rule the rest of Atrium follows.
+  if (!isAdmin) {
+    const approverResult = await isCollectionApproverAction()
+    if (!approverResult.isSuccess || !approverResult.data) notFound()
+  }
+
+  const {
+    approvals,
+    approvalsError,
+    audit,
+    auditError,
+    collections,
+    collectionsError,
+  } = await loadPanels(isAdmin)
 
   return (
     <div className="p-6">
@@ -49,8 +115,9 @@ export default async function AtriumAdminPage() {
           Atrium Oversight
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Manage district collections, approve public-publish requests, and
-          review the content audit trail
+          {isAdmin
+            ? "Manage district collections, approve publish requests, and review the content audit trail"
+            : "Approve publish requests for the sections you review"}
         </p>
       </div>
 
@@ -61,6 +128,7 @@ export default async function AtriumAdminPage() {
         auditError={auditError}
         initialCollections={collections}
         collectionsError={collectionsError}
+        isAdmin={isAdmin}
       />
     </div>
   )

--- a/app/(protected)/c/[slug]/page.tsx
+++ b/app/(protected)/c/[slug]/page.tsx
@@ -272,6 +272,12 @@ export default async function ReaderPage({
         editHref={editHref}
         commentHref={editHref}
         commentCount={commentCount}
+        // The chrome-free viewer, reachable in ONE click from here for every
+        // viewer. Previously the only route was Edit → "Open full screen",
+        // which put an editing surface in front of a read-only action and left
+        // non-editors with no route at all. `/atrium/[id]/view` re-runs its own
+        // `canView` server-side, so this link grants nothing.
+        fullScreenHref={`/atrium/${published.id}/view`}
         publishedAt={published.publishedAt}
         collectionName={published.collectionName}
         // Artifact readers skip the TOC (no document headings to walk).

--- a/app/api/atrium/collections/[id]/hero/route.ts
+++ b/app/api/atrium/collections/[id]/hero/route.ts
@@ -17,12 +17,9 @@
  */
 
 import { NextRequest } from "next/server";
-import { eq } from "drizzle-orm";
 import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
-import { executeQuery } from "@/lib/db/drizzle-client";
-import { contentCollections } from "@/lib/db/schema";
 import { s3Store } from "@/lib/content/storage/s3-store";
-import { requesterMayViewCollection } from "@/lib/content/collection-access";
+import { collectionAccessSnapshot } from "@/lib/content/collection-access";
 import { getOptionalRequester } from "@/actions/db/atrium/requester";
 import { MAX_HERO_IMAGE_BYTES } from "@/lib/content/collection-hero-service";
 
@@ -50,36 +47,37 @@ export async function GET(
   try {
     const requester = await getOptionalRequester(requestId);
 
+    // ONE snapshot answers both questions. It already carries every collection
+    // row (including `heroImageKey`), so the access check and the key lookup
+    // come from the same read rather than a permission call followed by a
+    // second query for a column we were already holding — this is the hot path
+    // for every section landing page.
+    //
+    // Taking the key from the snapshot rather than the request is also what
+    // keeps this route from being an arbitrary S3 read primitive.
+    const access = await collectionAccessSnapshot(requester);
+    const collection = access.byId.get(id);
+
     // Existence masking: a collection the caller may not enter is reported the
     // same as one that does not exist, matching every other Atrium read path.
-    if (!(await requesterMayViewCollection(requester, id))) {
+    if (!collection || !access.allowedCollectionIds.has(id)) {
       timer({ status: "error", reason: "forbidden" });
       return new Response("Not Found", { status: 404 });
     }
-
-    const [row] = await executeQuery(
-      (db) =>
-        db
-          .select({ heroImageKey: contentCollections.heroImageKey })
-          .from(contentCollections)
-          .where(eq(contentCollections.id, id))
-          .limit(1),
-      "atrium.collectionHero.loadKey"
-    );
-    if (!row?.heroImageKey) {
+    if (!collection.heroImageKey) {
       timer({ status: "success", reason: "no-image" });
       return new Response("Not Found", { status: 404 });
     }
 
     const bytes = await s3Store.getBytesBounded(
-      row.heroImageKey,
+      collection.heroImageKey,
       MAX_HERO_IMAGE_BYTES
     );
 
     timer({ status: "success" });
     return new Response(Buffer.from(bytes), {
       headers: {
-        "Content-Type": contentTypeFor(row.heroImageKey),
+        "Content-Type": contentTypeFor(collection.heroImageKey),
         "Content-Length": String(bytes.byteLength),
         // PRIVATE, not public: a personal collection's artwork must never be
         // cached by a shared proxy where the next viewer's access check is

--- a/app/api/atrium/collections/[id]/hero/route.ts
+++ b/app/api/atrium/collections/[id]/hero/route.ts
@@ -1,0 +1,103 @@
+/**
+ * Atrium collection hero image (migration 178).
+ *
+ * `GET /api/atrium/collections/{id}/hero` — streams the section's header image.
+ *
+ * ## Why this is not `/api/images/[...key]`
+ *
+ * That route serves AI-generated CHAT images and authorizes them by validating
+ * the caller owns the conversation embedded in the S3 key. A collection has no
+ * conversation, so every hero would 404 there. Access to a section's artwork is
+ * a collection question, so it is answered by the collection-access snapshot —
+ * the same predicate that decides whether the section appears in the sidebar.
+ *
+ * The KEY is never accepted from the caller: it is read from the collection row
+ * after the access check. A client-supplied key would make this an arbitrary
+ * S3-read primitive scoped only by whatever prefix validation it happened to do.
+ */
+
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import { contentCollections } from "@/lib/db/schema";
+import { s3Store } from "@/lib/content/storage/s3-store";
+import { requesterMayViewCollection } from "@/lib/content/collection-access";
+import { getOptionalRequester } from "@/actions/db/atrium/requester";
+import { MAX_HERO_IMAGE_BYTES } from "@/lib/content/collection-hero-service";
+
+/** S3 reads need the Node runtime; the app's default is fine but be explicit. */
+export const runtime = "nodejs";
+
+/** Guess the response content type from the stored key's extension. */
+function contentTypeFor(key: string): string {
+  if (key.endsWith(".png")) return "image/png";
+  if (key.endsWith(".jpg") || key.endsWith(".jpeg")) return "image/jpeg";
+  if (key.endsWith(".webp")) return "image/webp";
+  if (key.endsWith(".gif")) return "image/gif";
+  return "application/octet-stream";
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const requestId = generateRequestId();
+  const timer = startTimer("api.atrium.collectionHero");
+  const log = createLogger({ requestId, route: "api.atrium.collectionHero" });
+  const { id } = await params;
+
+  try {
+    const requester = await getOptionalRequester(requestId);
+
+    // Existence masking: a collection the caller may not enter is reported the
+    // same as one that does not exist, matching every other Atrium read path.
+    if (!(await requesterMayViewCollection(requester, id))) {
+      timer({ status: "error", reason: "forbidden" });
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const [row] = await executeQuery(
+      (db) =>
+        db
+          .select({ heroImageKey: contentCollections.heroImageKey })
+          .from(contentCollections)
+          .where(eq(contentCollections.id, id))
+          .limit(1),
+      "atrium.collectionHero.loadKey"
+    );
+    if (!row?.heroImageKey) {
+      timer({ status: "success", reason: "no-image" });
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const bytes = await s3Store.getBytesBounded(
+      row.heroImageKey,
+      MAX_HERO_IMAGE_BYTES
+    );
+
+    timer({ status: "success" });
+    return new Response(Buffer.from(bytes), {
+      headers: {
+        "Content-Type": contentTypeFor(row.heroImageKey),
+        "Content-Length": String(bytes.byteLength),
+        // PRIVATE, not public: a personal collection's artwork must never be
+        // cached by a shared proxy where the next viewer's access check is
+        // skipped. `immutable` is safe because replacing a hero writes a NEW
+        // key rather than overwriting this one.
+        "Cache-Control": "private, max-age=3600, immutable",
+        // The bytes are user-supplied; never let a browser re-interpret them as
+        // markup regardless of what the extension claims.
+        "X-Content-Type-Options": "nosniff",
+        "Content-Disposition": "inline",
+      },
+    });
+  } catch (error) {
+    timer({ status: "error" });
+    log.error("Failed to serve collection hero image", {
+      collectionId: id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return new Response("Not Found", { status: 404 });
+  }
+}

--- a/components/atrium/CollectionManagementPanel.tsx
+++ b/components/atrium/CollectionManagementPanel.tsx
@@ -41,6 +41,7 @@ interface EditorState {
   defaultVisibilityLevel: VisibilityLevel;
   inheritGrants: boolean;
   grants: CollectionGrant[];
+  requiresApproval: boolean;
 }
 
 const EMPTY_EDITOR: EditorState = {
@@ -51,6 +52,7 @@ const EMPTY_EDITOR: EditorState = {
   defaultVisibilityLevel: "internal",
   inheritGrants: true,
   grants: [],
+  requiresApproval: false,
 };
 
 function editorFor(row: CollectionDTO): EditorState {
@@ -62,6 +64,7 @@ function editorFor(row: CollectionDTO): EditorState {
     defaultVisibilityLevel: row.defaultVisibilityLevel,
     inheritGrants: row.inheritGrants,
     grants: row.grants,
+    requiresApproval: row.requiresApproval,
   };
 }
 
@@ -159,6 +162,11 @@ function GrantEditor({
             >
               <option value="view">View</option>
               <option value="create">Create</option>
+              {/* Only meaningful on a collection with "Require approval"
+                  switched on; harmless (and forward-looking) elsewhere, since
+                  an `approve` grant confers no view or create access on its
+                  own — `effectiveGrantResolver` matches on exact access. */}
+              <option value="approve">Approve</option>
             </select>
             <select
               aria-label={`Grant ${index + 1} kind`}
@@ -407,6 +415,93 @@ function DistrictCollectionOptions({
         disabled={readOnly}
         onChange={(grants) => onChange({ ...editor, grants })}
       />
+      {/*
+        Per-collection publish review (migration 178). Deliberately a
+        per-section OPT-IN, not a policy change: publishing stays immediate
+        everywhere it is today, and only the sections where review is the point
+        — the staff intranet, SOPs — route through the approval queue.
+
+        Approvers are the collection owner, district admins, and anyone holding
+        an `approve` grant above, so a gated section can never end up with
+        nobody able to clear its queue.
+      */}
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="district-requires-approval"
+          checked={editor.requiresApproval}
+          disabled={readOnly}
+          onCheckedChange={(checked) =>
+            onChange({ ...editor, requiresApproval: checked === true })
+          }
+        />
+        <Label htmlFor="district-requires-approval">
+          Require approval before publishing from this collection
+        </Label>
+      </div>
+    </>
+  );
+}
+
+/**
+ * Sharing controls for a PERSONAL collection (migration 178).
+ *
+ * Personal collections could always be created and nested, but never shared —
+ * so "here is the collection I built for this project, have a look" was not
+ * expressible, and the workaround was to re-share every document in it one at
+ * a time.
+ *
+ * Only two levels are offered. `internal`/`public` are absent by construction
+ * rather than disabled: a collection meant for everyone is a district section,
+ * which belongs in the governed hierarchy. The service and a DB CHECK both
+ * refuse the wider values regardless of what this form sends.
+ */
+function PrivateCollectionOptions({
+  editor,
+  grantOptions,
+  onChange,
+}: {
+  editor: EditorState;
+  grantOptions: GrantOptions;
+  onChange: (editor: EditorState) => void;
+}): React.JSX.Element {
+  const shared = editor.defaultVisibilityLevel === "group";
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="private-shared"
+          checked={shared}
+          onCheckedChange={(checked) =>
+            onChange({
+              ...editor,
+              defaultVisibilityLevel: checked === true ? "group" : "private",
+              // Dropping back to private discards the roster rather than
+              // keeping invisible grants that would silently reactivate if the
+              // box were ticked again.
+              grants: checked === true ? editor.grants : [],
+            })
+          }
+        />
+        <Label htmlFor="private-shared">Share this collection with specific people</Label>
+      </div>
+      {shared ? (
+        <>
+          <p className="text-xs text-muted-foreground">
+            Only the people you add below can open this collection. They cannot
+            re-share it — you stay the only person who can change this list.
+          </p>
+          <GrantEditor
+            grants={editor.grants}
+            options={grantOptions}
+            disabled={false}
+            onChange={(grants) => onChange({ ...editor, grants })}
+          />
+        </>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          This collection and its contents are visible only to you.
+        </p>
+      )}
     </>
   );
 }
@@ -465,9 +560,11 @@ function CollectionEditor({
           onChange={onChange}
         />
       ) : (
-        <p className="text-xs text-muted-foreground">
-          Private collections and their contents are visible only to you.
-        </p>
+        <PrivateCollectionOptions
+          editor={editor}
+          grantOptions={grantOptions}
+          onChange={onChange}
+        />
       )}
       {error ? (
         <p className="text-sm text-destructive" role="alert">
@@ -508,6 +605,36 @@ function CollectionEditor({
   );
 }
 
+/**
+ * The role/group options the grant editor offers.
+ *
+ * Loaded in BOTH modes. It used to be admin-only, which was correct while
+ * grants existed only on district collections — but migration 178 let an owner
+ * share a personal collection, so the private-mode grant editor needs the same
+ * options. Without them its role and group pickers render empty and sharing
+ * silently cannot be configured.
+ *
+ * The action is itself capability-gated, so a caller who may not enumerate
+ * options gets an empty list rather than a widened one.
+ */
+function useGrantOptions(): GrantOptions {
+  const [options, setOptions] = useState<GrantOptions>({
+    roles: [],
+    groups: [],
+  });
+  useEffect(() => {
+    let cancelled = false;
+    void listGrantOptionsAction().then((result) => {
+      if (cancelled) return;
+      if (result.isSuccess && result.data) setOptions(result.data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return options;
+}
+
 export function CollectionManagementPanel({
   mode,
   initialCollections = [],
@@ -515,10 +642,7 @@ export function CollectionManagementPanel({
 }: CollectionManagementPanelProps): React.JSX.Element {
   const [collections, setCollections] = useState(initialCollections);
   const [editor, setEditor] = useState<EditorState>(EMPTY_EDITOR);
-  const [grantOptions, setGrantOptions] = useState<GrantOptions>({
-    roles: [],
-    groups: [],
-  });
+  const grantOptions = useGrantOptions();
   const [error, setError] = useState<string | null>(initialError);
   const [notice, setNotice] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -588,11 +712,6 @@ export function CollectionManagementPanel({
 
   useEffect(() => {
     if (initialCollections.length === 0) refresh();
-    if (mode === "admin") {
-      void listGrantOptionsAction().then((result) => {
-        if (result.isSuccess && result.data) setGrantOptions(result.data);
-      });
-    }
     // Initial props are deliberately a one-time server snapshot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);
@@ -618,7 +737,14 @@ export function CollectionManagementPanel({
                   defaultVisibilityLevel: editor.defaultVisibilityLevel,
                   inheritGrants: editor.inheritGrants,
                   grants: editor.grants,
+                  requiresApproval: editor.requiresApproval,
                 }
+              : {}),
+            // A personal collection's owner sets its sharing. `inheritGrants` is
+            // never sent — pinned false for private trees by both the service
+            // and the DB check, so sending it only invites a violation.
+            ...(mode === "private"
+              ? { defaultVisibilityLevel: editor.defaultVisibilityLevel, grants: editor.grants }
               : {}),
           })
         : await createCollectionAction({
@@ -632,7 +758,18 @@ export function CollectionManagementPanel({
                   inheritGrants: editor.inheritGrants,
                   grants: editor.grants,
                 }
-              : {}),
+              : {
+                  // A personal collection may be created already shared, but
+                  // never wider than `group`. `EMPTY_EDITOR` seeds the
+                  // district default of `internal`, which the service would
+                  // (correctly) refuse for this scope — so normalize here
+                  // rather than sending a value that can only fail.
+                  defaultVisibilityLevel:
+                    editor.defaultVisibilityLevel === "group"
+                      ? "group"
+                      : "private",
+                  grants: editor.grants,
+                }),
           });
       if (!result.isSuccess || !result.data) {
         setError(result.message ?? "Failed to save collection");

--- a/components/atrium/LibraryBulkBar.tsx
+++ b/components/atrium/LibraryBulkBar.tsx
@@ -21,7 +21,14 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Archive, ArchiveRestore, FolderInput, Trash2, X } from "lucide-react";
+import {
+  Archive,
+  ArchiveRestore,
+  FolderInput,
+  Globe,
+  Trash2,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -32,6 +39,7 @@ import {
 } from "@/components/ui/select";
 import { updateContentAction } from "@/actions/db/atrium/update-content";
 import { deleteContentAction } from "@/actions/db/atrium/delete-content";
+import { publishDocumentAction } from "@/actions/db/atrium/publish-document";
 import { collectionTreeAction } from "@/actions/db/atrium/collection-tree";
 import { meridianPortalClassName } from "@/lib/meridian/fonts";
 import {
@@ -88,6 +96,7 @@ function BulkControls({
   onArchive,
   onRestore,
   onMove,
+  onPublish,
   onDelete,
   onClear,
 }: {
@@ -98,6 +107,7 @@ function BulkControls({
   onArchive: () => void;
   onRestore: () => void;
   onMove: (value: string) => void;
+  onPublish: () => void;
   onDelete: () => void;
   onClear: () => void;
 }): React.JSX.Element {
@@ -130,6 +140,22 @@ function BulkControls({
         >
           <Archive className="h-4 w-4" aria-hidden="true" />
           Archive
+        </Button>
+      )}
+
+      {/* Publishing an ARCHIVED object is incoherent (archiving retracts its
+          publications), so this is offered only in the working views. */}
+      {!archivedView && (
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          disabled={busy}
+          onClick={onPublish}
+          data-testid="bulk-publish"
+        >
+          <Globe className="h-4 w-4" aria-hidden="true" />
+          Publish to intranet
         </Button>
       )}
 
@@ -257,6 +283,46 @@ export function LibraryBulkBar({
     [run]
   );
 
+  /**
+   * Bulk publish to the internal reader.
+   *
+   * The motivating case: a whole section authored as drafts (the staff
+   * intranet, the SOP set) has to go live at once. One-at-a-time publishing
+   * through each object's Share dialog is the only route that existed, which
+   * for a 48-page section is 48 round trips through a modal.
+   *
+   * `widenOnly: true` is what makes this safe to fan out over a mixed
+   * selection. Publishing to the intranet requires `internal` visibility, but
+   * assignment semantics would NARROW anything already public down to
+   * internal. As a widen OFFER it is applied only where it actually broadens
+   * the object's locked audience, and skipped everywhere else — so a public
+   * page in the selection stays public.
+   *
+   * Still a per-object server call, so every visibility and permission gate
+   * runs unchanged; an object the user may not publish fails on its own and is
+   * reported in the aggregate line rather than failing the batch.
+   */
+  const publish = useCallback(() => {
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        `Publish ${count} ${count === 1 ? "item" : "items"} to the staff intranet?\n\n` +
+          "Anything not already visible to staff will be widened to Internal so " +
+          "it can be read there. Items that are already more widely published " +
+          "keep their current audience. Items you cannot publish are skipped and " +
+          "reported."
+      )
+    ) {
+      return;
+    }
+    void run("Published", (id) =>
+      publishDocumentAction(id, {
+        destination: "intranet",
+        visibility: { level: "internal", widenOnly: true },
+      })
+    );
+  }, [count, run]);
+
   const remove = useCallback(() => {
     if (
       typeof window !== "undefined" &&
@@ -290,6 +356,7 @@ export function LibraryBulkBar({
           onArchive={() => void setStatus("archived", "Archived")}
           onRestore={() => void setStatus("draft", "Restored")}
           onMove={(v) => void move(v)}
+          onPublish={publish}
           onDelete={remove}
           onClear={onClear}
         />

--- a/components/atrium/LibraryList.tsx
+++ b/components/atrium/LibraryList.tsx
@@ -24,6 +24,7 @@ import {
   ArrowUpRight,
   Archive,
   SearchX,
+  Maximize2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { timeAgo } from "@/lib/atrium/relative-time";
@@ -33,15 +34,31 @@ import { TagPills } from "./TagPills";
 import { FavoriteStar } from "./FavoriteStar";
 
 /** Meridian status pill class for a content object's lifecycle status. */
-function statusBadge(status: ContentObjectDTO["status"]): {
+function statusBadge(
+  status: ContentObjectDTO["status"],
+  /**
+   * A publish request for this object is sitting in the approval queue. It
+   * OVERRIDES the lifecycle label because it is the more actionable fact: the
+   * object is still technically a draft, but nobody should keep editing it or
+   * wonder why it has not gone live — it is waiting on a person.
+   */
+  pendingReview = false
+): {
   cls: string;
   label: string;
 } {
+  if (pendingReview && status !== "archived") {
+    return { cls: "mer-badge-review", label: "In review" };
+  }
   switch (status) {
     case "published":
       return { cls: "mer-badge-published", label: "Published" };
+    // Archived has its OWN pill now. It used to borrow the draft style, so the
+    // two states that behave most differently — one still being worked on, one
+    // deliberately put away — were the same grey and could only be told apart
+    // by reading the word.
     case "archived":
-      return { cls: "mer-badge-draft", label: "Archived" };
+      return { cls: "mer-badge-archived", label: "Archived" };
     default:
       return { cls: "mer-badge-draft", label: "Draft" };
   }
@@ -71,8 +88,81 @@ function cardMeta(it: ContentObjectDTO): string {
   return edited ? `${who} · edited ${edited}` : who;
 }
 
+/**
+ * The audience line on a card: who, roughly, can see this.
+ *
+ * The catalogue showed lifecycle (draft/published) but never AUDIENCE, so
+ * "which of these is actually shared, and how widely?" — the question that
+ * matters most when auditing a district-wide library — could only be answered
+ * by opening each item's Share dialog one at a time.
+ *
+ * A COUNT, never names. The grant roster is editor-only (see
+ * `getVisibilityAction`); printing it on a card would show every grantee the
+ * whole roster. "Shared · 3" answers the question without identifying anyone,
+ * and only reaches viewers who can already see the object.
+ */
+function AudienceLabel({ it }: { it: ContentObjectDTO }): React.JSX.Element | null {
+  const label = ((): string | null => {
+    switch (it.visibilityLevel) {
+      case "public":
+        return "Public";
+      case "internal":
+        return "All staff";
+      case "group":
+        // A group-level object with zero grants is reachable by nobody but its
+        // owner — a real and confusing state worth naming rather than
+        // rendering as a bare "Shared · 0".
+        return it.grantCount > 0
+          ? `Shared · ${it.grantCount}`
+          : "Shared with nobody yet";
+      case "private":
+        return "Private";
+      default:
+        return null;
+    }
+  })();
+  if (!label) return null;
+  return (
+    <p className="mer-lib-card-audience" data-testid="card-audience">
+      {label}
+    </p>
+  );
+}
+
+/**
+ * One-click full screen for an artifact card.
+ *
+ * Full screen already existed at `/atrium/[id]/view` but was linked from
+ * exactly one place: the authoring topbar. Reaching it from the library meant
+ * opening the artifact, clicking Edit, then "Open full screen" — three steps
+ * through an EDITING surface to do the most common read-only thing anyone does
+ * with an artifact.
+ *
+ * A SIBLING of the card's `<Link>`, never a descendant: an anchor inside an
+ * anchor is invalid HTML, and the click would also trigger the card's own
+ * navigation. Same rule the selection checkbox and favourite star follow.
+ *
+ * Deliberately not `target="_blank"`: the authoring topbar opens a new tab
+ * because you are working in the editor and want to keep it, but from the
+ * library this is just "look at this thing", and back should return to the
+ * grid.
+ */
+function FullScreenLink({ it }: { it: ContentObjectDTO }): React.JSX.Element {
+  return (
+    <Link
+      href={`/atrium/${it.id}/view`}
+      className="mer-lib-card-fullscreen"
+      aria-label={`Open ${it.title} full screen`}
+      title="Open full screen"
+      data-testid={`card-fullscreen-${it.id}`}
+    >
+      <Maximize2 className="h-3.5 w-3.5" aria-hidden="true" />
+    </Link>
+  );
+}
+
 function DocCard({ it }: { it: ContentObjectDTO }): React.JSX.Element {
-  const status = statusBadge(it.status);
+  const status = statusBadge(it.status, it.pendingReview);
   const isAgent = it.createdByActor === "agent";
   const isArchived = it.status === "archived";
   return (
@@ -115,6 +205,7 @@ function DocCard({ it }: { it: ContentObjectDTO }): React.JSX.Element {
           {it.ownerName}
         </p>
       )}
+      <AudienceLabel it={it} />
       <TagPills tags={it.tags} />
     </Link>
   );
@@ -129,6 +220,7 @@ function ArtifactCard({
 }): React.JSX.Element {
   const isAgent = it.createdByActor === "agent";
   const isArchived = it.status === "archived";
+  const status = statusBadge(it.status, it.pendingReview);
   return (
     <Link
       href={cardHref(it)}
@@ -144,11 +236,18 @@ function ArtifactCard({
           in the accessibility tree). */}
       <div className="mer-artifact-preview-wrap">
         <ArtifactThumbnail artifactId={it.id} sandboxSrc={sandboxSrc} />
-        {isArchived && (
-          <span className="mer-badge mer-badge-draft mer-artifact-archived-badge">
-            Archived
-          </span>
-        )}
+        {/*
+          Artifact cards carried NO lifecycle pill — only an Archived overlay —
+          so a published artifact and an unpublished draft were
+          indistinguishable in the grid while doc cards showed the difference
+          plainly. Same badge vocabulary as `DocCard`, positioned as an overlay
+          because the thumbnail occupies the card's head slot.
+        */}
+        <span
+          className={cn("mer-badge", status.cls, "mer-artifact-archived-badge")}
+        >
+          {status.label}
+        </span>
       </div>
       <p className="mer-lib-card-title">{it.title}</p>
       {it.ownerName && (
@@ -156,6 +255,7 @@ function ArtifactCard({
           {it.ownerName}
         </p>
       )}
+      <AudienceLabel it={it} />
       <TagPills tags={it.tags} />
       <div className="mer-lib-card-foot">
         <span className="mer-lib-card-meta">
@@ -211,6 +311,7 @@ function SelectableCard({
         initial={it.isFavorite}
         onChange={onFavoriteChange}
       />
+      {it.kind === "artifact" && <FullScreenLink it={it} />}
       {children}
     </div>
   );
@@ -239,7 +340,10 @@ export function ContentCard({
         onChange={onFavoriteChange}
       />
       {it.kind === "artifact" ? (
-        <ArtifactCard it={it} sandboxSrc={sandboxSrc} />
+        <>
+          <FullScreenLink it={it} />
+          <ArtifactCard it={it} sandboxSrc={sandboxSrc} />
+        </>
       ) : (
         <DocCard it={it} />
       )}

--- a/components/atrium/LibraryView.tsx
+++ b/components/atrium/LibraryView.tsx
@@ -28,6 +28,7 @@ import { Search, Plus, Sparkles, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { listContentAction } from "@/actions/db/atrium/list-content";
+import { listContentTagsAction } from "@/actions/db/atrium/list-tags";
 import { createContentAction } from "@/actions/db/atrium/create-content";
 import type { ContentObjectDTO, ContentKind, ListFilter } from "@/lib/content";
 import { ARTIFACT_STARTER_HTML } from "@/lib/content/artifact-starter";
@@ -54,6 +55,7 @@ const VIEWS = [
   { value: "all", label: "All content" },
   { value: "favorites", label: "Favorites" },
   { value: "mine", label: "Mine" },
+  { value: "others", label: "Everyone else" },
   { value: "document", label: "Docs" },
   { value: "artifact", label: "Artifacts" },
   { value: "shared", label: "Shared with me" },
@@ -63,20 +65,64 @@ const VIEWS = [
 
 /**
  * The chips shown by DEFAULT. The full `VIEWS` list is every reachable view, but
- * putting all nine in the bar turned the filter row into a wall of options —
+ * putting all of them in the bar turned the filter row into a wall of options —
  * the same "everything at once" problem the home page exists to fix. The rest
  * stay reachable from the home bands' "see all" links, and a chip for the active
  * view is added back in `LibraryChips` so the bar always shows where you are.
+ *
+ * "Mine" and "Everyone else" are primary despite that budget. An administrator
+ * sees the whole district here, so the unfiltered library is mostly other
+ * people's work and the first question on opening it is always "which of this
+ * is mine?". Leaving the answer off the bar (it was reachable only from a home
+ * band) made the one view that makes the library usable at admin scale the one
+ * view nobody could find.
+ *
+ * Status and creator are deliberately NOT chips — see `LibraryChips`.
  */
 const PRIMARY_VIEWS: readonly LibraryFilterView[] = [
   "home",
   "all",
+  "mine",
+  "others",
   "favorites",
   "document",
   "artifact",
   "shared",
   "archived",
 ];
+
+/**
+ * Lifecycle filter, applied ORTHOGONALLY to the view chips.
+ *
+ * Not a chip: chips are single-select, so a "Published" chip would mean giving
+ * up "Docs" to ask "which docs are published?" — which is the actual question,
+ * and the one the chip row could never answer. "Archived" stays a view chip
+ * rather than joining this control because it is a lifecycle DESTINATION (with
+ * its own restore/delete affordances and its own empty state), not a lens on
+ * the working set.
+ */
+const STATUS_FILTERS = [
+  { value: "any", label: "Any status" },
+  { value: "published", label: "Published" },
+  { value: "draft", label: "Draft" },
+] as const;
+
+type LibraryStatusFilter = (typeof STATUS_FILTERS)[number]["value"];
+
+/**
+ * Creator filter (`content_objects.created_by_actor`), also orthogonal.
+ *
+ * Object-grain, matching the card badge: an agent-created doc later edited by a
+ * human still reads as agent-created. Per-version authorship is a different
+ * question and lives in the provenance footer.
+ */
+const ACTOR_FILTERS = [
+  { value: "any", label: "Anyone" },
+  { value: "human", label: "People" },
+  { value: "agent", label: "Agents" },
+] as const;
+
+type LibraryActorFilter = (typeof ACTOR_FILTERS)[number]["value"];
 
 type LibraryFilterView = (typeof VIEWS)[number]["value"];
 
@@ -263,19 +309,84 @@ function LibraryHeader({
 }
 
 /**
- * The filter chip row: view chips + a debounced tag filter + a "sorted by
- * recent" affordance. Presentational — all state lives in the parent.
+ * Tag suggestions for the tag box's typeahead.
+ *
+ * Server-backed rather than derived from the loaded page: the grid holds only
+ * the current 50-row page, so a client-side distinct would suggest whichever
+ * tags happen to be on screen and silently omit the rest. The action applies
+ * the same visibility predicates as the listing, so a suggestion can never
+ * reveal a tag from content the caller cannot see.
+ *
+ * Failures are swallowed to an empty list on purpose — the typeahead is an
+ * accelerator, and the tag box stays fully usable by typing.
+ */
+function useTagSuggestions(prefix: string): string[] {
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const reqSeqRef = useRef(0);
+
+  useEffect(() => {
+    const reqSeq = ++reqSeqRef.current;
+    let cancelled = false;
+    void (async () => {
+      // Nothing typed yet → no request. The alternative (fetch the first page
+      // of tags on mount so the box has something to show on focus) would put
+      // a query on EVERY library load to serve a control most visits never
+      // touch. One typed character is signal enough, and it is also the point
+      // at which the suggestions get specific enough to be worth reading.
+      //
+      // Inside the IIFE, not synchronously in the effect body: a synchronous
+      // setState in an effect triggers a cascading render (and the lint that
+      // guards against it).
+      if (prefix.trim().length === 0) {
+        if (!cancelled && reqSeq === reqSeqRef.current) setSuggestions([]);
+        return;
+      }
+      try {
+        const res = await listContentTagsAction({ prefix });
+        // Both guards: `cancelled` covers unmount, the sequence check covers a
+        // slow earlier response landing after a newer one (last-request-wins).
+        if (cancelled || reqSeq !== reqSeqRef.current) return;
+        setSuggestions(res.isSuccess ? res.data : []);
+      } catch {
+        if (cancelled || reqSeq !== reqSeqRef.current) return;
+        setSuggestions([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [prefix]);
+
+  return suggestions;
+}
+
+/**
+ * The filter chip row: view chips, the orthogonal status/creator selects, a
+ * debounced tag filter with typeahead, and a "sorted by recent" affordance.
+ * Presentational — all state lives in the parent.
  */
 function LibraryChips({
   view,
   onView,
   tag,
   onTag,
+  tagSuggestions,
+  status,
+  onStatus,
+  actor,
+  onActor,
+  statusDisabled,
 }: {
   view: LibraryFilterView;
   onView: (v: LibraryFilterView) => void;
   tag: string;
   onTag: (v: string) => void;
+  tagSuggestions: string[];
+  status: LibraryStatusFilter;
+  onStatus: (v: LibraryStatusFilter) => void;
+  actor: LibraryActorFilter;
+  onActor: (v: LibraryActorFilter) => void;
+  statusDisabled: boolean;
 }): React.JSX.Element {
   return (
     <div className="mer-chip-row">
@@ -296,6 +407,47 @@ function LibraryChips({
         ))}
       </div>
       <div className="mer-chip-row-end">
+        {/*
+          Native selects, not the Radix `Select`: these sit in a dense toolbar
+          beside a text input, and the portal-based popover version fights the
+          chip row's overflow scrolling on narrow screens. Two fixed, tiny
+          option lists need no combobox.
+        */}
+        <select
+          aria-label="Filter by status"
+          className="mer-chip-select"
+          value={statusDisabled ? "any" : status}
+          disabled={statusDisabled}
+          // The Archived view IS a status filter, so offering a second one
+          // would let the user ask for "archived AND published" — an empty set
+          // by construction, indistinguishable from a broken filter.
+          title={
+            statusDisabled
+              ? "The Archived view already filters by status"
+              : undefined
+          }
+          onChange={(e) => onStatus(e.target.value as LibraryStatusFilter)}
+          data-testid="library-status-filter"
+        >
+          {STATUS_FILTERS.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+        <select
+          aria-label="Filter by creator"
+          className="mer-chip-select"
+          value={actor}
+          onChange={(e) => onActor(e.target.value as LibraryActorFilter)}
+          data-testid="library-actor-filter"
+        >
+          {ACTOR_FILTERS.map((a) => (
+            <option key={a.value} value={a.value}>
+              {a.label}
+            </option>
+          ))}
+        </select>
         <Input
           aria-label="Filter by tag"
           placeholder="Tag…"
@@ -303,7 +455,18 @@ function LibraryChips({
           onChange={(e) => onTag(e.target.value)}
           maxLength={100}
           className="h-9 w-28"
+          // A native datalist rather than a custom popover: it is keyboard- and
+          // screen-reader-accessible for free, and it does not capture typing —
+          // the filter still applies as a prefix while you type, so a tag that
+          // is not in the suggestion list is never unreachable.
+          list="atrium-tag-suggestions"
+          data-testid="library-tag-filter"
         />
+        <datalist id="atrium-tag-suggestions">
+          {tagSuggestions.map((t) => (
+            <option key={t} value={t} />
+          ))}
+        </datalist>
         <span className="mer-sorted-label">Sorted by recent</span>
       </div>
     </div>
@@ -319,7 +482,7 @@ function LibraryChips({
  */
 function viewToFilter(view: LibraryFilterView): {
   kind?: ContentKind;
-  owner?: "shared" | "mine";
+  owner?: "shared" | "mine" | "others";
   status?: "archived";
   filed?: "unfiled";
   favorite?: true;
@@ -333,6 +496,8 @@ function viewToFilter(view: LibraryFilterView): {
       return { owner: "shared" };
     case "mine":
       return { owner: "mine" };
+    case "others":
+      return { owner: "others" };
     case "favorites":
       return { favorite: true };
     case "unfiled":
@@ -398,7 +563,7 @@ function resolveView(
 ): {
   effectiveView: LibraryFilterView;
   kind?: ContentKind;
-  owner?: "shared" | "mine";
+  owner?: "shared" | "mine" | "others";
   status?: "archived";
   filed?: "unfiled";
   favorite?: true;
@@ -430,6 +595,24 @@ function useDebounced(value: string, delayMs = 300): string {
 }
 
 /**
+ * ⌘K / Ctrl+K focuses the library search (the design's "⌘K" hint). Global
+ * listener, cleaned up on unmount. No "is a text field already focused?" guard
+ * is needed — ⌘/Ctrl+K is not a text-entry combo.
+ */
+function useSearchHotkey(ref: React.RefObject<HTMLInputElement | null>): void {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        ref.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [ref]);
+}
+
+/**
  * The library's paged fetch (extracted from `LibraryView` so its body stays
  * under the max-lines lint). `fetchPage(0)` REPLACES the list for the current
  * filters; a non-zero offset APPENDS (the "Load more" path). A monotonic
@@ -455,7 +638,8 @@ function useLibraryPage(filter: ListFilter) {
   const [settledStatus, setSettledStatus] = useState<string | undefined>(undefined);
   const reqSeqRef = useRef(0);
 
-  const { collectionId, kind, owner, status, tag, query } = filter;
+  const { collectionId, kind, owner, status, tag, tagMatch, actor, query } =
+    filter;
 
   const fetchPage = useCallback(
     async (offset: number) => {
@@ -471,6 +655,8 @@ function useLibraryPage(filter: ListFilter) {
           owner,
           status,
           tag,
+          tagMatch,
+          actor,
           query,
           limit: PAGE_SIZE,
           offset,
@@ -498,7 +684,7 @@ function useLibraryPage(filter: ListFilter) {
         }
       }
     },
-    [collectionId, kind, owner, status, tag, query]
+    [collectionId, kind, owner, status, tag, tagMatch, actor, query]
   );
 
   // A STABLE re-fetch handle that always runs the CURRENT `fetchPage`.
@@ -594,6 +780,9 @@ export function LibraryView({
   );
   const [tag, setTag] = useState("");
   const [search, setSearch] = useState("");
+  // Orthogonal to the view chips — see STATUS_FILTERS / ACTOR_FILTERS.
+  const [statusFilter, setStatusFilter] = useState<LibraryStatusFilter>("any");
+  const [actorFilter, setActorFilter] = useState<LibraryActorFilter>("any");
   const searchRef = useRef<HTMLInputElement>(null);
 
   // BOTH free-text filters are SERVER round-trips (#1336 moved the title search
@@ -611,19 +800,7 @@ export function LibraryView({
   const searching =
     debouncedSearch.trim().length > 0 || debouncedTag.trim().length > 0;
 
-  // ⌘K / Ctrl+K focuses the library search (design "⌘K" hint). Global listener,
-  // cleaned up on unmount; ignores the combo when a modifier-less field already
-  // has focus is unnecessary — ⌘/Ctrl+K is not a text-entry combo.
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        searchRef.current?.focus();
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  useSearchHotkey(searchRef);
 
   // The Meridian creation flow (New doc → blank sheet; New artifact / create card
   // → agent-prompt dialog). Extracted to a hook to keep this body under the lint.
@@ -641,6 +818,17 @@ export function LibraryView({
   const { effectiveView, kind, owner, status, filed, favorite, archivedView, homeView } =
     resolveView(view, searching);
 
+  // The Archived VIEW wins over the status SELECT: it is itself a status
+  // filter, and the select is disabled while it is active, so there is exactly
+  // one status in play at a time.
+  const effectiveStatus = archivedView
+    ? status
+    : statusFilter === "any"
+      ? undefined
+      : statusFilter;
+
+  const tagSuggestions = useTagSuggestions(debouncedTag);
+
   const {
     items,
     loading,
@@ -655,10 +843,14 @@ export function LibraryView({
       collectionId: collectionId ?? undefined,
       kind,
       owner,
-      status,
+      status: effectiveStatus,
       filed,
       favorite,
+      actor: actorFilter === "any" ? undefined : actorFilter,
       tag: debouncedTag.trim() || undefined,
+      // Prefix, not whole-tag: typing toward a tag must narrow progressively
+      // instead of emptying the grid until the final character.
+      tagMatch: "prefix",
       query: debouncedSearch.trim() || undefined,
     });
 
@@ -709,7 +901,18 @@ export function LibraryView({
           </p>
         )}
 
-        <LibraryChips view={effectiveView} onView={setView} tag={tag} onTag={setTag} />
+        <LibraryChips
+          view={effectiveView}
+          onView={setView}
+          tag={tag}
+          onTag={setTag}
+          tagSuggestions={tagSuggestions}
+          status={statusFilter}
+          onStatus={setStatusFilter}
+          actor={actorFilter}
+          onActor={setActorFilter}
+          statusDisabled={archivedView}
+        />
 
         {homeView ? (
           <LibraryHome onSeeAll={setView} />

--- a/components/atrium/SectionLanding.tsx
+++ b/components/atrium/SectionLanding.tsx
@@ -88,6 +88,25 @@ function SectionHero({ node }: { node: CollectionTreeNode }): React.JSX.Element 
   const isPrivate = node.scope === "private";
   return (
     <header className="mer-section-hero">
+      {/*
+        Hero art (migration 178). Rendered through the access-checked API route
+        rather than a direct S3/CDN URL, so a personal collection's artwork is
+        as private as the collection.
+
+        A plain <img>, not next/image: the route is dynamic and access-gated per
+        request, so the image optimizer's cache would either be bypassed or
+        become a way to read a section's art without the access check.
+      */}
+      {node.hasHeroImage && (
+        <img
+          className="mer-section-hero-image"
+          src={`/api/atrium/collections/${node.id}/hero`}
+          // Alt text is required at write time; the fallback covers rows that
+          // predate the requirement rather than shipping an empty alt.
+          alt={node.heroImageAlt ?? `${node.name} header image`}
+          data-testid="section-hero-image"
+        />
+      )}
       <div className="mer-section-hero-head">
         <span className="mer-section-hero-icon" aria-hidden="true">
           {isPrivate ? <Lock className="h-5 w-5" /> : <FolderOpen className="h-5 w-5" />}
@@ -113,6 +132,8 @@ function SectionHero({ node }: { node: CollectionTreeNode }): React.JSX.Element 
               sectionName={node.name}
               initialDescription={node.description}
               initialLandingObjectId={node.landingObjectId}
+              hasHeroImage={node.hasHeroImage}
+              initialHeroImageAlt={node.heroImageAlt}
             />
           </div>
         )}

--- a/components/atrium/SectionSettingsDialog.tsx
+++ b/components/atrium/SectionSettingsDialog.tsx
@@ -35,6 +35,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { updateCollectionAction } from "@/actions/db/atrium/collection-management";
+import { setCollectionHeroImageAction } from "@/actions/db/atrium/collection-hero";
 import { listContentAction } from "@/actions/db/atrium/list-content";
 import type { ContentObjectDTO } from "@/lib/content";
 import { createLogger } from "@/lib/client-logger";
@@ -49,35 +50,205 @@ export interface SectionSettingsDialogProps {
   sectionName: string;
   initialDescription: string | null;
   initialLandingObjectId: string | null;
+  /** Whether the section currently has hero art (migration 178). */
+  hasHeroImage?: boolean;
+  /** Existing alt text, pre-filled when replacing an image. */
+  initialHeroImageAlt?: string | null;
 }
 
-/** Help text under the pin picker, by load state. */
-function pinHelpText(loading: boolean, count: number): string {
-  if (loading) return "Loading this section's pages…";
-  if (count === 0) return "This section has no pages yet.";
-  return "Pinned above everything else, so the page to read first is not buried by whatever changed most recently.";
+/** Mirrors `MAX_HERO_IMAGE_BYTES` — checked client-side to fail fast, and again on the server. */
+const HERO_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Read a picked file as a `data:` URL for the server action.
+ *
+ * Base64 through a server action rather than a presigned direct-to-S3 upload:
+ * a hero image is a single small file chosen once in a settings dialog, and the
+ * presigned flow would need an initiate endpoint, a client PUT, and a
+ * confirmation round-trip to save nothing at this size.
+ */
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("error", () =>
+      reject(new Error("Could not read that file"))
+    );
+    reader.addEventListener("load", () => resolve(String(reader.result)));
+    reader.readAsDataURL(file);
+  });
 }
 
-export function SectionSettingsDialog({
+/**
+ * The section's header image: upload one, generate one, or remove it.
+ *
+ * Its own component with its own state, and it applies changes IMMEDIATELY
+ * rather than participating in the dialog's Save. Image work is slow (a
+ * generation call is several seconds) and independently fallible (no model
+ * configured, a provider refusal, an oversized file) — folding it into Save
+ * would let an image failure discard the description edits made beside it, and
+ * would make Save's latency unpredictable.
+ */
+function HeroImageEditor({
   collectionId,
-  sectionName,
-  initialDescription,
-  initialLandingObjectId,
-}: SectionSettingsDialogProps): React.JSX.Element {
+  hasHeroImage,
+  initialAlt,
+}: {
+  collectionId: string;
+  hasHeroImage: boolean;
+  initialAlt: string | null;
+}): React.JSX.Element {
   const router = useRouter();
-  const [open, setOpen] = useState(false);
-  const [description, setDescription] = useState(initialDescription ?? "");
-  const [landingObjectId, setLandingObjectId] = useState(
-    initialLandingObjectId ?? ""
+  const [prompt, setPrompt] = useState("");
+  const [alt, setAlt] = useState(initialAlt ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [present, setPresent] = useState(hasHeroImage);
+
+  const apply = useCallback(
+    async (input: { dataUrl?: string; prompt?: string; clear?: boolean }) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const res = await setCollectionHeroImageAction(collectionId, {
+          ...input,
+          alt,
+        });
+        if (res.isSuccess) {
+          setPresent(!input.clear);
+          if (input.clear) setAlt("");
+          setPrompt("");
+          // The hero is server-rendered; re-run the server components in place
+          // rather than reloading the document.
+          router.refresh();
+        } else {
+          setError(res.message ?? "Could not update the header image");
+        }
+      } catch (e) {
+        setError("Could not update the header image");
+        log.error("setCollectionHeroImageAction threw", {
+          collectionId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+      setBusy(false);
+    },
+    [collectionId, alt, router]
   );
+
+  const onPickFile = useCallback(
+    (file: File | undefined) => {
+      if (!file) return;
+      // Checked here as well as on the server so an oversized pick fails
+      // instantly instead of after base64-inflating it over the wire.
+      if (file.size > HERO_MAX_BYTES) {
+        setError(
+          `That image is ${(file.size / 1024 / 1024).toFixed(1)}MB. The limit is ${
+            HERO_MAX_BYTES / 1024 / 1024
+          }MB.`
+        );
+        return;
+      }
+      void (async () => {
+        try {
+          await apply({ dataUrl: await readFileAsDataUrl(file) });
+        } catch {
+          setError("Could not read that file");
+        }
+      })();
+    },
+    [apply]
+  );
+
+  // Alt text is required by the server on both set paths, so the controls are
+  // disabled until it exists rather than letting the request fail.
+  const needsAlt = alt.trim().length === 0;
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="section-hero-alt">Header image</Label>
+      <input
+        id="section-hero-alt"
+        className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+        value={alt}
+        maxLength={300}
+        disabled={busy}
+        placeholder="Describe the image for screen readers"
+        onChange={(e) => setAlt(e.target.value)}
+        data-testid="section-hero-alt"
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="file"
+          accept="image/png,image/jpeg,image/webp,image/gif"
+          className="text-xs"
+          disabled={busy || needsAlt}
+          onChange={(e) => onPickFile(e.target.files?.[0])}
+          aria-label="Upload a header image"
+          data-testid="section-hero-upload"
+        />
+        {present && (
+          <button
+            type="button"
+            className="mer-btn"
+            disabled={busy}
+            onClick={() => void apply({ clear: true })}
+            data-testid="section-hero-remove"
+          >
+            Remove image
+          </button>
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          className="h-9 min-w-0 flex-1 rounded-md border bg-background px-3 text-sm"
+          value={prompt}
+          maxLength={1000}
+          disabled={busy}
+          placeholder="…or describe an image to generate"
+          onChange={(e) => setPrompt(e.target.value)}
+          data-testid="section-hero-prompt"
+        />
+        <button
+          type="button"
+          className="mer-btn"
+          disabled={busy || prompt.trim().length < 3 || needsAlt}
+          onClick={() => void apply({ prompt })}
+          data-testid="section-hero-generate"
+        >
+          {busy ? "Working…" : "Generate"}
+        </button>
+      </div>
+      {needsAlt && (
+        <p className="text-xs text-muted-foreground">
+          Add a description above before uploading or generating.
+        </p>
+      )}
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The "start here" pin candidates — this section's pages.
+ *
+ * Loaded only while the dialog is OPEN: the landing page already paid for its
+ * own listing, and this is a different (unpaginated, title-only) shape that
+ * would otherwise be fetched on every section render for a dialog most viewers
+ * never open.
+ *
+ * Extracted from the component to keep it under the max-lines lint.
+ */
+function usePinOptions(
+  open: boolean,
+  collectionId: string
+): { options: ContentObjectDTO[]; loadingOptions: boolean } {
   const [options, setOptions] = useState<ContentObjectDTO[]>([]);
   const [loadingOptions, setLoadingOptions] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  // Load the pin candidates only while the dialog is open — the landing page
-  // already paid for its own listing, and this is a different (unpaginated,
-  // title-only) shape.
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -105,6 +276,34 @@ export function SectionSettingsDialog({
       cancelled = true;
     };
   }, [open, collectionId]);
+
+  return { options, loadingOptions };
+}
+
+/** Help text under the pin picker, by load state. */
+function pinHelpText(loading: boolean, count: number): string {
+  if (loading) return "Loading this section's pages…";
+  if (count === 0) return "This section has no pages yet.";
+  return "Pinned above everything else, so the page to read first is not buried by whatever changed most recently.";
+}
+
+export function SectionSettingsDialog({
+  collectionId,
+  sectionName,
+  initialDescription,
+  initialLandingObjectId,
+  hasHeroImage = false,
+  initialHeroImageAlt = null,
+}: SectionSettingsDialogProps): React.JSX.Element {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [description, setDescription] = useState(initialDescription ?? "");
+  const [landingObjectId, setLandingObjectId] = useState(
+    initialLandingObjectId ?? ""
+  );
+  const { options, loadingOptions } = usePinOptions(open, collectionId);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const save = useCallback(() => {
     setSaving(true);
@@ -140,6 +339,7 @@ export function SectionSettingsDialog({
     })();
   }, [collectionId, description, landingObjectId, router]);
 
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -174,6 +374,12 @@ export function SectionSettingsDialog({
               onChange={(e) => setDescription(e.target.value)}
             />
           </div>
+
+          <HeroImageEditor
+            collectionId={collectionId}
+            hasHeroImage={hasHeroImage}
+            initialAlt={initialHeroImageAlt}
+          />
 
           <div className="space-y-2">
             <Label htmlFor="section-landing">Start here</Label>

--- a/components/atrium/SectionSettingsDialog.tsx
+++ b/components/atrium/SectionSettingsDialog.tsx
@@ -339,7 +339,6 @@ export function SectionSettingsDialog({
     })();
   }, [collectionId, description, landingObjectId, router]);
 
-
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>

--- a/components/atrium/VisibilityChip.tsx
+++ b/components/atrium/VisibilityChip.tsx
@@ -469,6 +469,7 @@ function ShareDialogBody({
   canEdit,
   saving,
   grants,
+  grantLabels,
   roleOptions,
   groupOptions,
   publicNotice,
@@ -492,6 +493,7 @@ function ShareDialogBody({
   canEdit: boolean;
   saving: boolean;
   grants: Grant[];
+  grantLabels: Record<string, string>;
   roleOptions: string[];
   groupOptions: GroupOption[];
   publicNotice: PublicNoticeState;
@@ -549,6 +551,7 @@ function ShareDialogBody({
         {level === "group" && (
           <GroupGrantEditor
             grants={grants}
+            grantLabels={grantLabels}
             canEdit={canEdit}
             saving={saving}
             roleOptions={roleOptions}
@@ -744,6 +747,46 @@ function useSharePublish(idOrSlug: string, onChanged: () => void) {
   return { publishBusy, publishError, publishPending, publish, unpublish };
 }
 
+/**
+ * Fold a successful `getVisibilityAction` read into component state.
+ *
+ * `draftDirty` decides whether the DRAFT is reseeded: a re-read must never
+ * clobber an edit in progress, so a dirty draft updates only the "last
+ * persisted" baseline that Cancel restores.
+ *
+ * Extracted from the load effect to keep `VisibilityChip` under the max-lines
+ * lint.
+ */
+function applyLoadedVisibility(
+  data: { visibilityLevel: string; grants: unknown[]; grantLabels: Record<string, string>; canEdit: boolean },
+  draftDirty: boolean,
+  set: {
+    setLevel: (v: Level) => void;
+    setGrants: (v: Grant[]) => void;
+    setSavedLevel: (v: Level) => void;
+    setSavedGrants: (v: Grant[]) => void;
+    setGrantLabels: (fn: (prev: Record<string, string>) => Record<string, string>) => void;
+    setCanEdit: (v: boolean) => void;
+    setError: (v: string | null) => void;
+    setLevelKnown: (v: boolean) => void;
+  }
+): void {
+  const level = data.visibilityLevel as Level;
+  const grants = data.grants as Grant[];
+  if (!draftDirty) {
+    set.setLevel(level);
+    set.setGrants(grants);
+  }
+  set.setSavedLevel(level);
+  set.setSavedGrants(grants);
+  // Merge, don't replace: a person just added through the picker has a
+  // locally-known label the server has not been told about yet.
+  set.setGrantLabels((prev) => ({ ...prev, ...data.grantLabels }));
+  set.setCanEdit(data.canEdit);
+  set.setError(null);
+  set.setLevelKnown(true);
+}
+
 export function VisibilityChip({ idOrSlug, share, onChange }: VisibilityChipProps) {
   const [open, setOpen] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -756,6 +799,8 @@ export function VisibilityChip({ idOrSlug, share, onChange }: VisibilityChipProp
   const [canEdit, setCanEdit] = useState(false);
   const [level, setLevel] = useState<Level>("private");
   const [grants, setGrants] = useState<Grant[]>([]);
+  // Display names for `user` grants — see `grantDisplay`.
+  const [grantLabels, setGrantLabels] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // §26.4 pending-approval notice — rendered distinctly from `error` (not a failure).
@@ -794,17 +839,16 @@ export function VisibilityChip({ idOrSlug, share, onChange }: VisibilityChipProp
         const result = await getVisibilityAction(idOrSlug);
         if (cancelled) return;
         if (result.isSuccess) {
-          const loadedLevel = result.data.visibilityLevel as Level;
-          const loadedGrants = result.data.grants as Grant[];
-          if (!draftDirtyRef.current) {
-            setLevel(loadedLevel);
-            setGrants(loadedGrants);
-          }
-          setSavedLevel(loadedLevel);
-          setSavedGrants(loadedGrants);
-          setCanEdit(result.data.canEdit);
-          setError(null);
-          setLevelKnown(true);
+          applyLoadedVisibility(result.data, draftDirtyRef.current, {
+            setLevel,
+            setGrants,
+            setSavedLevel,
+            setSavedGrants,
+            setGrantLabels,
+            setCanEdit,
+            setError,
+            setLevelKnown,
+          });
         } else {
           // Leave `levelKnown=false` so the badge keeps the neutral placeholder
           // rather than the default "Private" chrome for an unknown level.
@@ -850,7 +894,7 @@ export function VisibilityChip({ idOrSlug, share, onChange }: VisibilityChipProp
     setGrants((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
-  const addGrant = useCallback((grant: Grant) => {
+  const addGrant = useCallback((grant: Grant, label?: string) => {
     draftDirtyRef.current = true;
     // Skip an exact duplicate (kind+value) — the DB enforces uniqueness anyway.
     setGrants((prev) =>
@@ -858,6 +902,11 @@ export function VisibilityChip({ idOrSlug, share, onChange }: VisibilityChipProp
         ? prev
         : [...prev, grant]
     );
+    // Remember the picker's label so the new chip reads as a person straight
+    // away, rather than as "user 42" until the dialog is next re-read.
+    if (label) {
+      setGrantLabels((prev) => ({ ...prev, [`${grant.kind}:${grant.value}`]: label }));
+    }
   }, []);
 
   const save = useCallback(
@@ -935,6 +984,7 @@ export function VisibilityChip({ idOrSlug, share, onChange }: VisibilityChipProp
         canEdit={canEdit}
         saving={saving}
         grants={grants}
+        grantLabels={grantLabels}
         roleOptions={roleOptions}
         groupOptions={groupOptions}
         publicNotice={publicNotice}
@@ -993,12 +1043,54 @@ function LevelPicker({ level, disabled, onChange }: LevelPickerProps) {
 
 interface GroupGrantEditorProps {
   grants: Grant[];
+  /**
+   * Display labels keyed `${kind}:${value}`, from `getVisibilityAction`. Only
+   * `user` grants carry one; everything else is already readable.
+   */
+  grantLabels: Record<string, string>;
   canEdit: boolean;
   saving: boolean;
   roleOptions: string[];
   groupOptions: GroupOption[];
-  onAdd: (grant: Grant) => void;
+  /**
+   * `label` is the human name for a `user` grant, supplied by the people
+   * picker. Passing it through means a just-added person shows as their name
+   * immediately instead of as a numeric id until the next server read.
+   */
+  onAdd: (grant: Grant, label?: string) => void;
   onRemove: (index: number) => void;
+}
+
+/**
+ * What a grant chip should SAY.
+ *
+ * A `user` grant stores the numeric users.id, so the chip used to read
+ * "user 42" — technically the truth and practically unusable: nobody can
+ * verify they shared a page with the right person by reading a primary key.
+ *
+ * A `user` grant with no resolved label means the account is gone (the grant
+ * column is loose text with no FK, so this is a real state). Say so, rather
+ * than falling back to the id we were trying to get away from.
+ *
+ * ## Why labels are held apart from the grants themselves
+ *
+ * `VisibilityChip` keeps `grantLabels` in its own state rather than folding a
+ * name into each `Grant`. The grant list is the thing that gets SAVED, and a
+ * display name is not part of that record — merging them would send resolved
+ * names back to the write action and risk persisting a stale name as data.
+ * The map is also accumulated rather than replaced on each read, so a person
+ * just added through the picker keeps their name until the save round-trips.
+ */
+function grantDisplay(
+  grant: Grant,
+  labels: Record<string, string>
+): { kind: string; value: string } {
+  if (grant.kind !== "user") return { kind: grant.kind, value: grant.value };
+  const label = labels[`user:${grant.value}`];
+  return {
+    kind: "person",
+    value: label ?? "Account no longer exists",
+  };
 }
 
 /**
@@ -1027,7 +1119,12 @@ function GrantValueField({
   saving: boolean;
   roleOptions: string[];
   groupOptions: GroupOption[];
-  onAdd: (grant: Grant) => void;
+  /**
+   * `label` is the human name for a `user` grant, supplied by the people
+   * picker. Passing it through means a just-added person shows as their name
+   * immediately instead of as a numeric id until the next server read.
+   */
+  onAdd: (grant: Grant, label?: string) => void;
   onSubmit: () => void;
 }): React.JSX.Element {
   if (draftKind === "role") {
@@ -1074,7 +1171,12 @@ function GrantValueField({
     return (
       <PeoplePicker
         disabled={saving}
-        onSelect={(person) => onAdd({ kind: "user", value: String(person.id) })}
+        onSelect={(person) =>
+          onAdd(
+            { kind: "user", value: String(person.id) },
+            person.name?.trim() || person.email
+          )
+        }
       />
     );
   }
@@ -1097,6 +1199,7 @@ function GrantValueField({
 
 function GroupGrantEditor({
   grants,
+  grantLabels,
   canEdit,
   saving,
   roleOptions,
@@ -1126,24 +1229,27 @@ function GroupGrantEditor({
         </p>
       ) : (
         <ul className="flex flex-wrap gap-2">
-          {grants.map((g, i) => (
-            <li key={`${g.kind}:${g.value}`}>
-              <Badge variant="outline" className="gap-1">
-                <span className="font-medium">{g.kind}</span>
-                <span className="text-muted-foreground">{g.value}</span>
-                {canEdit && (
-                  <button
-                    type="button"
-                    aria-label={`Remove ${g.kind} grant ${g.value}`}
-                    className="ml-0.5 rounded-sm hover:text-destructive"
-                    onClick={() => onRemove(i)}
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                )}
-              </Badge>
-            </li>
-          ))}
+          {grants.map((g, i) => {
+            const shown = grantDisplay(g, grantLabels);
+            return (
+              <li key={`${g.kind}:${g.value}`}>
+                <Badge variant="outline" className="gap-1">
+                  <span className="font-medium">{shown.kind}</span>
+                  <span className="text-muted-foreground">{shown.value}</span>
+                  {canEdit && (
+                    <button
+                      type="button"
+                      aria-label={`Remove ${shown.kind} grant ${shown.value}`}
+                      className="ml-0.5 rounded-sm hover:text-destructive"
+                      onClick={() => onRemove(i)}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                </Badge>
+              </li>
+            );
+          })}
         </ul>
       )}
 

--- a/components/atrium/admin/atrium-admin-tabs.tsx
+++ b/components/atrium/admin/atrium-admin-tabs.tsx
@@ -21,6 +21,14 @@ interface AtriumAdminTabsProps {
   auditError: string | null
   initialCollections: CollectionDTO[]
   collectionsError: string | null
+  /**
+   * District administrator. False for a collection approver (migration 178),
+   * who reaches this page for their own sections' queue and must see ONLY the
+   * Approvals tab — collection management and the audit trail stay
+   * administrator-only. This hides them; their own server actions refuse a
+   * non-admin caller independently, so this is presentation, not the boundary.
+   */
+  isAdmin: boolean
 }
 
 export function AtriumAdminTabs({
@@ -30,6 +38,7 @@ export function AtriumAdminTabs({
   auditError,
   initialCollections,
   collectionsError,
+  isAdmin,
 }: AtriumAdminTabsProps) {
   return (
     <Tabs defaultValue="approvals">
@@ -38,8 +47,8 @@ export function AtriumAdminTabs({
           Approvals
           {initialApprovals.length > 0 ? ` (${initialApprovals.length})` : ""}
         </TabsTrigger>
-        <TabsTrigger value="collections">Collections</TabsTrigger>
-        <TabsTrigger value="audit">Audit</TabsTrigger>
+        {isAdmin && <TabsTrigger value="collections">Collections</TabsTrigger>}
+        {isAdmin && <TabsTrigger value="audit">Audit</TabsTrigger>}
       </TabsList>
       <TabsContent value="approvals">
         <ApprovalsQueue
@@ -47,16 +56,20 @@ export function AtriumAdminTabs({
           initialError={approvalsError}
         />
       </TabsContent>
-      <TabsContent value="collections">
-        <CollectionManagementPanel
-          mode="admin"
-          initialCollections={initialCollections}
-          initialError={collectionsError}
-        />
-      </TabsContent>
-      <TabsContent value="audit">
-        <AuditLogTable initialData={initialAudit} initialError={auditError} />
-      </TabsContent>
+      {isAdmin && (
+        <TabsContent value="collections">
+          <CollectionManagementPanel
+            mode="admin"
+            initialCollections={initialCollections}
+            initialError={collectionsError}
+          />
+        </TabsContent>
+      )}
+      {isAdmin && (
+        <TabsContent value="audit">
+          <AuditLogTable initialData={initialAudit} initialError={auditError} />
+        </TabsContent>
+      )}
     </Tabs>
   )
 }

--- a/components/atrium/reader/ReaderFrame.tsx
+++ b/components/atrium/reader/ReaderFrame.tsx
@@ -18,6 +18,7 @@
  */
 
 import Link from "next/link";
+import { Maximize2 } from "lucide-react";
 import { fontMeridian } from "@/lib/meridian/fonts";
 import type { DocumentHeading } from "@/lib/content/render/headings";
 import { coverGradientClass } from "@/lib/atrium/cover";
@@ -38,6 +39,15 @@ export interface ReaderFrameProps {
   editHref: string | null;
   /** Where the editors-only comment chip links (the editor), or null. */
   commentHref: string | null;
+  /**
+   * The `/atrium/[id]/view` chrome-free viewer, for artifact readers. Null on
+   * document readers (a document already IS the sheet — there is nothing to
+   * expand) and on the anonymous public reader, whose viewer route is
+   * authenticated.
+   *
+   * Shown to EVERY viewer, not just editors — see `ReaderBarActions`.
+   */
+  fullScreenHref?: string | null;
   /** Unresolved root-comment threads; the chip is hidden when 0 or non-editor. */
   commentCount: number;
   /** When the published version went live at this destination (meta line). */
@@ -136,21 +146,47 @@ function ReaderBarActions({
   commentHref,
   commentCount,
   editHref,
+  fullScreenHref,
 }: {
   viewOnly: boolean;
   commentHref: string | null;
   commentCount: number;
   editHref: string | null;
+  fullScreenHref: string | null;
 }): React.JSX.Element {
+  /*
+   * Full screen is rendered OUTSIDE the view-only branch on purpose.
+   *
+   * The reader's only route to full screen used to be Edit → "Open full
+   * screen", which meant the people most likely to just want to look at an
+   * artifact full size — the ones who cannot edit it — had no route at all.
+   * Reading is not an editing privilege, so this shows for every viewer who
+   * can see the artifact.
+   */
+  const fullScreen = fullScreenHref ? (
+    <Link
+      href={fullScreenHref}
+      className="mer-reader-fullscreen"
+      data-testid="reader-fullscreen-link"
+    >
+      <Maximize2 className="h-3.5 w-3.5" aria-hidden="true" />
+      Full screen
+    </Link>
+  ) : null;
+
   if (viewOnly) {
     return (
-      <span className="mer-reader-viewonly-inline" data-testid="reader-view-only">
-        👁 View only
-      </span>
+      <>
+        {fullScreen}
+        <span className="mer-reader-viewonly-inline" data-testid="reader-view-only">
+          👁 View only
+        </span>
+      </>
     );
   }
   return (
     <>
+      {fullScreen}
       {commentHref && commentCount > 0 && (
         <Link
           href={commentHref}
@@ -183,6 +219,7 @@ function FullBleedReaderFrame({
   commentHref,
   commentCount,
   editHref,
+  fullScreenHref,
   children,
   footer,
 }: {
@@ -193,6 +230,7 @@ function FullBleedReaderFrame({
   commentHref: string | null;
   commentCount: number;
   editHref: string | null;
+  fullScreenHref: string | null;
   children: React.ReactNode;
   footer: React.ReactNode;
 }): React.JSX.Element {
@@ -217,6 +255,7 @@ function FullBleedReaderFrame({
             commentHref={commentHref}
             commentCount={commentCount}
             editHref={editHref}
+            fullScreenHref={fullScreenHref}
           />
         </div>
       </div>
@@ -241,6 +280,7 @@ export function ReaderFrame({
   footer,
   fullBleed = false,
   surface = "app",
+  fullScreenHref = null,
 }: ReaderFrameProps): React.JSX.Element {
   const isPublic = surface === "public";
   const viewOnly = editHref === null;
@@ -267,6 +307,7 @@ export function ReaderFrame({
         commentHref={commentHref}
         commentCount={commentCount}
         editHref={editHref}
+        fullScreenHref={fullScreenHref}
         footer={footer}
       >
         {children}
@@ -303,6 +344,11 @@ export function ReaderFrame({
                     commentHref={commentHref}
                     commentCount={commentCount}
                     editHref={editHref}
+                    // The sheet variant is the DOCUMENT reader: the sheet is
+                    // already the whole document, so there is nothing a
+                    // full-screen view would add. Artifacts render through the
+                    // full-bleed variant above.
+                    fullScreenHref={null}
                   />
                 </div>
               )}

--- a/docs/features/atrium-collection-management.md
+++ b/docs/features/atrium-collection-management.md
@@ -130,9 +130,16 @@ service Nexus chat uses) and stored under `atrium/collections/{id}/hero/{uuid}`.
 They are served ONLY by `GET /api/atrium/collections/{id}/hero`, which re-checks
 collection access and reads the key from the row — the key is never accepted
 from the caller. Replacing an image writes a new key rather than overwriting, so
-a cached hero can never outlive its replacement. Generated images are not
-guardrail-screened (Hagel, 2026-08-14); generation is limited to people who can
-already edit the section, and every change is attributable through the audit log.
+a cached hero can never outlive its replacement — and the superseded object is
+deleted once the row points at the new one (the bucket's lifecycle rules are
+storage-class transitions and multi-year retention, not orphan cleanup, so
+without that every replace would leak indefinitely).
+
+Authorization runs BEFORE the store or the generation call, not after: both
+spend real resources, so a check that rejected afterwards would still let any
+signed-in account burn storage and paid model calls against any collection id.
+Generated images are not guardrail-screened (Hagel, 2026-08-14); every change is
+attributable through the audit log.
 
 ## Surfaces
 

--- a/docs/features/atrium-collection-management.md
+++ b/docs/features/atrium-collection-management.md
@@ -8,16 +8,30 @@ REST v1, and the owner-bound `psd-atrium` skill.
 - A row with `owner_user_id IS NULL` is a district/shared collection.
   Administrators may create, rename, move, reorder, archive, restore, and set
   its defaults/grants.
-- A row with `owner_user_id = users.id` is an owner-bound private collection.
-  Every Atrium author may manage their own private hierarchy. Private collections
-  are forced to `default_visibility_level = 'private'`,
-  `inherit_grants = false`, and carry no grants. Empty private collection trees
-  cascade away with a deleted owner account; content retains its independent
-  ownership foreign-key protections.
-- District administrators can inspect private collection metadata, owner, policy,
-  direct/subtree counts, and collection audit events. They cannot enter, read,
-  create in, or mutate another user's private collection. This is an additional
-  boundary around the existing object visibility rules.
+- A row with `owner_user_id = users.id` is an owner-bound personal collection.
+  Every Atrium author may manage their own hierarchy. Empty personal collection
+  trees cascade away with a deleted owner account; content retains its
+  independent ownership foreign-key protections.
+- **Personal collections are shareable (migration 178).** Their owner may raise
+  the default to `group` and attach `view` / `create` / `approve` grants, so
+  "here is the collection I built for this project" is expressible without
+  re-sharing every document in it. Two invariants are retained and enforced by
+  `ck_collection_private_owner_policy` as well as the service:
+  - the default may be `private` or `group`, never `internal` or `public` — a
+    collection meant for everyone is a district section and belongs in the
+    governed hierarchy;
+  - `inherit_grants` stays `false` — a personal tree's access is exactly what
+    its owner granted, never absorbed from an ancestor.
+
+  Only the OWNER may change the grants (`assertMayManage`), so a grantee cannot
+  re-share a collection shared with them. Zero grants means OWNER ONLY — the
+  opposite of the district "zero grants = unrestricted" rule, and the inversion
+  is load-bearing (see `tests/unit/atrium-shared-personal-collections.test.ts`).
+- District administrators can inspect personal collection metadata, owner,
+  policy, direct/subtree counts, and collection audit events. They cannot enter,
+  read, create in, or mutate another user's personal collection — not even one
+  that has been shared with other people. This is an additional boundary around
+  the existing object visibility rules.
 
 ## Hierarchy and lifecycle
 
@@ -43,9 +57,11 @@ Counts and content filtering intentionally use different, explicit meanings:
 
 ## Grants and defaults
 
-`content_collection_grants` distinguishes `view` from `create` access and uses
-the existing Atrium grant kinds (`role`, `group`, `building`, `department`,
-`grade`, and `user`). District children inherit ancestor grants while
+`content_collection_grants` distinguishes `view`, `create`, and `approve`
+access and uses the existing Atrium grant kinds (`role`, `group`, `building`,
+`department`, `grade`, and `user`). Matching is on the EXACT access level, so an
+`approve` grant confers no view or create access — naming an approver does not
+hand them the contents. District children inherit ancestor grants while
 `inherit_grants` is true; turning it off makes the child a new grant boundary.
 Matching is additive. Zero effective grants preserve the legacy unrestricted
 district behavior. A `group` default is valid only when the collection has at
@@ -65,7 +81,58 @@ If an accessible child cuts off inheritance beneath a denied ancestor,
 collection discovery omits the denied ancestor and re-roots the child at the
 nearest returned ancestor, so denied names, slugs, and ids are not exposed.
 When a collection default is `group`, its effective `view` grants become the new
-object's group-visibility grants. Private collection content is always private.
+object's group-visibility grants. A personal collection left at the `private`
+default still produces private content; one its owner has shared at `group`
+seeds new objects with that collection's own grants.
+
+## Publish review (migration 178)
+
+`content_collections.requires_approval` is a per-collection OPT-IN, default
+`false` on every row. The district-wide policy is unchanged and stays
+allow-then-notify (Hagel, 2026-07-25): authors publish immediately everywhere
+except the sections where review is the point — the staff intranet, the SOP set.
+
+When it is set, `publishService.publish` routes a non-approver's publish into
+the EXISTING `content_publish_requests` queue instead of publishing, pinned to
+the version submitted so approval replays what was reviewed. No new table, no
+new request kind: the pending-dedupe key is
+`(object_id, request_kind, destination)`, so an intranet review request cannot
+collide with a §26.4 public request for the same object.
+
+Approvers are, additively:
+
+- district administrators;
+- the collection's owner (personal collections);
+- anyone matching an `approve` grant on the collection — inherited down district
+  trees like `view`/`create`, never inherited into a personal tree.
+
+The first two are implicit so a gated collection can never reach a state where
+nobody can clear its queue. **Nobody may decide their own request**, including
+administrators; this cannot strand anything, because whoever raised a request
+was by definition not an approver at raise time.
+
+`/admin/atrium` therefore admits non-admin approvers, who see ONLY the Approvals
+tab, filtered to their own sections. Collections and Audit remain
+administrator-only in both the UI and their own actions; a caller who approves
+nothing gets a 404 rather than a 403.
+
+## Section hero images (migration 178)
+
+`hero_image_key` / `hero_image_alt` hold raster header art for a section —
+unlike the object-level `cover_gradient`, which is an allowlisted CSS gradient
+preset with "no raster assets" as an explicit rule. Both fields join
+`description` and `landing_object_id` in `SECTION_EDITOR_FIELDS`, so a non-admin
+holding `create` access to a section can illustrate it without an administrator,
+exactly as they can already write its description.
+
+Images are uploaded or generated (through the same `generateImageForNexus`
+service Nexus chat uses) and stored under `atrium/collections/{id}/hero/{uuid}`.
+They are served ONLY by `GET /api/atrium/collections/{id}/hero`, which re-checks
+collection access and reads the key from the row — the key is never accepted
+from the caller. Replacing an image writes a new key rather than overwriting, so
+a cached hero can never outlive its replacement. Generated images are not
+guardrail-screened (Hagel, 2026-08-14); generation is limited to people who can
+already edit the section, and every change is attributable through the audit log.
 
 ## Surfaces
 

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -167,6 +167,7 @@
     "174-unified-content-message-sanitizer-recovery.sql",
     "175-atrium-library-usability.sql",
     "176-openclaw-oauth-client-redirect-repair.sql",
-    "177-agent-usage-capture-complete.sql"
+    "177-agent-usage-capture-complete.sql",
+    "178-atrium-ux-overhaul.sql"
   ]
 }

--- a/infra/database/schema/178-atrium-ux-overhaul.sql
+++ b/infra/database/schema/178-atrium-ux-overhaul.sql
@@ -1,0 +1,131 @@
+-- ============================================================================
+-- 178 — Atrium UX overhaul: collection hero art, shareable private
+--       collections, and per-collection publish approval
+--
+-- Three independent, additive changes behind the Atrium admin/UX pass. Every
+-- statement is idempotent and every new column is nullable or defaulted, so
+-- existing collections keep working untouched.
+--
+--   1. Hero art on a section. Migration 175 gave collections a description;
+--      they still had no visual identity, so every section landing page read
+--      as the same wall of text. Raster art here (NOT the object-level
+--      `cover_gradient` preset key, which is a fixed CSS gradient allowlist by
+--      design) because sections carry real photography and generated header
+--      images.
+--
+--   2. Shareable private collections. Migration 166 introduced owner-bound
+--      private collections behind a CHECK that pinned them to
+--      `private` + no inheritance. That made "organize my own work" possible
+--      but "share the collection I built" impossible — the constraint rejected
+--      the write before the service ever saw it. This widens the allowed
+--      default to `private` OR `group` so an owner can grant access to their
+--      own tree. `inherit_grants = false` still holds: a private tree never
+--      silently absorbs district grants, and sharing stays an explicit,
+--      per-collection act by its owner.
+--
+--   3. Per-collection publish approval. The district-wide policy is
+--      unchanged and stays allow-then-notify (Hagel, 2026-07-25): authors
+--      publish freely and non-admin public exposure records an admin-visible
+--      audit row. This flag is a narrow, per-collection OPT-IN for the
+--      collections where review is the point — the staff intranet and SOPs —
+--      and it reuses the existing content_publish_requests queue rather than
+--      introducing a second approval mechanism.
+--
+--      `approve` joins the collection-grant access levels so approver rosters
+--      are configurable per collection instead of hardcoded to admins.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Section hero art
+-- ---------------------------------------------------------------------------
+-- The S3 object key, not a URL: presigned URLs expire and CDN hosts move, so
+-- the durable identifier is the key and the read path resolves it through the
+-- existing /api/images/[...key] route. Length 512 matches the key ceiling used
+-- by the other S3-backed columns in this schema.
+ALTER TABLE content_collections
+  ADD COLUMN IF NOT EXISTS hero_image_key varchar(512);
+
+-- Alt text is a separate column rather than packed into a JSONB blob because
+-- it is required for accessibility on every rendered hero and is read on the
+-- same query as the key.
+ALTER TABLE content_collections
+  ADD COLUMN IF NOT EXISTS hero_image_alt varchar(300);
+
+-- ---------------------------------------------------------------------------
+-- 2. Shareable private collections
+-- ---------------------------------------------------------------------------
+-- Widens migration 166's policy: an owner-bound collection may now default to
+-- `group` (shared with explicit grantees) as well as `private`. It may still
+-- never default to `internal` or `public` — a personal tree must not become
+-- district-wide by default, which is the invariant 166 was protecting.
+--
+-- `inherit_grants = false` is retained deliberately: private trees never
+-- inherit district grants down the hierarchy, so the only access to a shared
+-- personal collection is the one its owner explicitly granted.
+ALTER TABLE content_collections
+  DROP CONSTRAINT IF EXISTS ck_collection_private_owner_policy;
+ALTER TABLE content_collections
+  ADD CONSTRAINT ck_collection_private_owner_policy
+  CHECK (
+    owner_user_id IS NULL
+    OR (
+      default_visibility_level IN ('private', 'group')
+      AND inherit_grants = false
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. Per-collection publish approval
+-- ---------------------------------------------------------------------------
+-- Default false: every existing collection keeps today's fluid publishing.
+-- Only a collection explicitly switched on routes its publishes through the
+-- approval queue.
+ALTER TABLE content_collections
+  ADD COLUMN IF NOT EXISTS requires_approval boolean NOT NULL DEFAULT false;
+
+-- Partial index — the gate check runs on every publish into a collection, but
+-- the overwhelming majority of collections are ungated, so only index the rows
+-- that can actually match.
+CREATE INDEX IF NOT EXISTS idx_collection_requires_approval
+  ON content_collections(id)
+  WHERE requires_approval = true;
+
+-- Add 'approve' to the collection-grant access levels so a collection can name
+-- its own approver roster (by role, building, department, grade, user, or
+-- Google group) instead of falling back to district admins. The service treats
+-- the collection owner and district admins as implicit approvers on top of
+-- whatever this table names.
+ALTER TABLE content_collection_grants
+  DROP CONSTRAINT IF EXISTS ck_content_collection_grant_access;
+ALTER TABLE content_collection_grants
+  ADD CONSTRAINT ck_content_collection_grant_access
+  CHECK (access IN ('view', 'create', 'approve'));
+
+-- ============================================================================
+-- Manual rollback (not run automatically; only after application code has
+-- stopped using the fields). Note the CHECK reversals will FAIL if any row
+-- already violates the narrower constraint — narrow the data first:
+--
+--   DELETE FROM content_collection_grants WHERE access = 'approve';
+--   ALTER TABLE content_collection_grants
+--     DROP CONSTRAINT IF EXISTS ck_content_collection_grant_access;
+--   ALTER TABLE content_collection_grants
+--     ADD CONSTRAINT ck_content_collection_grant_access
+--     CHECK (access IN ('view', 'create'));
+--
+--   UPDATE content_collections SET default_visibility_level = 'private'
+--     WHERE owner_user_id IS NOT NULL AND default_visibility_level = 'group';
+--   ALTER TABLE content_collections
+--     DROP CONSTRAINT IF EXISTS ck_collection_private_owner_policy;
+--   ALTER TABLE content_collections
+--     ADD CONSTRAINT ck_collection_private_owner_policy
+--     CHECK (
+--       owner_user_id IS NULL
+--       OR (default_visibility_level = 'private' AND inherit_grants = false)
+--     );
+--
+--   DROP INDEX IF EXISTS idx_collection_requires_approval;
+--   ALTER TABLE content_collections DROP COLUMN IF EXISTS requires_approval;
+--   ALTER TABLE content_collections DROP COLUMN IF EXISTS hero_image_alt;
+--   ALTER TABLE content_collections DROP COLUMN IF EXISTS hero_image_key;
+-- ============================================================================

--- a/infra/database/schema/178-atrium-ux-overhaul.sql
+++ b/infra/database/schema/178-atrium-ux-overhaul.sql
@@ -39,8 +39,10 @@
 -- 1. Section hero art
 -- ---------------------------------------------------------------------------
 -- The S3 object key, not a URL: presigned URLs expire and CDN hosts move, so
--- the durable identifier is the key and the read path resolves it through the
--- existing /api/images/[...key] route. Length 512 matches the key ceiling used
+-- the durable identifier is the key. It is resolved by a DEDICATED route,
+-- GET /api/atrium/collections/{id}/hero, which re-checks collection access and
+-- reads this column itself — NOT by /api/images/[...key], which authorizes by
+-- conversation ownership and would 404 every hero. Length 512 matches the key ceiling used
 -- by the other S3-backed columns in this schema.
 ALTER TABLE content_collections
   ADD COLUMN IF NOT EXISTS hero_image_key varchar(512);

--- a/lib/content/collection-access.ts
+++ b/lib/content/collection-access.ts
@@ -44,6 +44,12 @@ export interface CollectionAccessRow {
   description: string | null;
   /** Pinned "start here" object for the section landing page, or null. */
   landingObjectId: string | null;
+  /** Section hero image S3 key (migration 178), or null. */
+  heroImageKey: string | null;
+  /** Alt text for the hero image; null whenever there is no image. */
+  heroImageAlt: string | null;
+  /** Publishing out of this collection needs approval (migration 178). */
+  requiresApproval: boolean;
 }
 
 export interface CollectionAccessSnapshot {
@@ -87,6 +93,53 @@ export function principalMatchesCollectionGrant(
   }
 }
 
+/**
+ * May this requester approve a publish out of `collection`?
+ *
+ * Only consulted for a collection with `requiresApproval` set. Three ways in,
+ * and the first two are implicit on purpose: a gated collection must never be
+ * able to reach a state where nobody can clear its queue, which is exactly what
+ * happens if the only approvers are an explicit roster that is later emptied,
+ * or whose members leave the district.
+ *
+ *  1. District administrators — the existing /admin/atrium approvers.
+ *  2. The collection's owner, for a personal collection.
+ *  3. Anyone matching an `approve` grant on the collection.
+ *
+ * Grant INHERITANCE follows the same rule as view/create: a district collection
+ * inherits approvers from its ancestors while `inheritGrants` holds, and a
+ * personal collection never inherits (its grants are read directly). This
+ * matters for the intranet, where sub-sections should be approvable by the
+ * people who approve their parent without re-listing them on every child.
+ *
+ * An `approve` grant confers NO view or create access — `effectiveGrantResolver`
+ * matches on exact access — so naming an approver does not hand them the
+ * contents.
+ */
+export function isCollectionApprover(
+  req: Requester,
+  collection: CollectionAccessRow,
+  access: Pick<CollectionAccessSnapshot, "effectiveGrants" | "directGrants">
+): boolean {
+  const principal = principalOf(req);
+  if (principal.isAdmin) return true;
+  if (
+    collection.ownerUserId != null &&
+    collectionOwnerUserId(req) === collection.ownerUserId
+  ) {
+    return true;
+  }
+  const approveGrants =
+    collection.ownerUserId == null
+      ? access.effectiveGrants(collection.id, "approve")
+      : (access.directGrants.get(collection.id) ?? []).filter(
+          (grant) => grant.access === "approve"
+        );
+  return approveGrants.some((grant) =>
+    principalMatchesCollectionGrant(principal, grant)
+  );
+}
+
 async function loadRows(): Promise<{
   collections: CollectionAccessRow[];
   directGrants: Map<string, CollectionGrant[]>;
@@ -108,6 +161,9 @@ async function loadRows(): Promise<{
             archivedAt: contentCollections.archivedAt,
             description: contentCollections.description,
             landingObjectId: contentCollections.landingObjectId,
+            heroImageKey: contentCollections.heroImageKey,
+            heroImageAlt: contentCollections.heroImageAlt,
+            requiresApproval: contentCollections.requiresApproval,
           })
           .from(contentCollections)
           .orderBy(
@@ -171,6 +227,9 @@ async function loadRowsInTx(tx: DbTransaction): Promise<{
       archivedAt: contentCollections.archivedAt,
       description: contentCollections.description,
       landingObjectId: contentCollections.landingObjectId,
+      heroImageKey: contentCollections.heroImageKey,
+      heroImageAlt: contentCollections.heroImageAlt,
+      requiresApproval: contentCollections.requiresApproval,
     })
     .from(contentCollections)
     .orderBy(
@@ -274,6 +333,50 @@ export async function collectionAccessSnapshotInTx(
   return accessSnapshotFromRows(req, collections, directGrants);
 }
 
+/**
+ * Access to ONE owner-bound (personal) collection: its owner always, plus
+ * anyone the owner explicitly granted after migration 178 made personal
+ * collections shareable.
+ *
+ * Grants are read from `directGrants`, deliberately NOT `effectiveGrants`. The
+ * no-inheritance rule for personal trees then holds STRUCTURALLY rather than by
+ * convention, so a future change to the inheritance walk cannot quietly start
+ * leaking a parent's grants into someone's private tree.
+ *
+ * The zero-grants case is the OPPOSITE of a district collection's. There, "no
+ * view grants" means unrestricted (legacy behaviour). Here it must mean OWNER
+ * ONLY — an ungranted personal collection is private by definition, and reusing
+ * the district rule would publish every private tree in the district to
+ * everyone. `.some()` over an empty array is false, so this fails closed by
+ * construction rather than by a guard someone could remove.
+ *
+ * Administrators are deliberately NOT admitted. Object-level `canView` already
+ * gives them the CONTENTS; the collection itself is someone's personal
+ * organization of their own work and stays out of everyone else's sidebar.
+ * That boundary predates sharing and is unchanged by it.
+ */
+function personalCollectionAccess(
+  collection: CollectionAccessRow,
+  principal: Principal,
+  ownerUserId: number | null,
+  directGrants: Map<string, CollectionGrant[]>
+): { mayView: boolean; mayCreate: boolean } {
+  if (ownerUserId != null && collection.ownerUserId === ownerUserId) {
+    return { mayView: true, mayCreate: true };
+  }
+  const own = directGrants.get(collection.id) ?? [];
+  const matches = (access: CollectionGrantAccess): boolean =>
+    own.some(
+      (grant) =>
+        grant.access === access &&
+        principalMatchesCollectionGrant(principal, grant)
+    );
+  const mayCreate = matches("create");
+  // `create` implies `view`: filing into a collection you cannot open is not a
+  // state worth representing.
+  return { mayView: mayCreate || matches("view"), mayCreate };
+}
+
 function accessSnapshotFromRows(
   req: Requester,
   collections: CollectionAccessRow[],
@@ -290,17 +393,14 @@ function accessSnapshotFromRows(
     if (collection.archivedAt) continue;
 
     if (collection.ownerUserId != null) {
-      if (
-        (ownerUserId != null && collection.ownerUserId === ownerUserId)
-      ) {
-        allowedCollectionIds.add(collection.id);
-      }
-      if (
-        ownerUserId != null &&
-        collection.ownerUserId === ownerUserId
-      ) {
-        selectableCollectionIds.add(collection.id);
-      }
+      const personal = personalCollectionAccess(
+        collection,
+        principal,
+        ownerUserId,
+        directGrants
+      );
+      if (personal.mayView) allowedCollectionIds.add(collection.id);
+      if (personal.mayCreate) selectableCollectionIds.add(collection.id);
       continue;
     }
 
@@ -336,6 +436,16 @@ function accessSnapshotFromRows(
     selectableCollectionIds,
   };
 }
+
+/**
+ * Pure internals exposed for unit tests. `accessSnapshotFromRows` is the whole
+ * access decision as a pure function of (requester, rows, grants), so the
+ * personal-collection and approver rules can be tested without a database.
+ */
+export const accessInternals = {
+  accessSnapshotFromRows,
+  personalCollectionAccess,
+};
 
 export async function requesterMayViewCollection(
   req: Requester,

--- a/lib/content/collection-access.ts
+++ b/lib/content/collection-access.ts
@@ -364,6 +364,22 @@ function personalCollectionAccess(
   if (ownerUserId != null && collection.ownerUserId === ownerUserId) {
     return { mayView: true, mayCreate: true };
   }
+
+  // A personal collection at `private` is OWNER-ONLY, whatever grant rows
+  // happen to exist. `private` is the level's plain meaning, and this is the
+  // single read path every surface goes through — so an owner who locks their
+  // collection back down has revoked access the moment the level changes, and
+  // no write path (REST, MCP, a future caller) can leave someone in by
+  // omitting `grants` from the patch.
+  //
+  // The service ALSO clears grants on that transition, so there is normally
+  // nothing here to ignore. This is the invariant; that is data hygiene. Both
+  // exist because the failure mode is silent: the owner believes the
+  // collection is private and it reads as private everywhere in the UI.
+  if (collection.defaultVisibilityLevel !== "group") {
+    return { mayView: false, mayCreate: false };
+  }
+
   const own = directGrants.get(collection.id) ?? [];
   const matches = (access: CollectionGrantAccess): boolean =>
     own.some(

--- a/lib/content/collection-hero-service.ts
+++ b/lib/content/collection-hero-service.ts
@@ -1,0 +1,253 @@
+/**
+ * Atrium collection hero images (migration 178).
+ *
+ * A section had a name, and after migration 175 a description — but no visual
+ * identity, so every section landing page read as the same wall of text and the
+ * intranet's top level was indistinguishable from its SOP index.
+ *
+ * Two ways to get one, both landing in the same place (an S3 key on the
+ * collection row):
+ *
+ *  1. UPLOAD — the author already has the photo.
+ *  2. GENERATE — the author does not, and describing the section is faster than
+ *     finding stock art. Routed through the SAME `generateImageForNexus`
+ *     service Nexus chat and the agent `images.generate` tool use, so there is
+ *     one image-generation code path in the codebase rather than three.
+ *
+ * ## Why the bytes are re-stored rather than linked
+ *
+ * `generateImageForNexus` writes to its own `v2/generated-images/{conversationId}/…`
+ * prefix, which `/api/images/[...key]` serves ONLY after validating conversation
+ * ownership. A collection has no conversation, so that route would (correctly)
+ * 404 every hero. Copying the bytes under `atrium/collections/{id}/hero/{imageId}`
+ * puts them behind Atrium's own collection-access check instead of borrowing a
+ * conversation's.
+ *
+ * ## Content safety
+ *
+ * Generated hero images are NOT guardrail-screened (Hagel, 2026-08-14: authors
+ * self-discern). Generation is limited to people who can already edit the
+ * section, and every image is attributable through the audit log.
+ */
+
+import { randomUUID } from "node:crypto";
+import { createLogger } from "@/lib/logger";
+import { getAIModels } from "@/lib/db/drizzle/ai-models";
+import { hasCapability } from "@/lib/ai/capability-utils";
+import { generateImageForNexus } from "@/lib/ai/image-generation-service";
+import { safeFetch } from "@/lib/security/safe-fetch";
+import { s3Store } from "./storage/s3-store";
+import { ValidationError } from "./errors";
+
+const log = createLogger({ context: "collection-hero-service" });
+
+/**
+ * Upload ceiling for a hero image. Generous for photography, small enough that
+ * a mis-selected RAW file or video fails fast instead of tying up a server
+ * action — and it bounds the base64 payload a single action can be asked to
+ * decode.
+ */
+export const MAX_HERO_IMAGE_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Raster formats only, and an explicit ALLOWLIST rather than a `image/*` test.
+ * `image/svg+xml` is the reason: an SVG is an active document that can carry
+ * script, and it would be served from our own origin. Nothing about a section
+ * header needs it.
+ */
+const ALLOWED_HERO_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
+
+/** Extension for the stored key, so a download has a sensible filename. */
+function extensionFor(contentType: string): string {
+  switch (contentType) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    default:
+      return "gif";
+  }
+}
+
+export interface StoredHeroImage {
+  key: string;
+  contentType: string;
+  byteLength: number;
+}
+
+/**
+ * Decode a `data:` URL from the upload control and store it as this
+ * collection's hero image.
+ *
+ * The size check runs on the DECODED bytes, not the base64 string — base64
+ * inflates by ~33%, so checking the encoded length would silently enforce a
+ * different (smaller) limit than the one documented.
+ */
+export async function storeHeroImageFromDataUrl(
+  collectionId: string,
+  dataUrl: string
+): Promise<StoredHeroImage> {
+  const match = /^data:([a-z0-9.+/-]+);base64,(.+)$/i.exec(dataUrl.trim());
+  if (!match) {
+    throw new ValidationError(
+      "Expected a base64 image. Try choosing the file again."
+    );
+  }
+  const [, contentType, base64] = match;
+  if (!ALLOWED_HERO_TYPES.has(contentType.toLowerCase())) {
+    throw new ValidationError(
+      `Unsupported image type "${contentType}". Use PNG, JPEG, WebP, or GIF.`
+    );
+  }
+
+  const bytes = Buffer.from(base64, "base64");
+  if (bytes.byteLength === 0) {
+    throw new ValidationError("That image file appears to be empty.");
+  }
+  if (bytes.byteLength > MAX_HERO_IMAGE_BYTES) {
+    throw new ValidationError(
+      `That image is ${(bytes.byteLength / 1024 / 1024).toFixed(1)}MB. The limit is ${
+        MAX_HERO_IMAGE_BYTES / 1024 / 1024
+      }MB.`
+    );
+  }
+
+  const key = s3Store.collectionHeroKey(
+    collectionId,
+    `${randomUUID()}.${extensionFor(contentType.toLowerCase())}`
+  );
+  await s3Store.putBytes(key, new Uint8Array(bytes), contentType.toLowerCase());
+  log.info("Stored uploaded collection hero image", {
+    collectionId,
+    byteLength: bytes.byteLength,
+  });
+  return { key, contentType, byteLength: bytes.byteLength };
+}
+
+/**
+ * The platform's configured image model, or null when none is active.
+ *
+ * Mirrors the agent tool's resolver rather than importing it: that one lives in
+ * the MCP tool registry and returns tool-shaped results. Same query, same
+ * capability flag, no cache — one indexed read is negligible beside the
+ * multi-second generation call it precedes.
+ */
+async function resolveImageModel(): Promise<
+  { modelId: string; provider: "openai" | "google" } | null
+> {
+  const models = await getAIModels();
+  const candidate = models.find(
+    (m) =>
+      m.active &&
+      (m.provider === "openai" || m.provider === "google") &&
+      hasCapability(m.capabilities, "imageGeneration")
+  );
+  if (!candidate) return null;
+  return {
+    modelId: candidate.modelId,
+    provider: candidate.provider as "openai" | "google",
+  };
+}
+
+/**
+ * Read generated image bytes back from the presigned URL the generation
+ * service returned.
+ *
+ * Through `safeFetch` (SSRF-guarded, no redirect following) even though the URL
+ * comes from our own service: it is still an outbound request to a host
+ * resolved at runtime, and this is the same treatment the generation service
+ * gives its own reference-image fetches.
+ *
+ * The body is read as an ArrayBuffer and then LENGTH-CHECKED. That check is a
+ * backstop, not the primary bound — the bytes originate from our own generation
+ * call at a size we requested, so a response over the cap means something is
+ * wrong upstream rather than a hostile payload.
+ */
+async function fetchGeneratedImageBytes(url: string): Promise<Uint8Array> {
+  const response = await safeFetch(url, { method: "GET" });
+  if (!response.ok) {
+    throw new ValidationError(
+      "The generated image could not be retrieved. Please try again."
+    );
+  }
+  const buffer = new Uint8Array(await response.arrayBuffer());
+  if (buffer.byteLength === 0) {
+    throw new ValidationError("The generated image came back empty.");
+  }
+  if (buffer.byteLength > MAX_HERO_IMAGE_BYTES) {
+    throw new ValidationError("The generated image was unexpectedly large.");
+  }
+  return buffer;
+}
+
+/**
+ * Generate a hero image from a text prompt and store it against the collection.
+ *
+ * Re-reads the generated bytes back out of the generation service's own
+ * storage and re-stores them under the Atrium collection prefix — see the
+ * module docblock for why linking the original key does not work.
+ */
+export async function generateHeroImage(
+  collectionId: string,
+  prompt: string,
+  userId: number
+): Promise<StoredHeroImage> {
+  const trimmed = prompt.trim();
+  if (trimmed.length < 3) {
+    throw new ValidationError(
+      "Describe the image you want in a few more words."
+    );
+  }
+
+  const model = await resolveImageModel();
+  if (!model) {
+    throw new ValidationError(
+      "No image-generation model is configured for this deployment."
+    );
+  }
+
+  const result = await generateImageForNexus({
+    prompt: trimmed,
+    modelId: model.modelId,
+    provider: model.provider,
+    // No conversation exists here. A stable, collection-scoped synthetic id
+    // keeps the generation service's own key layout meaningful (and traceable
+    // back to the section) without pretending a chat took place — the same
+    // approach the agent `images.generate` tool takes with `agent-{requestId}`.
+    conversationId: `atrium-collection-${collectionId}`,
+    userId: String(userId),
+    // Wide, because it renders as a banner across the top of a section page.
+    size: "1792x1024",
+  });
+
+  // Read the bytes back through the presigned URL the generation service
+  // returned, NOT through `s3Store.getBytesBounded(result.s3Key)`.
+  //
+  // The two services resolve their bucket differently: the generation service
+  // reads `DOCUMENTS_BUCKET_NAME` directly, while `s3Store` goes through
+  // `Settings.getS3()`, which prefers an `S3_BUCKET` setting and only falls
+  // back to that env var. They are the same bucket in every current
+  // deployment — but a key read is silent when that assumption breaks, and it
+  // breaks by configuration rather than by code change. The presigned URL
+  // carries its own bucket and needs no such assumption.
+  const bytes = await fetchGeneratedImageBytes(result.imageUrl);
+  const contentType = "image/png";
+  const key = s3Store.collectionHeroKey(
+    collectionId,
+    `${randomUUID()}.${extensionFor(contentType)}`
+  );
+  await s3Store.putBytes(key, bytes, contentType);
+  log.info("Stored generated collection hero image", {
+    collectionId,
+    provider: model.provider,
+    byteLength: bytes.byteLength,
+  });
+  return { key, contentType, byteLength: bytes.byteLength };
+}

--- a/lib/content/collection-hero-service.ts
+++ b/lib/content/collection-hero-service.ts
@@ -26,8 +26,19 @@
  * ## Content safety
  *
  * Generated hero images are NOT guardrail-screened (Hagel, 2026-08-14: authors
- * self-discern). Generation is limited to people who can already edit the
- * section, and every image is attributable through the audit log.
+ * self-discern), and every image is attributable through the audit log.
+ *
+ * ## Neither function here authorizes anything
+ *
+ * Both take a `collectionId` and act on it. The permission check lives in
+ * `setCollectionHeroImageAction`, which calls
+ * `collectionManagementService.assertMaySetSectionCopy` BEFORE either of them —
+ * deliberately before, because both spend real resources (an S3 write, a paid
+ * model call) and a check that runs afterwards cannot prevent the cost.
+ *
+ * Any NEW caller must do the same. Reaching these functions without that check
+ * hands every signed-in account a storage- and spend-abuse vector against
+ * arbitrary collection ids.
  */
 
 import { randomUUID } from "node:crypto";

--- a/lib/content/collection-management-service.ts
+++ b/lib/content/collection-management-service.ts
@@ -1073,6 +1073,46 @@ export const collectionManagementService = {
     }
   },
 
+  /**
+   * Cheap "may I edit this section's copy?" pre-flight, for callers that must
+   * do expensive work BEFORE they can call `update`.
+   *
+   * The hero-image action is the motivating case: it has to store bytes (an S3
+   * write) or call a paid image model to obtain the key it then patches in.
+   * Doing that first and relying on `update`'s own `assertMayManage` to reject
+   * afterwards means an unauthorized caller still burns the storage and the
+   * generation spend — an authenticated cost-abuse vector against ANY
+   * collectionId, including ones that do not exist.
+   *
+   * Applies the SAME rule as the copy-only carve-out inside `update`
+   * (`assertMayManage` + `SECTION_EDITOR_FIELDS`): administrators and district
+   * collections, a personal collection's owner, or a non-admin holding `create`
+   * access to the section. It is a pre-flight, NOT the authority — `update`
+   * re-asserts against the FOR-UPDATE-locked row, so a revocation landing
+   * between the two still wins.
+   *
+   * Returns the collection's CURRENT hero-image key so the caller can delete
+   * the superseded object after its replacement is live — see the action.
+   */
+  async assertMaySetSectionCopy(
+    req: Requester,
+    collectionId: string
+  ): Promise<{ previousHeroImageKey: string | null }> {
+    assertCollectionId(collectionId);
+    const access = await collectionAccessSnapshot(req);
+    const row = access.byId.get(collectionId);
+    // Unknown id is a NotFoundError, not a permission error — the same
+    // existence-masking `assertMayManage` applies, and it means a caller cannot
+    // use this to probe which collection ids exist.
+    if (!row) throw new NotFoundError("Collection not found", { collectionId });
+    assertMayManage(
+      req,
+      row,
+      access.selectableCollectionIds.has(collectionId)
+    );
+    return { previousHeroImageKey: row.heroImageKey };
+  },
+
   async update(
     req: Requester,
     collectionId: string,

--- a/lib/content/collection-management-service.ts
+++ b/lib/content/collection-management-service.ts
@@ -254,7 +254,16 @@ function scopeOf(row: CollectionAccessRow): CollectionScope {
  * every contributor to the section, so a field that influences access,
  * hierarchy, or lifecycle MUST NOT be added.
  */
-const SECTION_EDITOR_FIELDS = new Set(["description", "landingObjectId"]);
+const SECTION_EDITOR_FIELDS = new Set([
+  "description",
+  "landingObjectId",
+  // Migration 178. The hero image is section COPY in the same sense the
+  // description is — it says what this section is, and the person who
+  // contributes to a section is the one who knows. Restructuring the hierarchy
+  // still requires an administrator; illustrating your own section does not.
+  "heroImageKey",
+  "heroImageAlt",
+]);
 
 /**
  * Whether a patch touches ONLY the landing-page copy. An empty patch returns
@@ -621,6 +630,9 @@ async function managementDTOs(req: Requester): Promise<CollectionDTO[]> {
     archivedAt: row.archivedAt?.toISOString() ?? null,
     description: row.description,
     landingObjectId: row.landingObjectId,
+    heroImageKey: row.heroImageKey,
+    heroImageAlt: row.heroImageAlt,
+    requiresApproval: row.requiresApproval,
     directContentCount: directCounts.get(row.id) ?? 0,
     subtreeContentCount: subtreeCount(row.id),
     grants: access.directGrants.get(row.id) ?? [],
@@ -674,6 +686,9 @@ async function loadCollectionRows(
       // silently get `undefined` instead of a type error.
       description: contentCollections.description,
       landingObjectId: contentCollections.landingObjectId,
+      heroImageKey: contentCollections.heroImageKey,
+      heroImageAlt: contentCollections.heroImageAlt,
+      requiresApproval: contentCollections.requiresApproval,
     })
     .from(contentCollections)
     // Content create/move holds SHARE locks on these rows while it authorizes
@@ -718,20 +733,63 @@ function assertRestorableBelowParent(
   }
 }
 
+/**
+ * The two invariants a personal collection keeps after migration 178 made it
+ * shareable.
+ *
+ * What CHANGED: an owner may now raise their own tree to `group` and attach
+ * grants to it. Before, both were rejected here, which is why "share the
+ * collection I built" was impossible even though the grants table could
+ * express it.
+ *
+ * What did NOT change:
+ *  - It can never default to `internal` or `public`. Those levels mean
+ *    "everyone with an account", which is a district collection — if that is
+ *    what someone wants, an admin should make one, so it appears in the
+ *    district hierarchy and is governed like the rest of it.
+ *  - It can never inherit grants. A personal tree's access is exactly what its
+ *    owner granted, never something absorbed from an ancestor.
+ *
+ * The database backstops both (`ck_collection_private_owner_policy`); this is
+ * the layer that produces an intelligible message instead of a constraint
+ * violation.
+ *
+ * Note that only the OWNER reaches this code at all — `assertMayManage` throws
+ * for everyone else — so a grantee cannot re-share a collection shared with
+ * them.
+ */
+/**
+ * The default visibility a personal collection is created at. `private` unless
+ * the owner explicitly asked for `group`; anything wider is a hard error, not a
+ * silent clamp.
+ */
+function privateCollectionLevel(
+  requested: VisibilityLevel | undefined
+): VisibilityLevel {
+  if (requested === undefined || requested === "private") return "private";
+  if (requested === "group") return "group";
+  throw new ValidationError(
+    "A personal collection can be private or shared with specific people, but not internal or public"
+  );
+}
+
 function assertPrivateUpdate(
   scope: CollectionScope,
-  input: UpdateCollectionInput,
-  grants: CollectionGrant[] | undefined
+  input: UpdateCollectionInput
 ): void {
+  if (scope !== "private") return;
   if (
-    scope === "private" &&
-    ((input.defaultVisibilityLevel !== undefined &&
-      input.defaultVisibilityLevel !== "private") ||
-      input.inheritGrants === true ||
-      (grants !== undefined && grants.length > 0))
+    input.defaultVisibilityLevel !== undefined &&
+    input.defaultVisibilityLevel !== "private" &&
+    input.defaultVisibilityLevel !== "group"
   ) {
     throw new ValidationError(
-      "Private collections must remain private and cannot inherit or carry grants"
+      "A personal collection can be private or shared with specific people, but not internal or public"
+    );
+  }
+  if (input.inheritGrants === true) {
+    throw new ValidationError(
+      "Personal collections cannot inherit grants from a parent"
     );
   }
 }
@@ -753,10 +811,29 @@ function collectionUpdateValues(
   if (input.inheritGrants !== undefined) {
     values.inheritGrants = input.inheritGrants;
   }
-  // `?? null` (not the raw value): an explicit `null` from the caller CLEARS the
-  // field. Passing `undefined` into Drizzle's .set() silently drops the column
-  // from the UPDATE, so "clear this description" would look like it worked and
-  // change nothing — see docs/guides/silent-failure-patterns.md.
+  if (input.requiresApproval !== undefined) {
+    values.requiresApproval = input.requiresApproval;
+  }
+  applySectionCopyValues(input, values);
+  return values;
+}
+
+/**
+ * The section-editor fields (`SECTION_EDITOR_FIELDS`) — description, pinned
+ * page, and hero art. Split out of `collectionUpdateValues` so that function
+ * stays under the complexity lint; they also happen to be exactly the set a
+ * non-admin section editor may patch, so keeping them together is not merely
+ * cosmetic.
+ *
+ * Every one uses `?? null` CLEAR semantics: an explicit `null` from the caller
+ * must persist as a cleared column. Passing `undefined` into Drizzle's `.set()`
+ * silently drops the column from the UPDATE, so "clear this description" would
+ * appear to work and change nothing — see docs/guides/silent-failure-patterns.md.
+ */
+function applySectionCopyValues(
+  input: UpdateCollectionInput,
+  values: Partial<typeof contentCollections.$inferInsert>
+): void {
   if (input.description !== undefined) {
     const trimmed = input.description?.trim() ?? "";
     values.description = trimmed.length > 0 ? trimmed : null;
@@ -764,7 +841,36 @@ function collectionUpdateValues(
   if (input.landingObjectId !== undefined) {
     values.landingObjectId = input.landingObjectId ?? null;
   }
-  return values;
+  applyHeroImageValues(input, values);
+}
+
+/**
+ * The hero-image pair (migration 178), split from `applySectionCopyValues` to
+ * keep it under the complexity lint.
+ *
+ * The two columns are coupled: clearing the KEY must also clear the ALT. Alt
+ * text describing an image that is no longer there is worse than none, and
+ * leaving it behind would let the next uploaded image silently inherit a
+ * description of a completely different picture.
+ */
+function applyHeroImageValues(
+  input: UpdateCollectionInput,
+  values: Partial<typeof contentCollections.$inferInsert>
+): void {
+  const key = input.heroImageKey?.trim() ?? "";
+  const clearing = input.heroImageKey !== undefined && key.length === 0;
+
+  if (input.heroImageKey !== undefined) {
+    values.heroImageKey = key.length > 0 ? key : null;
+  }
+  if (clearing) {
+    values.heroImageAlt = null;
+    return;
+  }
+  if (input.heroImageAlt !== undefined) {
+    const alt = input.heroImageAlt?.trim() ?? "";
+    values.heroImageAlt = alt.length > 0 ? alt : null;
+  }
 }
 
 async function applyArchiveState(
@@ -813,7 +919,7 @@ async function updateCollectionInTx(
     collectionId
   );
   assertRestorableBelowParent(input, parentId, byId);
-  assertPrivateUpdate(scope, input, normalized.grants);
+  assertPrivateUpdate(scope, input);
   assertUpdatedSubtreeGroupDefaults({
     rows,
     collectionId,
@@ -866,17 +972,20 @@ export const collectionManagementService = {
     const name = normalizedName(input.name);
     const position = normalizedPosition(input.position);
     const ownerUserId = assertMayCreateScope(req, input.scope);
+    // A personal collection defaults to `private` but may be created already
+    // shared at `group` (migration 178). Any wider level is refused rather than
+    // silently downgraded, so "make my collection internal" fails loudly
+    // instead of appearing to work — see `assertPrivateUpdate` for why that
+    // ceiling exists.
     const level =
       input.scope === "private"
-        ? "private"
+        ? privateCollectionLevel(input.defaultVisibilityLevel)
         : input.defaultVisibilityLevel ?? "internal";
     assertVisibilityLevel(level);
+    // Never inherited for a personal tree, regardless of what was asked for.
     const inheritGrants =
       input.scope === "private" ? false : input.inheritGrants ?? true;
     const grants = normalizeGrants(input.grants ?? []);
-    if (input.scope === "private" && grants.length > 0) {
-      throw new ValidationError("Private collections cannot carry access grants");
-    }
 
     let createdId: string | undefined;
     try {

--- a/lib/content/collection-management-service.ts
+++ b/lib/content/collection-management-service.ts
@@ -934,8 +934,28 @@ async function updateCollectionInTx(
     .update(contentCollections)
     .set(collectionUpdateValues(input, normalized, parentId))
     .where(eq(contentCollections.id, collectionId));
+  // Un-sharing a personal collection CLEARS its grants, even when the caller
+  // sent only `defaultVisibilityLevel`.
+  //
+  // `updateCollectionBodySchema` is `.partial()`, so `{"defaultVisibilityLevel":
+  // "private"}` is a legal patch on its own, and `replaceGrants` below runs
+  // only when grants were explicitly supplied. Without this the rows would
+  // survive the transition — and a later flip back to `group` would silently
+  // resurrect a roster the owner believed they had dismantled. (The UI already
+  // clears them client-side; this covers REST/MCP and anything added later.)
+  //
+  // `personalCollectionAccess` independently refuses to honour grants on a
+  // `private` collection, so access is already revoked at the read path — this
+  // keeps the DATA honest rather than leaving invisible rows behind.
+  const unsharingPersonal =
+    scope === "private" &&
+    input.defaultVisibilityLevel === "private" &&
+    existing.defaultVisibilityLevel === "group";
+
   if (normalized.grants !== undefined) {
     await replaceGrants(tx, collectionId, normalized.grants);
+  } else if (unsharingPersonal) {
+    await replaceGrants(tx, collectionId, []);
   }
   await applyArchiveState(tx, rows, collectionId, input.archived);
 }

--- a/lib/content/collection-service.ts
+++ b/lib/content/collection-service.ts
@@ -60,6 +60,16 @@ export interface CollectionTreeNode {
    * object the viewer cannot see simply does not render.
    */
   landingObjectId: string | null;
+  /**
+   * Whether this section has a hero image (migration 178). A BOOLEAN, not the
+   * S3 key: the key is an internal storage detail and the image is fetched
+   * through `/api/atrium/collections/{id}/hero`, which re-checks access and
+   * reads the key itself. Shipping the key to the client would leak the bucket
+   * layout for no gain.
+   */
+  hasHeroImage: boolean;
+  /** Alt text for the hero image; null when there is none. */
+  heroImageAlt: string | null;
   /** Number of objects in THIS collection the requester can view (not subtree). */
   visibleObjectCount: number;
   children: CollectionTreeNode[];
@@ -406,6 +416,8 @@ export const collectionService = {
           selectableForCreate: access.selectableCollectionIds.has(c.id),
           description: c.description,
           landingObjectId: c.landingObjectId,
+          hasHeroImage: Boolean(c.heroImageKey),
+          heroImageAlt: c.heroImageAlt,
           visibleObjectCount: visibleCountByCollection.get(c.id) ?? 0,
           children: build(c.id),
         }))

--- a/lib/content/grant-labels.ts
+++ b/lib/content/grant-labels.ts
@@ -1,0 +1,90 @@
+/**
+ * Human-readable labels for visibility grants.
+ *
+ * A `user` grant stores the numeric `users.id` as text, because that is the
+ * only stable identifier — names and emails change. The share dialog rendered
+ * that identifier verbatim, so the grant list read "user 42": correct, and
+ * useless. Nobody can confirm they shared a document with the right person by
+ * reading a primary key.
+ *
+ * Every other grant kind already stores something a person can read (a role
+ * NAME, a building/department/grade value, a Google group email), so only
+ * `user` needs resolving.
+ *
+ * ## Exposure
+ *
+ * Only ever called for a caller who has already passed the editor gate in
+ * `getVisibilityAction` — grants are not returned to non-editors at all, so
+ * this adds no new disclosure. The name shown is the same one
+ * `searchPeopleAction` already returns to the same editors when they pick a
+ * person, so the roster reads the way it was written.
+ */
+
+import { inArray } from "drizzle-orm";
+import { executeQuery, type DrizzleDB } from "@/lib/db/drizzle-client";
+import { users } from "@/lib/db/schema";
+import type { VisibilityGrant } from "./types";
+
+/** The key a label is filed under: `${kind}:${value}`. */
+export function grantLabelKey(grant: VisibilityGrant): string {
+  return `${grant.kind}:${grant.value}`;
+}
+
+/**
+ * Display labels for the `user` grants in `grants`, keyed by
+ * `${kind}:${value}`. Kinds that are already readable are absent from the map
+ * and the caller falls back to the raw value.
+ *
+ * A grant pointing at a deleted user simply has no entry, so the UI degrades to
+ * its "former colleague" fallback rather than rendering a bare id or crashing —
+ * `content_visibility_grants.grant_value` is loose text with no FK, so this is
+ * a real state, not a defensive hypothetical.
+ */
+export async function resolveGrantLabels(
+  grants: VisibilityGrant[]
+): Promise<Record<string, string>> {
+  const userIds = [
+    ...new Set(
+      grants
+        .filter((g) => g.kind === "user")
+        .map((g) => Number(g.value))
+        // A non-numeric or non-positive value cannot match a users.id. Filtering
+        // here keeps a malformed row from turning the whole lookup into a
+        // driver-level type error.
+        .filter((id) => Number.isInteger(id) && id > 0)
+    ),
+  ];
+  if (userIds.length === 0) return {};
+
+  const rows = await executeQuery(
+    (db: DrizzleDB) =>
+      db
+        .select({
+          id: users.id,
+          firstName: users.firstName,
+          lastName: users.lastName,
+          email: users.email,
+        })
+        .from(users)
+        .where(inArray(users.id, userIds)),
+    "content.resolveGrantLabels"
+  );
+
+  const labels: Record<string, string> = {};
+  for (const row of rows) {
+    const name = [row.firstName, row.lastName]
+      .filter((part) => (part ?? "").trim().length > 0)
+      .join(" ")
+      .trim();
+    // Full email (not just the local part) is the fallback here, unlike the
+    // library card's `ownerName`. That one renders to every viewer; this renders
+    // only to an editor choosing who may read their document, where telling two
+    // people with the same name apart is the entire job.
+    //
+    // A row with neither a name nor an email contributes NO entry, so the UI
+    // falls through to its own fallback copy rather than showing a blank chip.
+    const label = name.length > 0 ? name : (row.email ?? "");
+    if (label.length > 0) labels[`user:${row.id}`] = label;
+  }
+  return labels;
+}

--- a/lib/content/grant-labels.ts
+++ b/lib/content/grant-labels.ts
@@ -25,9 +25,17 @@ import { executeQuery, type DrizzleDB } from "@/lib/db/drizzle-client";
 import { users } from "@/lib/db/schema";
 import type { VisibilityGrant } from "./types";
 
-/** The key a label is filed under: `${kind}:${value}`. */
-export function grantLabelKey(grant: VisibilityGrant): string {
-  return `${grant.kind}:${grant.value}`;
+/**
+ * The key a label is filed under: `${kind}:${value}`.
+ *
+ * NOT exported. The client components that also build this key
+ * (`VisibilityChip`'s `addGrant` and `grantDisplay`) cannot import from this
+ * module — it pulls in Drizzle and the DB client — so exporting it would
+ * advertise a shared contract that only one side can actually use. The format
+ * is two segments and stable; both sides document it.
+ */
+function grantLabelKey(kind: string, value: string): string {
+  return `${kind}:${value}`;
 }
 
 /**
@@ -84,7 +92,9 @@ export async function resolveGrantLabels(
     // A row with neither a name nor an email contributes NO entry, so the UI
     // falls through to its own fallback copy rather than showing a blank chip.
     const label = name.length > 0 ? name : (row.email ?? "");
-    if (label.length > 0) labels[`user:${row.id}`] = label;
+    if (label.length > 0) {
+      labels[grantLabelKey("user", String(row.id))] = label;
+    }
   }
   return labels;
 }

--- a/lib/content/mappers.ts
+++ b/lib/content/mappers.ts
@@ -68,6 +68,16 @@ export interface ObjectRowAsText {
    * optional. Coalesced to null.
    */
   summary?: string | null;
+  /**
+   * Explicit grant count — present only on the `listVisible` projection, hence
+   * optional. Coalesced to 0.
+   */
+  grantCount?: number | null;
+  /**
+   * Pending approval-queue request — present only on the `listVisible`
+   * projection, hence optional. Coalesced to false.
+   */
+  pendingReview?: boolean | null;
   createdByActor: string;
   createdByAgentId: string | null;
   collectionId: string | null;
@@ -100,6 +110,10 @@ export function rowToObjectDTO(row: ObjectRowAsText): ContentObjectDTO {
     isFavorite: row.isFavorite ?? false,
     // Present only on the list projection; null everywhere else.
     summary: row.summary ?? null,
+    // Present only on the list projection; 0 everywhere else.
+    grantCount: Number(row.grantCount ?? 0),
+    // Present only on the list projection; false everywhere else.
+    pendingReview: row.pendingReview === true,
     createdByActor: row.createdByActor as "human" | "agent",
     createdByAgentId: row.createdByAgentId,
     collectionId: row.collectionId,

--- a/lib/content/publish-service.ts
+++ b/lib/content/publish-service.ts
@@ -51,6 +51,10 @@ import {
   VersionPreconditionFailedError,
 } from "./errors";
 import {
+  collectionAccessSnapshot,
+  isCollectionApprover,
+} from "./collection-access";
+import {
   isPublicDestination,
   type PublishAdapter,
   type PublishDestination,
@@ -453,6 +457,52 @@ function assertMayUnpublishPublicOrRaise(
       { destination, objectId, requestKind: "unpublish" }
     );
   }
+}
+
+/**
+ * Per-collection review gate (migration 178). Raises `ApprovalRequiredError`
+ * — persisting a durable `content_publish_requests` row pinned to the version
+ * being published — when the object sits in a collection with
+ * `requiresApproval` set and the caller is not one of its approvers.
+ *
+ * A no-op for unfiled content, for ungated collections (every collection by
+ * default), and for approvers, so the overwhelmingly common publish path pays
+ * one already-cached collection-access snapshot and nothing else.
+ *
+ * Pinning `versionId` is what makes approval meaningful: the approver replays
+ * the version that was submitted, not whatever the author edited it into while
+ * the request sat in the queue (#1118).
+ */
+async function raiseCollectionReviewApproval(args: {
+  req: Requester;
+  obj: PublishableObject;
+  objectId: string;
+  destination: PublishDestination;
+  publishedVersionId: string;
+}): Promise<void> {
+  const { req, obj, objectId, destination, publishedVersionId } = args;
+  if (!obj.collectionId) return;
+
+  const access = await collectionAccessSnapshot(req);
+  const collection = access.byId.get(obj.collectionId);
+  if (!collection?.requiresApproval) return;
+  if (isCollectionApprover(req, collection, access)) return;
+
+  raisePublishApprovalRequired(
+    req,
+    `Publishing from "${collection.name}" requires approval`,
+    { objectId, slug: obj.slug, destination },
+    {
+      destination,
+      objectId,
+      requestKind: "publish",
+      // Pins the queued row to the version submitted for review, so approving
+      // replays what was reviewed rather than whatever the author has since
+      // edited it into (#1118).
+      versionId: publishedVersionId,
+      collectionId: collection.id,
+    }
+  );
 }
 
 /**
@@ -882,6 +932,34 @@ export const publishService = {
         opts.expectedVersionId
       );
     }
+
+    // PER-COLLECTION REVIEW GATE (migration 178).
+    //
+    // Independent of §26.4 above, and deliberately narrower. §26.4 asks "is
+    // this exposure public?"; this asks "does this SECTION require review?".
+    // The district-wide policy is untouched and stays allow-then-notify
+    // (Hagel, 2026-07-25) — publishing is immediate everywhere except the
+    // sections an administrator has explicitly switched review on for, which
+    // in practice means the staff intranet and the SOP set, where an
+    // unreviewed page going live is the failure mode worth paying a queue for.
+    //
+    // Reuses the SAME `content_publish_requests` queue and the SAME admin
+    // surface rather than introducing a second approval mechanism. The pending
+    // dedupe index is (object_id, request_kind, destination), so an intranet
+    // review request cannot collide with a §26.4 public request for the same
+    // object — they carry different destinations.
+    //
+    // Runs AFTER the doomed-request validations above (no head, bad pinned
+    // version, unimplemented adapter) for the same reason §26.4 does: a request
+    // that can only fail on approve must not be queued for a human to discover
+    // that for us.
+    await raiseCollectionReviewApproval({
+      req,
+      obj,
+      objectId,
+      destination: input.destination,
+      publishedVersionId,
+    });
 
     // The actor recording the publish. Guests/autonomous agents have no user id;
     // `published_by` is nullable, so a null here is persisted as "system".

--- a/lib/content/rest.ts
+++ b/lib/content/rest.ts
@@ -123,7 +123,12 @@ export const restGrantSchema = z.object({
 });
 
 export const restCollectionGrantSchema = restGrantSchema.extend({
-  access: z.enum(["view", "create"]),
+  // `approve` (migration 178) must be accepted here even though the approver
+  // roster is configured from the admin UI. The collection DTO RETURNS approve
+  // grants, this schema is `.strict()`, and grants are replaced wholesale — so
+  // without it any REST client doing a read-modify-write on a gated collection
+  // would 400 on a value we had just handed it.
+  access: z.enum(["view", "create", "approve"]),
 });
 
 export const createCollectionBodySchema = z
@@ -151,6 +156,19 @@ export const updateCollectionBodySchema = createCollectionBodySchema
     // omitting them here would 400 every legitimate description edit.
     description: z.string().max(2000).nullable().optional(),
     landingObjectId: z.string().uuid().nullable().optional(),
+    // Per-collection publish review (migration 178). Update-only, like the
+    // fields above, and for the same reason: review is turned on for a section
+    // that already exists.
+    requiresApproval: z.boolean().optional(),
+    // `heroImageKey` / `heroImageAlt` are deliberately ABSENT.
+    //
+    // The key is an S3 storage detail, and `/api/atrium/collections/{id}/hero`
+    // serves whatever key the row holds. Letting a client set it would turn
+    // that route into an arbitrary read primitive for anything in the bucket —
+    // point the row at another object's key and the access check passes while
+    // the wrong bytes are served. The key is only ever written by
+    // `setCollectionHeroImageAction`, immediately after that code stored the
+    // bytes itself.
   })
   .strict()
   .refine((value) => Object.keys(value).length > 0, {

--- a/lib/content/storage/s3-store.ts
+++ b/lib/content/storage/s3-store.ts
@@ -234,6 +234,21 @@ export const s3Store = {
   },
 
   /**
+   * Build the S3 key for a collection's hero image (migration 178).
+   *
+   * Collection-scoped rather than object-scoped, so a personal collection's
+   * artwork lives under a key that can never be confused with (or reached
+   * through) an object asset path. `imageId` makes each upload a NEW key rather
+   * than overwriting: a replaced hero would otherwise keep serving the old
+   * bytes from any CDN or browser cache that had already fetched the key.
+   */
+  collectionHeroKey(collectionId: string, imageId: string): string {
+    assertSafeSegment(collectionId, "collectionId");
+    assertSafeSegment(imageId, "imageId");
+    return `${ATRIUM_PREFIX}/collections/${collectionId}/hero/${imageId}`;
+  },
+
+  /**
    * Build the S3 key for an exported OKF bundle (Phase 8, §36.5). Bundles live
    * under `atrium/okf/{collectionId}/{exportId}.json` — collection-scoped rather
    * than object-scoped (a bundle is a collection subtree, not a single object).

--- a/lib/content/types.ts
+++ b/lib/content/types.ts
@@ -39,7 +39,17 @@ export interface VisibilityGrant {
 export type VisibilityLevel = "private" | "group" | "internal" | "public";
 
 export type CollectionScope = "district" | "private";
-export type CollectionGrantAccess = "view" | "create";
+/**
+ * `view` = may enter the collection; `create` = may put content in it;
+ * `approve` (migration 178) = may clear the publish queue of a collection whose
+ * `requiresApproval` flag is set.
+ *
+ * Must stay in lockstep with the identically-named type on the schema table
+ * module — they are structurally compared at the service boundary, so a value
+ * added to one and not the other is a compile error rather than a silent
+ * divergence.
+ */
+export type CollectionGrantAccess = "view" | "create" | "approve";
 
 export interface CollectionGrant {
   access: CollectionGrantAccess;
@@ -75,6 +85,12 @@ export interface UpdateCollectionInput {
   defaultVisibilityLevel?: VisibilityLevel;
   inheritGrants?: boolean;
   grants?: CollectionGrant[];
+  /** Section hero image S3 key; `null` clears it (and its alt text). */
+  heroImageKey?: string | null;
+  /** Alt text for the hero image; `null` clears it. */
+  heroImageAlt?: string | null;
+  /** Route publishes out of this collection through the approval queue. */
+  requiresApproval?: boolean;
   archived?: boolean;
 }
 
@@ -95,6 +111,15 @@ export interface CollectionDTO {
   description: string | null;
   /** Pinned "start here" object for the landing page, or null. */
   landingObjectId: string | null;
+  /** Section hero image S3 key (migration 178), or null. */
+  heroImageKey: string | null;
+  /** Alt text for the hero image; null whenever there is no image. */
+  heroImageAlt: string | null;
+  /**
+   * Publishing out of this collection needs approval (migration 178). False
+   * everywhere by default — the district-wide policy is unchanged.
+   */
+  requiresApproval: boolean;
   directContentCount: number;
   subtreeContentCount: number;
   grants: CollectionGrant[];
@@ -219,6 +244,32 @@ export interface ListFilter {
   collectionIds?: string[];
   kind?: ContentKind;
   tag?: string;
+  /**
+   * How `tag` is matched. Defaults to `"exact"` — case-insensitive whole-tag
+   * equality, the long-standing behaviour every REST/MCP caller was written
+   * against, so this stays the default rather than silently widening their
+   * result sets.
+   *
+   * `"prefix"` matches any tag STARTING WITH the supplied text, which is what
+   * the library's tag box passes: typing `psd-staff-` used to collapse the list
+   * to "No matches" until the whole tag was typed, because a partially-typed
+   * tag equals nothing. Progressive narrowing as you type is the point of the
+   * control, so the UI opts in.
+   */
+  tagMatch?: "exact" | "prefix";
+  /**
+   * Restrict to objects created by a human or by an agent
+   * (`content_objects.created_by_actor`).
+   *
+   * Object-grain, matching the library card badge: it reflects who CREATED the
+   * object, not who authored the version currently at head. An agent-created
+   * doc later edited by a human still reads as agent-created here. The
+   * per-version truth lives on `content_versions.author_actor` and is surfaced
+   * by the provenance footer.
+   *
+   * Narrowing-only, like `owner` and `filed` — never a visibility rule.
+   */
+  actor?: "human" | "agent";
   /** Return objects updated at or after this ISO 8601 timestamp. */
   since?: string;
   /**
@@ -237,8 +288,15 @@ export interface ListFilter {
    * it is not a visibility rule and needs no `canView` mirroring. Omitted / "all"
    * applies no ownership restriction; a guest (no user id) gets no rows under
    * "shared".
+   *
+   * "others" is the admin triage counterpart to "mine": everything visible that
+   * the caller does NOT own, whatever route it became visible by. It is
+   * deliberately broader than "shared" — an admin sees the whole district, and
+   * the question they actually need answered is "what is everyone else's?", not
+   * "what did someone hand me?". The two are not complements: "shared"
+   * additionally requires group/private visibility, so "others" is a superset.
    */
-  owner?: "all" | "shared" | "mine";
+  owner?: "all" | "shared" | "mine" | "others";
   /**
    * Whether the object sits in a collection. "unfiled" is `collection_id IS
    * NULL`; "filed" is its complement. Added for the library home, where an
@@ -288,6 +346,30 @@ export interface ContentObjectDTO {
    * for content whose author never wrote one.
    */
   summary: string | null;
+  /**
+   * How many explicit visibility grants this object carries, so a library card
+   * can say "Shared · 3" without naming anyone.
+   *
+   * A COUNT, deliberately not the grant list. Who an object is shared with is
+   * editor-only information (see `getVisibilityAction`) — surfacing the roster
+   * on a card would show every grantee the whole roster, which the owner never
+   * agreed to. A bare count answers the question the catalogue actually raises
+   * ("is this shared, and roughly how widely?") without identifying anyone, and
+   * only ever reaches viewers who can already see the object.
+   *
+   * LIST-ONLY, like `ownerName` / `isFavorite` / `summary`: 0 everywhere else.
+   */
+  grantCount: number;
+  /**
+   * A publish request for this object is pending in the approval queue.
+   *
+   * Derived from `content_publish_requests`, not stored on the object — the
+   * queue is the single source of truth for "awaiting review", so there is no
+   * second state that can drift out of sync with it.
+   *
+   * LIST-ONLY: false everywhere else.
+   */
+  pendingReview: boolean;
   createdByActor: "human" | "agent";
   createdByAgentId: string | null;
   collectionId: string | null;

--- a/lib/content/visibility-service.ts
+++ b/lib/content/visibility-service.ts
@@ -15,6 +15,7 @@ import { and, desc, eq, gte, ilike, inArray, ne, sql, type SQL } from "drizzle-o
 import {
   executeQuery,
   executeTransaction,
+  toPgRows,
   type DbTransaction,
   type DrizzleDB,
 } from "@/lib/db/drizzle-client";
@@ -75,9 +76,10 @@ function escapeLikePattern(text: string): string {
 
 /**
  * The narrowing filters behind the library HOME views and the section landing
- * page — `collectionIds`, `owner: "mine"`, `filed`, and `favorite`.
+ * page — `collectionIds`, `owner: "mine" | "others"`, `actor`, `filed`, and
+ * `favorite`.
  *
- * All three are additive ANDs on top of `buildVisibilitySql`: they can only
+ * All of them are additive ANDs on top of `buildVisibilitySql`: they can only
  * shrink the already-authorized set, never widen it, so none of them is a
  * visibility rule and none needs mirroring in `canView`. A guest (no user id)
  * owns nothing and has favorited nothing, so those two arms fail closed to
@@ -107,6 +109,21 @@ function buildNarrowingFilters(filter: ListFilter, principal: Principal): SQL[] 
         ? sql`${o.ownerUserId} = ${principal.userId}`
         : sql`false`
     );
+  } else if (filter.owner === "others") {
+    // The admin-triage counterpart to "mine". Unlike the fail-closed arms
+    // above, a guest owning nothing means EVERYTHING visible is "someone
+    // else's" — so the honest degenerate case is no restriction, not `false`.
+    // Skipping the push (rather than pushing `true`) keeps the predicate list
+    // free of a no-op term.
+    if (principal.userId != null) {
+      out.push(sql`${o.ownerUserId} <> ${principal.userId}`);
+    }
+  }
+
+  if (filter.actor === "human" || filter.actor === "agent") {
+    // Object-grain provenance, matching the library card badge. Compared as a
+    // bound parameter against the `actor_kind` enum column.
+    out.push(sql`${o.createdByActor} = ${filter.actor}`);
   }
 
   if (filter.filed === "unfiled") {
@@ -899,12 +916,27 @@ export const visibilityService = {
       // case-sensitive overlap), but like the query arm this runs only on
       // explicit user filter text and is bounded by the visibility predicate +
       // LIMIT.
+      //
+      // PREFIX mode (`tagMatch: "prefix"`, opted into by the library tag box)
+      // relaxes that equality to `LIKE '<typed>%'`. Whole-tag equality makes a
+      // partially-typed tag match nothing, so typing toward
+      // `psd-staff-intranet` emptied the list at every keystroke until the
+      // final character — the control looked broken precisely while being
+      // used. The typed text is LIKE-escaped like the query arm below, so a
+      // tag containing `%` or `_` still narrows literally instead of turning
+      // into a wildcard. Exact remains the default so REST/MCP callers, which
+      // pass a known whole tag, keep their existing result sets.
       const tag = filter.tag.slice(0, MAX_TAG_LENGTH);
       filters.push(
-        sql`EXISTS (
-          SELECT 1 FROM unnest(${o.tags}) AS exact_tag
-          WHERE lower(exact_tag) = lower(${tag})
-        )`
+        filter.tagMatch === "prefix"
+          ? sql`EXISTS (
+              SELECT 1 FROM unnest(${o.tags}) AS prefix_tag
+              WHERE lower(prefix_tag) LIKE lower(${`${escapeLikePattern(tag)}%`})
+            )`
+          : sql`EXISTS (
+              SELECT 1 FROM unnest(${o.tags}) AS exact_tag
+              WHERE lower(exact_tag) = lower(${tag})
+            )`
       );
     }
     if (filter.query) {
@@ -964,6 +996,29 @@ export const visibilityService = {
         SELECT v.summary FROM content_versions v
         WHERE v.id = ${o.currentVersionId}
       )`,
+      // How many principals were explicitly granted access, for the card's
+      // audience line. A COUNT and never the grant rows themselves — the
+      // roster is editor-only (see `getVisibilityAction`), and these cards
+      // render to every viewer. Correlated subquery for the same reason as
+      // `summary` above: a join would multiply rows and corrupt LIMIT/OFFSET.
+      grantCount: sql<number>`(
+        SELECT count(*)::int FROM content_visibility_grants g
+        WHERE g.object_id = ${o.id}
+      )`,
+      // Whether a publish request for this object is sitting in the approval
+      // queue (migration 178's per-collection review, or the §26.4 public
+      // gate). Derived from the queue rather than stored on the object, so
+      // there is exactly one source of truth for "awaiting review" and no
+      // second state to keep in sync with the request rows.
+      //
+      // Deliberately NOT a new `content_status` enum value: adding one would
+      // mean an enum migration plus auditing every `status` comparison in the
+      // codebase for a fourth case, to represent something the queue already
+      // knows.
+      pendingReview: sql<boolean>`EXISTS (
+        SELECT 1 FROM content_publish_requests pr
+        WHERE pr.object_id = ${o.id} AND pr.status = 'pending'
+      )`,
     };
 
     const rows = await executeQuery(
@@ -993,5 +1048,60 @@ export const visibilityService = {
     // narrows enum columns, so it is not directly assignable to the mapper's
     // ObjectRowAsText parameter.
     return rows.map((row) => rowToObjectDTO(row as ObjectRowAsText));
+  },
+
+  /**
+   * Distinct tags starting with `prefix`, for the library tag box's typeahead.
+   *
+   * ## Why this cannot be a plain `SELECT DISTINCT unnest(tags)`
+   *
+   * A tag STRING is itself disclosure. `psd-superintendent-search-finalists` on
+   * a private object tells you the object exists, roughly what it is about, and
+   * that it is being worked on — without ever returning the row. So this runs
+   * behind the SAME `buildVisibilitySql` + collection-access predicates as
+   * `listVisible`, not a cheaper "distinct tags" query over the whole table.
+   * Suggestions are therefore a strict projection of what the caller could
+   * already have found by listing.
+   *
+   * Archived objects are excluded to match the library's default view, so a tag
+   * that survives only on archived content does not resurface as a suggestion
+   * that then yields an empty list.
+   *
+   * Returns at most `limit` (hard-capped) tags, alphabetically. An empty prefix
+   * is legal and yields the first page of visible tags.
+   */
+  async listVisibleTags(
+    req: Requester,
+    prefix: string,
+    limit = 12
+  ): Promise<string[]> {
+    const principal = principalOf(req);
+    const o = contentObjects;
+    const visiblePredicate = buildVisibilitySql(principal);
+    const collectionPredicate = buildCollectionAccessSql(
+      (await collectionAccessSnapshot(req)).allowedCollectionIds
+    );
+    const cap = Number.isFinite(limit) ? Math.min(Math.max(limit, 1), 50) : 12;
+    // LIKE-escaped and length-bounded exactly like the `filter.tag` prefix arm,
+    // so `%` typed into the box narrows literally instead of matching every tag.
+    const pattern = `${escapeLikePattern(prefix.slice(0, MAX_TAG_LENGTH))}%`;
+
+    const rows = await executeQuery(
+      (db: DrizzleDB) =>
+        db.execute(sql`
+          SELECT DISTINCT tag_value AS tag
+          FROM ${o}, unnest(${o.tags}) AS tag_value
+          WHERE ${and(
+            sql`${o.status} <> 'archived'`,
+            visiblePredicate,
+            collectionPredicate,
+            sql`lower(tag_value) LIKE lower(${pattern})`
+          )}
+          ORDER BY tag
+          LIMIT ${cap}
+        `),
+      "content.listVisibleTags"
+    );
+    return toPgRows<{ tag: string }>(rows).map((r) => r.tag);
   },
 };

--- a/lib/db/schema/tables/content-collection-grants.ts
+++ b/lib/db/schema/tables/content-collection-grants.ts
@@ -1,10 +1,17 @@
 /**
  * Collection-level access grants for Atrium.
  *
- * Issue #1438. A collection grant controls either entry/view access or whether
- * content may be created in the collection. District/shared collections may
- * inherit grants from their ancestors. Owner-bound private collections never
- * carry or inherit grants.
+ * Issue #1438. A collection grant controls entry/view access, whether content
+ * may be created in the collection, or (migration 178) who may approve a
+ * publish out of a collection that requires review. District/shared
+ * collections may inherit grants from their ancestors.
+ *
+ * Owner-bound private collections carry their own grants but never INHERIT
+ * (`inherit_grants` is pinned false for them by
+ * `ck_collection_private_owner_policy`). Migration 178 widened that policy so
+ * an owner may share their personal tree at `group` level; the grants that
+ * make it shared live in this table, and every one of them is an explicit act
+ * by the owner rather than something absorbed from a district ancestor.
  */
 
 import {
@@ -20,7 +27,13 @@ import { sql } from "drizzle-orm";
 import { grantKindEnum } from "../enums";
 import { contentCollections } from "./content-collections";
 
-export type CollectionGrantAccess = "view" | "create";
+/**
+ * `approve` (migration 178) names the approver roster for a collection whose
+ * `requires_approval` flag is set. It is additive to the implicit approvers the
+ * service always honours (the collection owner and district admins), so a
+ * gated collection is never left with nobody able to clear its queue.
+ */
+export type CollectionGrantAccess = "view" | "create" | "approve";
 
 export const contentCollectionGrants = pgTable(
   "content_collection_grants",
@@ -46,7 +59,7 @@ export const contentCollectionGrants = pgTable(
     ),
     check(
       "ck_content_collection_grant_access",
-      sql`${t.access} IN ('view', 'create')`
+      sql`${t.access} IN ('view', 'create', 'approve')`
     ),
   ]
 );

--- a/lib/db/schema/tables/content-collections.ts
+++ b/lib/db/schema/tables/content-collections.ts
@@ -49,8 +49,10 @@ export const contentCollections = pgTable(
       .notNull(),
     /**
      * NULL = district/shared collection. A user id = owner-bound private
-     * collection. Private collections are forced to private/no-inheritance by
-     * both the service and the database check below.
+     * collection. Private collections never inherit grants (enforced by both
+     * the service and the database check below) and may default only to
+     * `private` or, once their owner shares them, `group` — never `internal`
+     * or `public`.
      */
     ownerUserId: integer("owner_user_id").references(() => users.id, {
       // Empty private trees are organizational metadata and follow their owner
@@ -78,6 +80,27 @@ export const contentCollections = pgTable(
      * its self-reference.
      */
     landingObjectId: uuid("landing_object_id"),
+    /**
+     * Section hero art (migration 178) — the S3 object KEY, not a URL, because
+     * presigned URLs expire and CDN hosts move. Resolved for display through
+     * the existing `/api/images/[...key]` route.
+     *
+     * Deliberately raster, unlike the object-level `cover_gradient`, which is
+     * an allowlisted CSS gradient preset key with "no raster assets" as an
+     * explicit design rule. Sections carry real photography and generated
+     * header images; documents carry a tint.
+     */
+    heroImageKey: varchar("hero_image_key", { length: 512 }),
+    /** Alt text for `heroImageKey`. Required whenever a hero image is set. */
+    heroImageAlt: varchar("hero_image_alt", { length: 300 }),
+    /**
+     * Per-collection publish review (migration 178). Default false: the
+     * district-wide policy stays allow-then-notify (Hagel, 2026-07-25) and
+     * authors publish freely everywhere else. Switching this on for a
+     * collection — the staff intranet, SOPs — routes publishes out of it
+     * through the existing `content_publish_requests` queue instead.
+     */
+    requiresApproval: boolean("requires_approval").default(false).notNull(),
     archivedAt: timestamp("archived_at"),
     navItemId: integer("nav_item_id").references(() => navigationItems.id),
     position: integer("position").default(0).notNull(),
@@ -89,9 +112,12 @@ export const contentCollections = pgTable(
     index("idx_collection_owner").on(t.ownerUserId),
     index("idx_collection_archived").on(t.archivedAt),
     index("idx_collection_landing_object").on(t.landingObjectId),
+    index("idx_collection_requires_approval")
+      .on(t.id)
+      .where(sql`${t.requiresApproval} = true`),
     check(
       "ck_collection_private_owner_policy",
-      sql`${t.ownerUserId} IS NULL OR (${t.defaultVisibilityLevel} = 'private' AND ${t.inheritGrants} = false)`
+      sql`${t.ownerUserId} IS NULL OR (${t.defaultVisibilityLevel} IN ('private', 'group') AND ${t.inheritGrants} = false)`
     ),
     foreignKey({
       columns: [t.parentId],

--- a/styles/meridian-core.css
+++ b/styles/meridian-core.css
@@ -324,8 +324,20 @@
   color: var(--mer-brand);
 }
 .mer-badge-draft {
+  background: var(--mer-draft-tint, #fdf3e0);
+  color: var(--mer-draft, #8a5a00);
+}
+/* Archived keeps the recessed grey Draft used to borrow: inactive, not urgent. */
+.mer-badge-archived {
   background: var(--mer-canvas-sunken);
   color: var(--mer-ink-secondary);
+}
+/* Awaiting approval. Solid amber rather than Draft's tint — a queued item is
+   waiting on a PERSON, so it should read louder than the thing still being
+   written. Same hue keeps the two visibly related. */
+.mer-badge-review {
+  background: var(--mer-draft, #8a5a00);
+  color: #fff;
 }
 .mer-badge-agent {
   background: var(--mer-agent-tint);
@@ -511,6 +523,34 @@
   display: flex;
   align-items: center;
   gap: 10px;
+}
+/* The orthogonal status / creator filters that sit beside the tag box. Styled
+   to read as siblings of .mer-chip rather than as form fields — they are
+   filters, not data entry — while staying a native <select> for free keyboard
+   and screen-reader behaviour. */
+.mer-chip-select {
+  height: 36px;
+  padding: 0 8px;
+  border: 1px solid var(--mer-line);
+  border-radius: var(--mer-r-pill);
+  background: var(--mer-canvas);
+  color: var(--mer-ink-secondary);
+  font-size: 12.5px;
+  line-height: 1;
+  cursor: pointer;
+  max-width: 9.5rem;
+}
+.mer-chip-select:hover:not(:disabled) {
+  border-color: var(--mer-brand);
+  color: var(--mer-ink);
+}
+.mer-chip-select:focus-visible {
+  outline: 2px solid var(--mer-brand);
+  outline-offset: 1px;
+}
+.mer-chip-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .mer-sorted-label {
   font-size: 12.5px;
@@ -949,6 +989,63 @@
 }
 .mer-lib-card-star:hover {
   color: var(--mer-brand);
+}
+
+/* Section hero art (migration 178). A fixed aspect band rather than the
+   image's natural height, so a portrait upload cannot push the section's title
+   and contents below the fold. */
+.mer-section-hero-image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 5;
+  object-fit: cover;
+  border-radius: var(--mer-r-card, 10px);
+  margin-bottom: 14px;
+  background: var(--mer-canvas-sunken);
+}
+
+/* Audience line on a card ("All staff", "Shared · 3"). Quieter than the owner
+   name above it — it is orienting metadata, not the card's subject. */
+.mer-lib-card-audience {
+  font-size: 11.5px;
+  color: var(--mer-ink-muted);
+  margin-top: 2px;
+}
+
+/* Full-screen shortcut on artifact cards. Also a sibling of the card link,
+   tucked just left of the favourite star so the two never overlap. Mirrors the
+   star's reveal-on-hover behaviour for the same reason: the grid should not
+   read as a wall of buttons at rest. */
+.mer-lib-card-fullscreen {
+  position: absolute;
+  top: 8px;
+  right: 40px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--mer-r-pill);
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--mer-ink-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease, color 120ms ease;
+}
+.mer-lib-card-wrap:hover .mer-lib-card-fullscreen,
+.mer-lib-card-fullscreen:focus-visible {
+  opacity: 1;
+}
+.mer-lib-card-fullscreen:hover {
+  color: var(--mer-brand);
+}
+/* Touch devices get no hover, so the control must be permanently visible or it
+   is unreachable — same accommodation the selection checkbox makes. */
+@media (hover: none) {
+  .mer-lib-card-fullscreen {
+    opacity: 1;
+  }
 }
 
 /* Content card grid */
@@ -2829,6 +2926,29 @@
   transition: background 150ms ease-out, border-color 150ms ease-out;
 }
 .mer-reader-edit:hover {
+  background: var(--mer-brand-tint);
+  border-color: var(--mer-brand-mid);
+}
+/* Full-screen action in the artifact reader bar. Same shape as Edit — it sits
+   beside it and they are peers — but it never carries Edit's emphasis: looking
+   at an artifact should not compete with changing one. */
+.mer-reader-fullscreen {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: var(--mer-r-button);
+  font-size: 12.5px;
+  font-weight: 600;
+  border: 1px solid var(--mer-border);
+  background: var(--mer-surface);
+  color: var(--mer-ink-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 150ms ease-out, border-color 150ms ease-out;
+}
+.mer-reader-fullscreen:hover {
   background: var(--mer-brand-tint);
   border-color: var(--mer-brand-mid);
 }

--- a/styles/meridian-tokens.css
+++ b/styles/meridian-tokens.css
@@ -110,6 +110,18 @@ html:has(.meridian) body {
   --mer-danger: #b32227;
   --mer-danger-tint: #ffedeb; /* error panel fill */
 
+  /* ---- Draft / in-review ----
+   * Draft used to render in the same recessed grey as Archived, so the two
+   * most operationally different states in the library — "still being written"
+   * and "put away" — were visually identical and told apart only by reading
+   * the label. Amber gives "in progress" its own hue while staying inside the
+   * restrained palette; grey keeps its real meaning of "inactive".
+   *
+   * #8a5a00 on the tint is 5.7:1, so the pill text passes AA. Colour is never
+   * the ONLY signal — every pill also carries its word. */
+  --mer-draft: #8a5a00;
+  --mer-draft-tint: #fdf3e0;
+
   /* ---- Icon rail ---- */
   --mer-rail-bg: #003049;
   --mer-rail-active: rgba(235, 241, 245, 0.16);

--- a/tests/e2e/atrium-archived-view.functional.spec.ts
+++ b/tests/e2e/atrium-archived-view.functional.spec.ts
@@ -134,8 +134,10 @@ test.describe('Atrium archived-content view (authenticated)', () => {
       // once the debounced tag commits — so assert it inside the retry.
       const zeroMatch = page.getByTestId('library-search-empty')
       await expect(async () => {
+        // `combobox`, not `textbox`: the tag filter gained a typeahead
+        // `list` attribute, which changes the input's implicit ARIA role.
         await page
-          .getByRole('textbox', { name: 'Filter by tag' })
+          .getByRole('combobox', { name: 'Filter by tag' })
           .fill('no-such-tag-zzz-e2e')
         await expect(zeroMatch).toBeVisible({ timeout: 3000 })
       }).toPass({ timeout: 30_000 })

--- a/tests/e2e/atrium-collection-hero.guard.spec.ts
+++ b/tests/e2e/atrium-collection-hero.guard.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "./fixtures";
+
+/**
+ * E2E guard: the collection hero-image route (migration 178) — always-run, CI-safe.
+ *
+ * `GET /api/atrium/collections/[id]/hero` serves a section's header image. It is
+ * a NEW public surface, and the interesting thing about it is what it must NOT
+ * be: an arbitrary S3-read primitive.
+ *
+ * Two properties are worth pinning at this tier, both provable without a
+ * session or a seeded collection:
+ *
+ *  1. It never serves bytes to an anonymous caller. Access is decided by the
+ *     collection-access snapshot, and a guest passes it for nothing that has an
+ *     image (a personal collection's artwork must be as private as the
+ *     collection).
+ *  2. It EXISTS-MASKS. An absent collection and one the caller may not enter
+ *     must be indistinguishable — 404 for both, never 403 — matching the rule
+ *     the rest of Atrium follows. An anonymous probe cannot tell the two apart
+ *     here, which is exactly the point.
+ *
+ * What this CANNOT cover is the authenticated path (an editor uploads or
+ * generates, a viewer with access gets the bytes). That lives in the
+ * authorization unit tests over `collectionAccessSnapshot` and in manual
+ * verification, because it needs both a seeded collection and stored S3 bytes.
+ */
+
+// Well-formed but absent. The route only needs a UUID-shaped id to reach its
+// access check; the id never resolves to a row.
+const ABSENT_COLLECTION = "00000000-0000-0000-0000-000000000000";
+
+test.describe("Atrium collection hero image — route guarding (always-run)", () => {
+  test("GET the hero of an absent collection -> never serves bytes", async ({
+    request,
+  }) => {
+    const res = await request.get(
+      `/api/atrium/collections/${ABSENT_COLLECTION}/hero`,
+      { maxRedirects: 0 }
+    );
+
+    // 404 (masked) or an auth redirect are both acceptable; a 200 with image
+    // bytes is not, and neither is a 403 — that would confirm the collection
+    // exists to a caller who may not see it.
+    expect(res.status()).not.toBe(200);
+    expect(res.status()).not.toBe(403);
+    expect([301, 302, 307, 308, 401, 404]).toContain(res.status());
+  });
+
+  test("the route does not accept a caller-supplied S3 key", async ({
+    request,
+  }) => {
+    // The key is read from the collection row AFTER the access check, never
+    // from the request — otherwise this would be a read primitive scoped only
+    // by whatever prefix validation it happened to do. A traversal-shaped id
+    // must not escape the route's own path segment.
+    const res = await request.get(
+      `/api/atrium/collections/${ABSENT_COLLECTION}/hero?key=../../../etc/passwd`,
+      { maxRedirects: 0 }
+    );
+    expect(res.status()).not.toBe(200);
+
+    const body = await res.text().catch(() => "");
+    expect(body).not.toContain("root:");
+  });
+});

--- a/tests/e2e/atrium-library.spec.ts
+++ b/tests/e2e/atrium-library.spec.ts
@@ -65,8 +65,12 @@ test.describe("Atrium content library (authenticated)", () => {
       await expect(
         page.getByRole("textbox", { name: "Search content by title or tag" })
       ).toBeVisible();
+      // `combobox`, not `textbox`: the tag filter carries a `list` attribute
+      // (its typeahead datalist, migration 178's tag-discovery work), and an
+      // input with `list` has an implicit ARIA role of combobox. Still a
+      // free-text field — the suggestions accelerate, they never constrain.
       await expect(
-        page.getByRole("textbox", { name: "Filter by tag" })
+        page.getByRole("combobox", { name: "Filter by tag" })
       ).toBeVisible();
     } finally {
       await context.close();

--- a/tests/e2e/atrium-publish-share.functional.spec.ts
+++ b/tests/e2e/atrium-publish-share.functional.spec.ts
@@ -381,7 +381,18 @@ function defineAtriumPublishShareAuthenticatedSuite1Part3() {test('atrium-share-
       await results.getByRole('button').first().click()
 
       // The grant chip appears, then save.
-      await expect(page.getByText('user', { exact: true })).toBeVisible()
+      //
+      // It reads "person <Name>", not "user <id>". A `user` grant stores the
+      // numeric users.id, and the chip used to render that verbatim — correct
+      // and unusable, since nobody can confirm they shared a page with the
+      // right colleague by reading a primary key. The kind now matches the
+      // picker's own "Person" label and the value is the resolved name.
+      await expect(page.getByText('person', { exact: true })).toBeVisible()
+      // The name itself, not just the kind: this is the assertion that would
+      // catch a regression back to rendering the raw id.
+      await expect(
+        page.locator('span', { hasText: /^Student/ }).first()
+      ).toBeVisible()
       await page.getByRole('button', { name: 'Save', exact: true }).click()
 
       // The granted user can now read the intranet reader.

--- a/tests/unit/atrium-approvals-actions.test.ts
+++ b/tests/unit/atrium-approvals-actions.test.ts
@@ -30,6 +30,17 @@ jest.mock("@/lib/content/visibility-service", () => ({
   visibilityService: { setLevel: (...a: unknown[]) => setLevelMock(...a) },
 }));
 
+// Migration 178 made the approver roster per-collection, so the actions now
+// consult collection access. Mocked to "approves nothing" by default; the
+// approver test overrides it.
+const collectionAccessSnapshotMock = jest.fn();
+const isCollectionApproverMock = jest.fn();
+jest.mock("@/lib/content/collection-access", () => ({
+  collectionAccessSnapshot: (...a: unknown[]) =>
+    collectionAccessSnapshotMock(...a),
+  isCollectionApprover: (...a: unknown[]) => isCollectionApproverMock(...a),
+}));
+
 // Queries never execute their drizzle callback — the mock dispatches on the
 // executeQuery label (2nd arg), so the schema/drizzle imports stay real.
 type Row = Record<string, unknown>;
@@ -97,8 +108,22 @@ beforeEach(() => {
   unpublishMock.mockReset().mockResolvedValue({ unpublished: true });
   setLevelMock.mockReset().mockResolvedValue({ visibilityLevel: "public" });
   executeQueryMock.mockClear();
+  // Default: no collection anywhere requires approval, so nobody is a
+  // collection approver and authority comes from the administrator role alone.
+  collectionAccessSnapshotMock.mockReset().mockResolvedValue({
+    collections: [],
+    byId: new Map(),
+    directGrants: new Map(),
+    effectiveGrants: () => [],
+    allowedCollectionIds: new Set(),
+    selectableCollectionIds: new Set(),
+  });
+  isCollectionApproverMock.mockReset().mockReturnValue(false);
   queryResults.clear();
   queryResults.set("atrium.approvals.load", [{ ...BASE_ROW }]);
+  queryResults.set("atrium.approvals.loadRequestCollection", [
+    { collectionId: "col-1" },
+  ]);
   // Claim-first: the atomic pending→approved compare-and-set. A non-empty result
   // means THIS caller won the claim; [] means it was decided concurrently.
   queryResults.set("atrium.approvals.claimApprove", [{ id: "req-1" }]);
@@ -106,7 +131,7 @@ beforeEach(() => {
   queryResults.set("atrium.approvals.markDenied", [{ id: "req-1" }]);
 });
 
-describe("admin gating", () => {
+describe("authorization gating", () => {
   it.each([
     ["listPendingApprovalsAction", () => listPendingApprovalsAction()],
     [
@@ -118,13 +143,61 @@ describe("admin gating", () => {
       () => denyPublishRequestAction("req-1", "no"),
     ],
     ["listContentAuditAction", () => listContentAuditAction({})],
-  ])("%s rejects a non-admin before any query or replay", async (_name, run) => {
-    getUserRequesterMock.mockResolvedValue(NON_ADMIN);
-    const result = await run();
-    expect(result.isSuccess).toBe(false);
-    expect(executeQueryMock).not.toHaveBeenCalled();
+  ])(
+    "%s rejects a caller who is neither an admin nor a collection approver",
+    async (_name, run) => {
+      getUserRequesterMock.mockResolvedValue(NON_ADMIN);
+      const result = await run();
+      expect(result.isSuccess).toBe(false);
+      // The guarantee that matters: an unauthorized caller can never cause the
+      // recorded action to be replayed, nor the request to be DECIDED.
+      //
+      // Note this no longer asserts "before any query". Migration 178 made the
+      // approver roster per-collection, so approve/deny must READ the request
+      // (and its collection) to know who is allowed to decide it — the read is
+      // an input to the gate, not something done after passing it.
+      expect(publishMock).not.toHaveBeenCalled();
+      expect(unpublishMock).not.toHaveBeenCalled();
+      expect(setLevelMock).not.toHaveBeenCalled();
+      expect(labelCalls("atrium.approvals.claimApprove")).toBe(0);
+      expect(labelCalls("atrium.approvals.markDenied")).toBe(0);
+    }
+  );
+
+  it("refuses to let anyone decide their own request, administrator included", async () => {
+    // Segregation of duties. Cannot strand a request: whoever raised it was by
+    // definition not an approver at raise time, so another approver exists.
+    getUserRequesterMock.mockResolvedValue({ ...ADMIN, userId: 42 });
+    queryResults.set("atrium.approvals.load", [
+      { ...BASE_ROW, requestedByUserId: 42 },
+    ]);
+
+    const approved = await approvePublishRequestAction("req-1");
+    expect(approved.isSuccess).toBe(false);
+    const denied = await denyPublishRequestAction("req-1", "nope");
+    expect(denied.isSuccess).toBe(false);
+
     expect(publishMock).not.toHaveBeenCalled();
-    expect(setLevelMock).not.toHaveBeenCalled();
+    expect(labelCalls("atrium.approvals.claimApprove")).toBe(0);
+    expect(labelCalls("atrium.approvals.markDenied")).toBe(0);
+  });
+
+  it("lets a non-admin approver of the request's collection decide it", async () => {
+    getUserRequesterMock.mockResolvedValue(NON_ADMIN);
+    // This caller approves the collection the request's object lives in.
+    collectionAccessSnapshotMock.mockResolvedValue({
+      collections: [{ id: "col-1", requiresApproval: true }],
+      byId: new Map(),
+      directGrants: new Map(),
+      effectiveGrants: () => [],
+      allowedCollectionIds: new Set(),
+      selectableCollectionIds: new Set(),
+    });
+    isCollectionApproverMock.mockReturnValue(true);
+
+    const result = await approvePublishRequestAction("req-1", "reviewed");
+    expect(result.isSuccess).toBe(true);
+    expect(publishMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -283,10 +356,13 @@ describe("approvePublishRequestAction — replay", () => {
 });
 
 describe("denyPublishRequestAction", () => {
-  it("requires a non-empty note before touching the database", async () => {
+  it("requires a non-empty note, and records nothing without one", async () => {
     const result = await denyPublishRequestAction("req-1", "   ");
     expect(result.isSuccess).toBe(false);
-    expect(executeQueryMock).not.toHaveBeenCalled();
+    // The request row IS read first now — migration 178 derives who may decide
+    // from the request's collection, so the read precedes both the authority
+    // check and this validation. What must not happen is the WRITE.
+    expect(labelCalls("atrium.approvals.markDenied")).toBe(0);
   });
 
   it("records the denial without replaying anything", async () => {

--- a/tests/unit/atrium-approvals-actions.test.ts
+++ b/tests/unit/atrium-approvals-actions.test.ts
@@ -182,6 +182,51 @@ describe("authorization gating", () => {
     expect(labelCalls("atrium.approvals.markDenied")).toBe(0);
   });
 
+  it("does not load the request at all for a caller who can decide nothing", async () => {
+    // Existence masking. The per-request decider set depends on the request's
+    // collection, so the row has to be read before the precise check — done
+    // naively that lets an unauthorized caller tell "bad id" (not found) from
+    // "real id I may not touch" (forbidden) and enumerate valid request ids.
+    // A caller who approves nothing must be turned away before the read.
+    getUserRequesterMock.mockResolvedValue(NON_ADMIN);
+
+    const result = await approvePublishRequestAction("req-1");
+    expect(result.isSuccess).toBe(false);
+    expect(labelCalls("atrium.approvals.load")).toBe(0);
+  });
+
+  it("answers an eligible approver the same way for a foreign request and a missing one", async () => {
+    // This caller approves SOMETHING (so they clear the coarse gate) but not
+    // the collection this request belongs to. They must not be able to tell it
+    // apart from a request id that does not exist.
+    getUserRequesterMock.mockResolvedValue(NON_ADMIN);
+    collectionAccessSnapshotMock.mockResolvedValue({
+      collections: [{ id: "col-other", requiresApproval: true }],
+      byId: new Map(),
+      directGrants: new Map(),
+      effectiveGrants: () => [],
+      allowedCollectionIds: new Set(),
+      selectableCollectionIds: new Set(),
+    });
+    isCollectionApproverMock.mockReturnValue(true);
+    // The request's object lives in a DIFFERENT collection.
+    queryResults.set("atrium.approvals.loadRequestCollection", [
+      { collectionId: "col-not-mine" },
+    ]);
+
+    const foreign = await approvePublishRequestAction("req-1");
+    expect(foreign.isSuccess).toBe(false);
+
+    // Same shape as a genuinely absent row.
+    queryResults.set("atrium.approvals.load", []);
+    const missing = await approvePublishRequestAction("req-1");
+    expect(missing.isSuccess).toBe(false);
+    expect(foreign.message).toBe(missing.message);
+
+    expect(publishMock).not.toHaveBeenCalled();
+    expect(labelCalls("atrium.approvals.claimApprove")).toBe(0);
+  });
+
   it("lets a non-admin approver of the request's collection decide it", async () => {
     getUserRequesterMock.mockResolvedValue(NON_ADMIN);
     // This caller approves the collection the request's object lives in.

--- a/tests/unit/atrium-collection-hero-action.test.ts
+++ b/tests/unit/atrium-collection-hero-action.test.ts
@@ -1,0 +1,193 @@
+/** @jest-environment node */
+
+/**
+ * `setCollectionHeroImageAction` — ORDERING tests.
+ *
+ * Both properties this file pins are about WHEN things happen, not whether. A
+ * refactor that keeps every call but reorders them reintroduces the exact bugs
+ * these cover, and nothing else in the suite would notice:
+ *
+ *  1. Authorization runs BEFORE the S3 write and the image-generation call.
+ *     Checking afterwards still lets any signed-in account burn storage and
+ *     paid model spend against any collection id — the rejection arrives after
+ *     the cost.
+ *  2. The superseded S3 object is deleted only AFTER the row points at its
+ *     replacement. Every hero write uses a new key, so until the update
+ *     commits the old object is still the live image.
+ */
+
+const getUserRequesterMock = jest.fn();
+jest.mock("@/actions/db/atrium/requester", () => ({
+  getUserRequester: (...a: unknown[]) => getUserRequesterMock(...a),
+}));
+
+// One shared call log, so ORDER across modules is observable.
+const calls: string[] = [];
+
+const assertMaySetSectionCopyMock = jest.fn();
+const updateMock = jest.fn();
+jest.mock("@/lib/content/collection-management-service", () => ({
+  collectionManagementService: {
+    assertMaySetSectionCopy: (...a: unknown[]) => {
+      calls.push("authorize");
+      return assertMaySetSectionCopyMock(...a);
+    },
+    update: (...a: unknown[]) => {
+      calls.push("update");
+      return updateMock(...a);
+    },
+  },
+}));
+
+const storeMock = jest.fn();
+const generateMock = jest.fn();
+jest.mock("@/lib/content/collection-hero-service", () => ({
+  MAX_HERO_IMAGE_BYTES: 8 * 1024 * 1024,
+  storeHeroImageFromDataUrl: (...a: unknown[]) => {
+    calls.push("store");
+    return storeMock(...a);
+  },
+  generateHeroImage: (...a: unknown[]) => {
+    calls.push("generate");
+    return generateMock(...a);
+  },
+}));
+
+const deleteKeyMock = jest.fn();
+jest.mock("@/lib/content/storage/s3-store", () => ({
+  s3Store: {
+    deleteKey: (...a: unknown[]) => {
+      calls.push("delete");
+      return deleteKeyMock(...a);
+    },
+  },
+}));
+
+import { setCollectionHeroImageAction } from "@/actions/db/atrium/collection-hero";
+
+const COLLECTION = "11111111-1111-4111-8111-111111111111";
+const USER = { kind: "user", userId: 7, roles: ["staff"], isAdmin: false };
+
+beforeEach(() => {
+  calls.length = 0;
+  getUserRequesterMock.mockReset().mockResolvedValue(USER);
+  assertMaySetSectionCopyMock
+    .mockReset()
+    .mockResolvedValue({ previousHeroImageKey: null });
+  updateMock.mockReset().mockResolvedValue({ id: COLLECTION });
+  storeMock
+    .mockReset()
+    .mockResolvedValue({ key: "atrium/collections/x/hero/new.png", byteLength: 10 });
+  generateMock
+    .mockReset()
+    .mockResolvedValue({ key: "atrium/collections/x/hero/gen.png", byteLength: 10 });
+  deleteKeyMock.mockReset().mockResolvedValue(undefined);
+});
+
+describe("hero image — authorize before spending", () => {
+  it("does not store an upload when the caller may not edit the section", async () => {
+    assertMaySetSectionCopyMock.mockRejectedValue(new Error("forbidden"));
+
+    const result = await setCollectionHeroImageAction(COLLECTION, {
+      dataUrl: "data:image/png;base64,aGk=",
+      alt: "A header",
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(storeMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call the image model when the caller may not edit the section", async () => {
+    // The expensive one: this is a paid provider call.
+    assertMaySetSectionCopyMock.mockRejectedValue(new Error("forbidden"));
+
+    const result = await setCollectionHeroImageAction(COLLECTION, {
+      prompt: "a calm library",
+      alt: "A header",
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(generateMock).not.toHaveBeenCalled();
+  });
+
+  it("authorizes first even on the happy path", async () => {
+    await setCollectionHeroImageAction(COLLECTION, {
+      dataUrl: "data:image/png;base64,aGk=",
+      alt: "A header",
+    });
+
+    expect(calls.indexOf("authorize")).toBeLessThan(calls.indexOf("store"));
+    expect(calls.indexOf("store")).toBeLessThan(calls.indexOf("update"));
+  });
+});
+
+describe("hero image — superseded object cleanup", () => {
+  it("deletes the previous image only after the row points at the new one", async () => {
+    assertMaySetSectionCopyMock.mockResolvedValue({
+      previousHeroImageKey: "atrium/collections/x/hero/old.png",
+    });
+
+    await setCollectionHeroImageAction(COLLECTION, {
+      dataUrl: "data:image/png;base64,aGk=",
+      alt: "A header",
+    });
+
+    expect(deleteKeyMock).toHaveBeenCalledWith("atrium/collections/x/hero/old.png");
+    // Deleting BEFORE the update would break a live section if the update then
+    // failed — the old object is the live image until the row moves.
+    expect(calls.indexOf("update")).toBeLessThan(calls.indexOf("delete"));
+  });
+
+  it("deletes nothing when the section had no image", async () => {
+    await setCollectionHeroImageAction(COLLECTION, {
+      dataUrl: "data:image/png;base64,aGk=",
+      alt: "A header",
+    });
+    expect(deleteKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("still reports success when the cleanup delete fails", async () => {
+    // Leaking one object is strictly better than failing a change the user can
+    // already see applied.
+    assertMaySetSectionCopyMock.mockResolvedValue({
+      previousHeroImageKey: "atrium/collections/x/hero/old.png",
+    });
+    deleteKeyMock.mockRejectedValue(new Error("S3 down"));
+
+    const result = await setCollectionHeroImageAction(COLLECTION, {
+      dataUrl: "data:image/png;base64,aGk=",
+      alt: "A header",
+    });
+
+    expect(result.isSuccess).toBe(true);
+  });
+
+  it("clears the row and then deletes, on remove", async () => {
+    assertMaySetSectionCopyMock.mockResolvedValue({
+      previousHeroImageKey: "atrium/collections/x/hero/old.png",
+    });
+
+    const result = await setCollectionHeroImageAction(COLLECTION, {
+      clear: true,
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(USER, COLLECTION, {
+      heroImageKey: null,
+    });
+    expect(calls.indexOf("update")).toBeLessThan(calls.indexOf("delete"));
+  });
+
+  it("authorizes a remove too", async () => {
+    assertMaySetSectionCopyMock.mockRejectedValue(new Error("forbidden"));
+
+    const result = await setCollectionHeroImageAction(COLLECTION, {
+      clear: true,
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(deleteKeyMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/atrium-collection-management.test.ts
+++ b/tests/unit/atrium-collection-management.test.ts
@@ -39,6 +39,9 @@ function row(
     archivedAt: null,
     description: null,
     landingObjectId: null,
+    heroImageKey: null,
+    heroImageAlt: null,
+    requiresApproval: false,
     ...values,
   };
 }

--- a/tests/unit/atrium-shared-personal-collections.test.ts
+++ b/tests/unit/atrium-shared-personal-collections.test.ts
@@ -124,6 +124,36 @@ describe("personal collection access (migration 178)", () => {
     expect(snapshot.selectableCollectionIds.has("mine")).toBe(false);
   });
 
+  it("revokes a shared collection the moment its level returns to private", () => {
+    // The grant rows still exist — a level-only PATCH (updateCollectionBodySchema
+    // is .partial(), so {"defaultVisibilityLevel":"private"} is legal on its
+    // own) would not have touched them. Access must be gone anyway: the owner
+    // believes the collection is locked down and it reads as private in the UI,
+    // so honouring stale rows here would be a silent failure.
+    //
+    // The service also clears grants on that transition; this proves the READ
+    // path holds the line independently of any write path.
+    const rows = [personal("mine", { defaultVisibilityLevel: "private" })];
+    const grants = new Map<string, CollectionGrant[]>([
+      ["mine", [{ access: "view", kind: "user", value: "8" }]],
+    ]);
+
+    expect(snapshotFor(grantee, rows, grants).allowedCollectionIds.has("mine")).toBe(false);
+    // …and the owner is of course unaffected.
+    expect(snapshotFor(owner, rows, grants).allowedCollectionIds.has("mine")).toBe(true);
+  });
+
+  it("ignores a stale create grant on a private-level personal collection", () => {
+    const rows = [personal("mine", { defaultVisibilityLevel: "private" })];
+    const grants = new Map<string, CollectionGrant[]>([
+      ["mine", [{ access: "create", kind: "user", value: "8" }]],
+    ]);
+    const snapshot = snapshotFor(grantee, rows, grants);
+
+    expect(snapshot.allowedCollectionIds.has("mine")).toBe(false);
+    expect(snapshot.selectableCollectionIds.has("mine")).toBe(false);
+  });
+
   it("never inherits grants into a personal tree from a district ancestor", () => {
     // Cross-scope parents are rejected at write time, but the resolver must not
     // rely on that: a legacy or hand-edited row must still not inherit.

--- a/tests/unit/atrium-shared-personal-collections.test.ts
+++ b/tests/unit/atrium-shared-personal-collections.test.ts
@@ -1,0 +1,194 @@
+/** @jest-environment node */
+
+/**
+ * Migration 178 — shared personal collections and the per-collection approver
+ * roster.
+ *
+ * These two rules are the ones most likely to be broken by a later change, and
+ * both fail SILENTLY if they are:
+ *
+ *  - Personal collections invert the district "zero grants = unrestricted"
+ *    default. If that inversion is ever lost, every private tree in the
+ *    district becomes readable by everyone, and nothing errors.
+ *  - An `approve` grant must confer no view or create access. If access
+ *    matching ever stops discriminating on the exact access level, naming
+ *    someone an approver would quietly hand them the contents too.
+ */
+
+import {
+  accessInternals,
+  isCollectionApprover,
+  type CollectionAccessRow,
+} from "@/lib/content/collection-access";
+import type { CollectionGrant, Requester } from "@/lib/content/types";
+
+const owner: Requester = { kind: "user", userId: 7, roles: ["staff"], isAdmin: false };
+const grantee: Requester = { kind: "user", userId: 8, roles: ["staff"], isAdmin: false };
+const stranger: Requester = { kind: "user", userId: 9, roles: ["staff"], isAdmin: false };
+const admin: Requester = { kind: "user", userId: 1, roles: ["administrator"], isAdmin: true };
+
+function row(
+  id: string,
+  values: Partial<CollectionAccessRow> = {}
+): CollectionAccessRow {
+  return {
+    id,
+    name: id,
+    slug: id,
+    parentId: null,
+    ownerUserId: null,
+    defaultVisibilityLevel: "internal",
+    inheritGrants: true,
+    position: 0,
+    archivedAt: null,
+    description: null,
+    landingObjectId: null,
+    heroImageKey: null,
+    heroImageAlt: null,
+    requiresApproval: false,
+    ...values,
+  };
+}
+
+/** A personal collection, as migration 178 permits it to be shared. */
+function personal(id: string, values: Partial<CollectionAccessRow> = {}) {
+  return row(id, {
+    ownerUserId: 7,
+    defaultVisibilityLevel: "private",
+    inheritGrants: false,
+    ...values,
+  });
+}
+
+function snapshotFor(
+  req: Requester,
+  rows: CollectionAccessRow[],
+  grants: Map<string, CollectionGrant[]> = new Map()
+) {
+  return accessInternals.accessSnapshotFromRows(req, rows, grants);
+}
+
+describe("personal collection access (migration 178)", () => {
+  it("admits only the owner when the collection carries no grants", () => {
+    const rows = [personal("mine")];
+
+    expect(snapshotFor(owner, rows).allowedCollectionIds.has("mine")).toBe(true);
+    expect(snapshotFor(grantee, rows).allowedCollectionIds.has("mine")).toBe(false);
+    // The inversion that matters: for a DISTRICT collection zero view grants
+    // means unrestricted. Reusing that rule here would expose every private
+    // tree in the district.
+    expect(snapshotFor(stranger, rows).allowedCollectionIds.has("mine")).toBe(false);
+  });
+
+  it("keeps a personal collection out of an administrator's tree", () => {
+    // Object-level canView already gives admins the CONTENTS; the collection is
+    // someone's own organization of their work and stays out of admin sidebars.
+    const snapshot = snapshotFor(admin, [personal("mine")]);
+    expect(snapshot.allowedCollectionIds.has("mine")).toBe(false);
+    expect(snapshot.selectableCollectionIds.has("mine")).toBe(false);
+  });
+
+  it("admits an explicit grantee once the owner shares it", () => {
+    const rows = [personal("mine", { defaultVisibilityLevel: "group" })];
+    const grants = new Map<string, CollectionGrant[]>([
+      ["mine", [{ access: "view", kind: "user", value: "8" }]],
+    ]);
+
+    expect(snapshotFor(grantee, rows, grants).allowedCollectionIds.has("mine")).toBe(true);
+    // View access alone must not let a grantee file content into someone
+    // else's collection.
+    expect(snapshotFor(grantee, rows, grants).selectableCollectionIds.has("mine")).toBe(false);
+    // A share with one person is not a share with everyone.
+    expect(snapshotFor(stranger, rows, grants).allowedCollectionIds.has("mine")).toBe(false);
+  });
+
+  it("treats a create grant as implying view", () => {
+    const rows = [personal("mine", { defaultVisibilityLevel: "group" })];
+    const grants = new Map<string, CollectionGrant[]>([
+      ["mine", [{ access: "create", kind: "user", value: "8" }]],
+    ]);
+    const snapshot = snapshotFor(grantee, rows, grants);
+
+    expect(snapshot.allowedCollectionIds.has("mine")).toBe(true);
+    expect(snapshot.selectableCollectionIds.has("mine")).toBe(true);
+  });
+
+  it("does not let an approve grant confer view or create", () => {
+    const rows = [personal("mine", { defaultVisibilityLevel: "group" })];
+    const grants = new Map<string, CollectionGrant[]>([
+      ["mine", [{ access: "approve", kind: "user", value: "8" }]],
+    ]);
+    const snapshot = snapshotFor(grantee, rows, grants);
+
+    expect(snapshot.allowedCollectionIds.has("mine")).toBe(false);
+    expect(snapshot.selectableCollectionIds.has("mine")).toBe(false);
+  });
+
+  it("never inherits grants into a personal tree from a district ancestor", () => {
+    // Cross-scope parents are rejected at write time, but the resolver must not
+    // rely on that: a legacy or hand-edited row must still not inherit.
+    const parent = row("district-parent");
+    const child = personal("mine", {
+      parentId: "district-parent",
+      defaultVisibilityLevel: "group",
+    });
+    const grants = new Map<string, CollectionGrant[]>([
+      ["district-parent", [{ access: "view", kind: "user", value: "8" }]],
+    ]);
+
+    const snapshot = snapshotFor(grantee, [parent, child], grants);
+    expect(snapshot.allowedCollectionIds.has("mine")).toBe(false);
+  });
+});
+
+describe("collection approver roster (migration 178)", () => {
+  const noGrants = {
+    effectiveGrants: () => [],
+    directGrants: new Map<string, CollectionGrant[]>(),
+  };
+
+  it("always admits district administrators", () => {
+    const gated = row("intranet", { requiresApproval: true });
+    expect(isCollectionApprover(admin, gated, noGrants)).toBe(true);
+  });
+
+  it("admits a personal collection's owner", () => {
+    const gated = personal("mine", { requiresApproval: true });
+    expect(isCollectionApprover(owner, gated, noGrants)).toBe(true);
+    expect(isCollectionApprover(grantee, gated, noGrants)).toBe(false);
+  });
+
+  it("admits a named approver on a district collection, by role", () => {
+    const gated = row("sops", { requiresApproval: true });
+    const approveGrants: CollectionGrant[] = [
+      { access: "approve", kind: "role", value: "staff" },
+    ];
+    const access = {
+      effectiveGrants: (_id: string, level: string) =>
+        level === "approve" ? approveGrants : [],
+      directGrants: new Map<string, CollectionGrant[]>(),
+    };
+
+    expect(isCollectionApprover(grantee, gated, access)).toBe(true);
+  });
+
+  it("reads a personal collection's approvers from its OWN grants only", () => {
+    const gated = personal("mine", {
+      requiresApproval: true,
+      defaultVisibilityLevel: "group",
+    });
+    const access = {
+      // An inherited approve grant must be ignored for a personal collection —
+      // if this were consulted, the test would wrongly pass.
+      effectiveGrants: (): CollectionGrant[] => [
+        { access: "approve", kind: "user", value: "9" },
+      ],
+      directGrants: new Map<string, CollectionGrant[]>([
+        ["mine", [{ access: "approve", kind: "user", value: "8" }]],
+      ]),
+    };
+
+    expect(isCollectionApprover(grantee, gated, access)).toBe(true);
+    expect(isCollectionApprover(stranger, gated, access)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Atrium is hard to navigate at district scale, and several things it already supported were unreachable from the UI. This is one pass over findability, sharing, and section identity, plus the first governance control the staff-intranet and SOP rollout needs.

All schema changes ride on **migration 178** (`178-atrium-ux-overhaul.sql`). Every statement is idempotent; every new column is nullable or defaulted, so existing collections keep working untouched.

## Already built, merely unreachable

Worth calling out, because it is why the diff is smaller than the feature list:

- **Full screen** already existed at `/atrium/[id]/view`, linked from exactly one place — the authoring topbar. Reaching it meant *artifact → Edit → Open full screen*: three steps through an editing surface for the most common read-only thing anyone does with an artifact. Now one click from a card **and** from the `/c/[slug]` reader, and the reader control renders for **every** viewer — non-editors previously had no route at all.
- **"Mine"** was fully wired server-side but excluded from `PRIMARY_VIEWS`, so the one view that makes the library usable at admin scale was the one nobody could find.
- **Multi-person artifact sharing** already worked. The real defect was cosmetic and severe: a `user` grant stores the numeric `users.id`, and the chip rendered it verbatim — the roster read `user 42`.
- **Sub-collections** already worked (`parent_id`, `assertNoCycle`).

## What changed

**Findability** — tag filtering is prefix-matched from the library box (typing toward `psd-staff-intranet` used to empty the grid at every keystroke); a server-backed typeahead runs behind the *same* permission-pushed predicates as `listVisible`, because a tag string is itself disclosure. Status and creator are **orthogonal selects, not chips** — chips are single-select, so a "Published" chip would mean giving up "Docs" to ask "which docs are published?". Cards gained an audience line (`All staff`, `Shared · 3`) — a **count, never names**, since the roster is editor-only.

**Status legibility** — Draft rendered in the same grey as Archived, so the two most operationally different states were distinguishable only by reading the label. Draft is now amber, Archived keeps grey, and "In review" covers the queue. Colour is never the only signal. Artifact cards had no lifecycle pill at all; now they do.

**Shareable personal collections** — migration 166 pinned owner-bound collections to `private` with no inheritance, so "share the collection I built" was rejected by a CHECK before the service saw it. Now `private` **or** `group`. Retained in both service and database: never `internal`/`public`, and `inherit_grants` stays false. Only the owner may change grants, so a grantee cannot re-share.

**Per-collection publish review** — `requires_approval`, default **false** everywhere. The district-wide allow-then-notify policy is unchanged; this is a narrow opt-in for the intranet and SOPs. Reuses the existing `content_publish_requests` queue — no new table, no new request kind. Approvers are additive (admins + collection owner + `approve` grants), the first two implicit so a gated collection can never end up with nobody able to clear its queue. **Nobody decides their own request**, admins included.

**Section hero art** — upload or AI-generate, through the same `generateImageForNexus` service Nexus uses. Served by a dedicated access-checked route that reads the key **from the row**, never from the caller.

**Bulk publish** — the intranet is authored as drafts and has to go live at once; 48 pages meant 48 modal round-trips. `widenOnly: true` makes it safe over a mixed selection (a public page stays public rather than being narrowed to internal).

## Security notes for review

Three decisions worth a reviewer's attention:

1. **`/admin/atrium` is no longer admin-only.** A collection approver can enter, but the widening is *entry only*: Approvals tab only, filtered to their sections; Collections and Audit stay admin-only in both UI and their own actions. A non-approver gets **404, not 403**, matching Atrium's existence-masking rule.
2. **Zero-grants is inverted for personal collections.** For district collections "no view grants" means unrestricted; here it must mean owner-only. Reusing the district rule would publish every private tree in the district. `.some()` over an empty array is false, so it fails closed by construction rather than by a removable guard. Pinned by test.
3. **`heroImageKey` is deliberately absent from the REST update schema.** Letting a client set it would turn the hero route into an arbitrary read primitive for anything in the bucket. Keys are written only server-side, immediately after that code stored the bytes.

An `approve` grant confers **no** view or create access — matching is on the exact access level, so naming an approver does not hand them the contents.

## Fixes found while building

- Grant options were loaded only in admin mode, so the new personal-collection sharing UI would have shipped with empty role/group pickers.
- `restCollectionGrantSchema` is `.strict()` and the DTO now returns `approve` grants, so a REST read-modify-write on a gated collection would have 400'd on a value we had just handed the client.

## Tests

- **New:** `atrium-shared-personal-collections.test.ts` (10 cases) pins the two rules that fail *silently* if broken — the zero-grants inversion, and that `approve` confers nothing else.
- **New:** `atrium-collection-hero.guard.spec.ts` — the hero route never serves bytes anonymously and never accepts a caller-supplied key.
- **Updated:** `atrium-approvals-actions.test.ts` for the new decider contract. The old assertion was "rejects before any query"; approve/deny must now *read* the request to learn who may decide it, so assertions were re-pointed at what actually matters — no replay, no decision recorded — rather than deleted. Adds self-approval refusal and non-admin-approver coverage.
- **Updated:** three E2E specs for two intentional UI changes — the tag filter's implicit ARIA role is now `combobox` (it carries a typeahead `list`), and the grant chip reads `person <Name>` instead of `user <id>`. The share-grant assertion was *strengthened* to check the resolved name, so a regression back to raw ids fails.

## Verification

- `bun run typecheck` clean
- `bun run lint` clean at `--max-warnings 0`
- **5568 unit tests passing** across 583 suites
- Authenticated Playwright suite green
- Migration 178 applies, re-applies idempotently, and its constraint boundaries were exercised directly against PostgreSQL: `owner+group` permitted; `owner+internal` and `owner+inherit_grants=true` refused

## Rollout

Nothing is gated on merge — `requires_approval` defaults to `false` on every row, so publishing behaves exactly as it does today until the box is ticked on the intranet and SOP collections in **Atrium Oversight → Collections**.
