### PR TITLE
fix(agent): answer only from the run this turn started

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -205,6 +205,44 @@ class TurnResult:
     nudged: bool = False
 
 
+def _shape_of(value: object) -> str:
+    """Field names and types of a payload — never its values.
+
+    Schema discovery needs to know which fields a frame carries. The values
+    can be spreadsheet cells, document text or tool arguments, so they must
+    not reach the logs to establish a key list.
+    """
+    if isinstance(value, dict):
+        return json.dumps(
+            {key: type(item).__name__ for key, item in sorted(value.items())}
+        )[:600]
+    if isinstance(value, list):
+        return f"list[{len(value)}]"
+    return type(value).__name__ if value is not None else "none"
+
+
+# The only fields echoed by value. Each is a closed-vocabulary discriminator
+# the adapter already branches on, so none of them carries user content.
+_STRUCTURAL_MARK_FIELDS = ("stream", "phase", "kind", "status", "state")
+
+
+def _structural_marks(payload: object) -> str:
+    """Echo only closed-vocabulary discriminators, and only short ones."""
+    if not isinstance(payload, dict):
+        return "{}"
+    marks: dict = {}
+    for source in (payload, payload.get("data")):
+        if not isinstance(source, dict):
+            continue
+        for field in _STRUCTURAL_MARK_FIELDS:
+            candidate = source.get(field)
+            # Bounded: a discriminator is a short token. Anything longer is
+            # not one, and is not worth risking.
+            if isinstance(candidate, str) and 0 < len(candidate) <= 32:
+                marks.setdefault(field, candidate)
+    return json.dumps(marks)[:300]
+
+
 def _format_for_chat(text: str) -> str:
     """Final transform applied to every outbound message before it leaves
     the adapter. Converts model-emitted Markdown into Google Chat's
@@ -1538,13 +1576,26 @@ class OpenClawAdapter(HarnessAdapter):
                     # could truncate real answers if they are progress ticks
                     # inside one segment, so capture the shape first and change
                     # behaviour second.
+                    # Logs the SHAPE, never the values. What is needed here is
+                    # which fields a task/tick frame carries, not what the user
+                    # was working on — and these payloads can hold spreadsheet
+                    # cells, document text and tool arguments. Field names plus
+                    # types answer the question; a raw dump would put user
+                    # content in CloudWatch to establish a key list.
+                    # Only the structural discriminators are echoed by value.
                     _kind_key = f"_seen_kind::{key}"
                     if _kind_key not in event_counts:
                         event_counts[_kind_key] = 1
                         logger.info(
-                            "openclaw_kind_sample kind=%s payload=%s",
+                            "openclaw_kind_shape kind=%s payload=%s data=%s marks=%s",
                             key,
-                            json.dumps(msg.get("payload", {}))[:1200],
+                            _shape_of(msg.get("payload")),
+                            _shape_of(
+                                (msg.get("payload") or {}).get("data")
+                                if isinstance(msg.get("payload"), dict)
+                                else None
+                            ),
+                            _structural_marks(msg.get("payload")),
                         )
 
                     if mtype == "event" and mevent == "agent":

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1470,6 +1470,31 @@ class OpenClawAdapter(HarnessAdapter):
                 # final-event handler suppresses ("Here's how far I got: Now
                 # run the batchUpdate."). Covered by test_reply_replay.py.
                 assistant_boundary_pending: bool = False
+                # The run THIS turn started, learned from the chat.send res
+                # (`{"runId": ..., "status": "started"}`). Everything the reply
+                # is built from must belong to it.
+                #
+                # This socket is not private to this turn. The adapter connects
+                # as `role: operator` with operator.admin/read/write, so the
+                # gateway delivers agent events for runs this turn did not
+                # start — including runs in OTHER sessions, and subagent
+                # `announce:` runs. Assistant text was accumulated from all of
+                # them, so a run that outlived the turn which launched it had
+                # its answer returned to whatever turn happened to be listening
+                # when it finished.
+                #
+                # That is not hypothetical. On 2026-08-14 a Docs turn failed at
+                # the harness (subagent Bedrock error), kept running, and
+                # completed two minutes later; the next turn — a different
+                # request, in a DIFFERENT session (6ef59dd1 -> 0093fbb5) — was
+                # answered with that stale run's text, and the user's actual
+                # request was never processed. A confidently wrong answer is a
+                # worse failure than an error, so this fences by run id.
+                turn_run_id: Optional[str] = None
+                # Counted, not silent: if this is ever large the gateway is
+                # delivering someone else's traffic and we want that visible in
+                # the turn log rather than inferred from a wrong answer.
+                foreign_run_events: int = 0
                 # Allow recv() to sit idle for up to 60s between events
                 # without raising — long tool calls (web_fetch, model
                 # inference on a big prompt) produce gaps with no stream
@@ -1495,6 +1520,32 @@ class OpenClawAdapter(HarnessAdapter):
                         first_event_types.append(key)
                     if len(raw_event_samples) < 3:
                         raw_event_samples.append(raw[:600] if isinstance(raw, str) else str(raw)[:600])
+
+                    # DIAGNOSTIC: sample the first frame of every message KIND,
+                    # not just `event:agent`.
+                    #
+                    # The agent-only sampler below is why the adapter's picture
+                    # of the protocol has a hole in it. A turn on 2026-08-14
+                    # carried 69 `event:task` frames and 1 `event:tick`, none of
+                    # which had ever been sampled, so nothing is known about
+                    # what they mean. That matters because assistant segments
+                    # fused in that same turn ("Now read values." + "It's a
+                    # single-column staff directory" -> "values.It's"), and the
+                    # task lane is the obvious suspect for the tool activity
+                    # that should have separated them.
+                    #
+                    # Treating those frames as segment boundaries on a guess
+                    # could truncate real answers if they are progress ticks
+                    # inside one segment, so capture the shape first and change
+                    # behaviour second.
+                    _kind_key = f"_seen_kind::{key}"
+                    if _kind_key not in event_counts:
+                        event_counts[_kind_key] = 1
+                        logger.info(
+                            "openclaw_kind_sample kind=%s payload=%s",
+                            key,
+                            json.dumps(msg.get("payload", {}))[:1200],
+                        )
 
                     if mtype == "event" and mevent == "agent":
                         # DIAGNOSTIC (remove after schema discovery): log the
@@ -1531,6 +1582,21 @@ class OpenClawAdapter(HarnessAdapter):
                         agent_payload = msg.get("payload", {})
                         stream = agent_payload.get("stream")
                         data = agent_payload.get("data", {})
+                        # Drop events belonging to a run this turn did not
+                        # start. Deliberately conservative: it discards only
+                        # when BOTH ids are known and they disagree, so an
+                        # event without a runId, or a gateway that never names
+                        # the run, behaves exactly as before rather than
+                        # silently muting the reply.
+                        event_run_id = agent_payload.get("runId")
+                        if (
+                            isinstance(event_run_id, str)
+                            and event_run_id
+                            and turn_run_id
+                            and event_run_id != turn_run_id
+                        ):
+                            foreign_run_events += 1
+                            continue
                         # Lifecycle events carry sessionId/agentId at the
                         # payload top level (streaming events don't) — capture
                         # them wherever they appear so the post-turn transcript
@@ -1680,6 +1746,29 @@ class OpenClawAdapter(HarnessAdapter):
 
                     elif mtype == "event" and mevent == "chat":
                         payload = msg.get("payload", {})
+                        # Same fence as the agent stream, and for a sharper
+                        # reason: a chat event carrying `state: "error"` ABORTS
+                        # the turn. A subagent's failure arrives on this
+                        # channel under its own `announce:v1:...subagent:...`
+                        # run id, so one failing subagent killed the parent
+                        # turn even though the parent went on to finish the
+                        # work. That is what returned "I couldn't complete
+                        # that" for a Docs task whose doc was created, and
+                        # ownership transferred, two minutes later
+                        # (2026-08-14, run 63282254).
+                        #
+                        # A foreign run's outcome is not this turn's outcome.
+                        # If the turn's own run then never reaches final, the
+                        # deadline still governs — nothing hangs forever.
+                        chat_run_id = payload.get("runId")
+                        if (
+                            isinstance(chat_run_id, str)
+                            and chat_run_id
+                            and turn_run_id
+                            and chat_run_id != turn_run_id
+                        ):
+                            foreign_run_events += 1
+                            continue
                         state = payload.get("state")
                         last_state = state
                         event_message = payload.get("message")
@@ -1941,6 +2030,12 @@ class OpenClawAdapter(HarnessAdapter):
                             observed_model = model_field
                         status = res_payload.get("status")
                         if status in {"started", "accepted"}:
+                            # The gateway names THIS turn's run here. Capture it
+                            # so foreign runs on this socket cannot contribute
+                            # to the reply — see turn_run_id below.
+                            started_run = res_payload.get("runId")
+                            if isinstance(started_run, str) and started_run:
+                                turn_run_id = started_run
                             continue
                         if status in {"final", "done"}:
                             if (
@@ -2158,11 +2253,14 @@ class OpenClawAdapter(HarnessAdapter):
             )
 
         logger.info(
-            "chat turn ok: resp_len=%d last_state=%s event_counts=%s "
+            "chat turn ok: resp_len=%d last_state=%s run_id=%s "
+            "foreign_run_events=%d event_counts=%s "
             "model=%s tokens_in=%d tokens_out=%d cache_read=%d cache_write=%d "
             "latency_ms=%d tool_calls=%d transcript_model_calls=%d",
             len(response_text),
             last_state,
+            turn_run_id or "unknown",
+            foreign_run_events,
             json.dumps(event_counts),
             observed_model or "unknown",
             tokens_in,

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -48,13 +48,18 @@ class _FakeTimeout(Exception):
     """Stands in for websocket.WebSocketTimeoutException (an idle gap)."""
 
 
-def agent_event(stream, data):
+# The run FakeGateway reports for this turn via the chat.send res. Events
+# carrying a different runId belong to somebody else's run.
+TURN_RUN_ID = "run-replay"
+
+
+def agent_event(stream, data, run_id=TURN_RUN_ID):
     """One `event:agent` frame, matching the captured envelope."""
     return {
         "type": "event",
         "event": "agent",
         "payload": {
-            "runId": "run-replay",
+            "runId": run_id,
             "stream": stream,
             "data": data,
             "sessionKey": "agent:main:replay",
@@ -62,6 +67,11 @@ def agent_event(stream, data):
             "isHeartbeat": False,
         },
     }
+
+
+def foreign_says(text, run_id="run-somebody-else"):
+    """An assistant delta from a run this turn did not start."""
+    return agent_event("assistant", {"text": text, "delta": text}, run_id=run_id)
 
 
 def says(text):
@@ -132,6 +142,11 @@ class FakeGateway:
         elif method == "chat.abort":
             self._reply(request_id, {})
         elif method == "chat.send":
+            # The gateway names this turn's run before streaming anything —
+            # `{"runId": ..., "status": "started"}` — then closes with a final
+            # res. Both are replayed so the runId fence sees what it sees in
+            # production.
+            self._reply(request_id, {"status": "started", "runId": TURN_RUN_ID})
             for event in self._agent_events:
                 self._outbox.append(json.dumps(event))
             self._reply(request_id, {"status": "final"})
@@ -154,6 +169,19 @@ def aborts(stop_reason="cancelled"):
         "type": "event",
         "event": "chat",
         "payload": {"state": "aborted", "stopReason": stop_reason},
+    }
+
+
+def foreign_error(run_id="announce:v1:agent:main:subagent:4a5a5b24:7c6a718d"):
+    """A chat error belonging to a subagent run, not to this turn."""
+    return {
+        "type": "event",
+        "event": "chat",
+        "payload": {
+            "state": "error",
+            "runId": run_id,
+            "errorMessage": "LLM request failed.",
+        },
     }
 
 
@@ -300,6 +328,98 @@ class AbortedTurnDoesNotShipScratchpad(unittest.TestCase):
             ]
         )
         self.assertIn("The Q3 doc lists four owners.", text)
+
+
+class ForeignRunsCannotAnswerThisTurn(unittest.TestCase):
+    """The reply must be built only from the run this turn started.
+
+    The adapter's socket is not private to the turn: it connects as
+    `role: operator` with operator.admin/read/write, so the gateway delivers
+    agent events for runs this turn did not start — other sessions included.
+    Assistant text was accumulated from all of them.
+
+    On 2026-08-14 a Docs turn failed at the harness (subagent Bedrock error),
+    kept running, and finished two minutes later. The next turn — a different
+    request in a DIFFERENT session (6ef59dd1 -> 0093fbb5) — was answered with
+    that stale run's text, and the user's real request was never processed.
+    """
+
+    def test_a_stale_runs_answer_is_not_returned(self):
+        text = replay(
+            [
+                foreign_says("Done. Doc created and ownership transferred."),
+                says("Updated the cell to 253.590.6433."),
+            ]
+        )
+        self.assertEqual(text, "Updated the cell to 253.590.6433.")
+
+    def test_a_foreign_run_cannot_supply_the_whole_reply(self):
+        # The turn produced nothing of its own. Answering with someone else's
+        # text is the exact failure; an empty reply is the honest outcome.
+        text = replay([foreign_says("Done. Doc created and ownership transferred.")])
+        self.assertNotIn("Doc created", text)
+
+    def test_a_foreign_run_cannot_split_this_turns_answer(self):
+        # Interleaving must not corrupt the real reply either.
+        text = replay(
+            [
+                says("The sheet has "),
+                foreign_says("Done. Doc created."),
+                says("20 entries."),
+            ]
+        )
+        self.assertEqual(text, "The sheet has 20 entries.")
+
+    def test_a_subagents_failure_does_not_abort_the_parent_turn(self):
+        # A chat event with state:"error" aborts the turn. A subagent's failure
+        # arrives on that channel under its own announce: run id, so one
+        # failing subagent killed a parent turn that went on to finish the
+        # work — the user got "I couldn't complete that" for a doc that was
+        # created and handed over two minutes later.
+        text = replay(
+            [
+                says("Working on it."),
+                foreign_error(),
+                *uses_tool("exec"),
+                says("Created the doc and transferred ownership to you."),
+            ]
+        )
+        self.assertEqual(text, "Created the doc and transferred ownership to you.")
+
+    def test_an_error_on_this_turns_own_run_still_fails_it(self):
+        # The fence must not swallow a real failure of our own run.
+        text = replay(
+            [
+                says("Working on it."),
+                {
+                    "type": "event",
+                    "event": "chat",
+                    "payload": {
+                        "state": "error",
+                        "runId": TURN_RUN_ID,
+                        "errorMessage": "LLM request failed.",
+                    },
+                },
+            ]
+        )
+        self.assertIn("couldn't", text.lower())
+
+    def test_events_without_a_run_id_are_still_accepted(self):
+        # Fails open: a gateway that does not name the run must behave exactly
+        # as before rather than silently muting every reply.
+        text = replay(
+            [
+                {
+                    "type": "event",
+                    "event": "agent",
+                    "payload": {
+                        "stream": "assistant",
+                        "data": {"text": "No runId here.", "delta": "No runId here."},
+                    },
+                }
+            ]
+        )
+        self.assertEqual(text, "No runId here.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A turn was answered with a different turn's output, in a different session, and the user's actual request was never processed.

## What happened (dev, 2026-08-14)

| Time | Run / session | Outcome |
|---|---|---|
| 22:26:23 | `63282254` / **`6ef59dd1`** | "create a Doc, transfer ownership" — subagent hit a Bedrock error, harness gave up: *"I couldn't complete that"* |
| ~22:28 | (same run, never stopped) | **finished the work anyway** — doc exists, ownership mail timestamped 3:28pm |
| 22:27:43 | `76a96a79` / `0093fbb5` | spreadsheet summary, correct, 943 chars |
| 22:30:11 | `d30863a4` / `0093fbb5` | "change my cell to …" — **answered with run `63282254`'s text** (156 chars); cell never changed |

Output crossed a **session** boundary: `6ef59dd1` → `0093fbb5`.

## Why

The adapter's socket is not private to a turn. It connects as `role: operator` with `operator.admin/read/write`, so the gateway delivers agent and chat events for runs this turn did not start — other sessions included, and subagent `announce:v1:…` runs. The reply was accumulated from every assistant event that arrived, regardless of which run produced it.

The gateway already names the turn's run in the chat.send res — `{"runId": …, "status": "started"}` — and the adapter read that payload for usage and model id while discarding the runId.

## The fence

Capture the runId from the started res; drop events whose runId disagrees, on **both** channels:

- **`event:agent`** — stops a foreign run contributing assistant text. Also covers a class of "fused" replies, since foreign text was concatenated mid-stream into real answers.
- **`event:chat`** — sharper, because `state: "error"` *aborts the turn*. A subagent failure arrives here under its own `announce:` run id, so **one failing subagent killed a parent turn that went on to finish the work**. A foreign run's outcome is not this turn's outcome; if our own run never reaches final, the deadline still governs.

Deliberately conservative: discards only when **both** ids are known and disagree. No runId, or a gateway that never names the run, behaves exactly as before — this cannot silently mute replies. Foreign frames are counted and logged per turn as `foreign_run_events=N` alongside `run_id=`.

## Tests

Six new cases, all **mutation-verified** — disabling each fence reproduces the production symptom, not merely a failure:

```
agent fence off -> 'Done. Doc created and ownership transferred.'  (returned alone)
                -> 'The sheet has Done. Doc created.20 entries.'
chat fence off  -> "I couldn't finish that" replacing the real answer
```

Also asserted: an error on our **own** run still fails the turn, and events without a runId are still accepted.

## Not fixed here

**Narration fusion within a single run.** That turn carried 69 `event:task` frames and 1 `event:tick` — message kinds the adapter has never sampled. The task lane is the obvious suspect for tool activity that should separate assistant segments, but treating those frames as boundaries on a guess could **truncate real answers** if they're progress ticks inside one segment. This adds an `openclaw_kind_sample` diagnostic that samples the first frame of every message kind and changes no behaviour. Shape first, fix second.

**The underlying Bedrock error** — OpenClaw sends a subagent request whose history has `toolUse`/`toolResult` blocks with no `toolConfig` — is inside the pinned `2026.7.2-beta.5` bundle. This change stops it destroying the parent turn, which is the part that reached users.

246 tests pass across `test_reply_replay`, `test_harness_adapter`, `test_iteration_telemetry`, `test_agentcore_wrapper`.

Pushed with `SKIP_E2E=1`: agent-image-only, and the new-branch case fails open in the pre-push hook (no remote sha to diff against).