### PR TITLE
fix(atrium): make the header-image control usable, and free ownership from the chip row

### DIFF
--- a/actions/db/atrium/collection-hero.ts
+++ b/actions/db/atrium/collection-hero.ts
@@ -148,7 +148,17 @@ export async function setCollectionHeroImageAction(
       return createSuccess(cleared, "Header image removed");
     }
 
-    const alt = parsed.alt?.trim() ?? "";
+    // Alt text, with the GENERATION prompt as its fallback.
+    //
+    // The prompt is already a description of the image, so requiring separate
+    // alt text asked the same question twice — and the UI expressed that by
+    // disabling Generate until both were filled, which read as a broken button.
+    // Defaulting here rather than only in the client means every caller gets
+    // the same behaviour and the accessibility requirement still always holds.
+    //
+    // An UPLOAD has no prompt to borrow, so alt text remains genuinely
+    // required there.
+    const alt = parsed.alt?.trim() || parsed.prompt?.trim() || "";
     if (alt.length === 0) {
       // Enforced here rather than in the schema so it applies only to the two
       // set paths — a clear has no image left to describe.

--- a/components/atrium/LibraryView.tsx
+++ b/components/atrium/LibraryView.tsx
@@ -54,11 +54,8 @@ const VIEWS = [
   { value: "home", label: "Home" },
   { value: "all", label: "All content" },
   { value: "favorites", label: "Favorites" },
-  { value: "mine", label: "Mine" },
-  { value: "others", label: "Everyone else" },
   { value: "document", label: "Docs" },
   { value: "artifact", label: "Artifacts" },
-  { value: "shared", label: "Shared with me" },
   { value: "unfiled", label: "Unfiled" },
   { value: "archived", label: "Archived" },
 ] as const;
@@ -70,26 +67,38 @@ const VIEWS = [
  * stay reachable from the home bands' "see all" links, and a chip for the active
  * view is added back in `LibraryChips` so the bar always shows where you are.
  *
- * "Mine" and "Everyone else" are primary despite that budget. An administrator
- * sees the whole district here, so the unfiltered library is mostly other
- * people's work and the first question on opening it is always "which of this
- * is mine?". Leaving the answer off the bar (it was reachable only from a home
- * band) made the one view that makes the library usable at admin scale the one
- * view nobody could find.
- *
- * Status and creator are deliberately NOT chips — see `LibraryChips`.
+ * Ownership is deliberately NOT here — see `OWNER_FILTERS`.
  */
 const PRIMARY_VIEWS: readonly LibraryFilterView[] = [
   "home",
   "all",
-  "mine",
-  "others",
   "favorites",
   "document",
   "artifact",
-  "shared",
   "archived",
 ];
+
+/**
+ * Ownership filter, applied ORTHOGONALLY to the view chips.
+ *
+ * These began life as chips, which was wrong: chips are single-select, so
+ * picking "Mine" meant giving up "Docs", and "show me MY docs" — the single
+ * most common question an administrator asks of a district-wide library — was
+ * the one combination the bar could not express. Same mistake, and same fix, as
+ * status and creator below.
+ *
+ * "Everyone else" is broader than "Shared with me" and they are not
+ * complements: shared additionally requires group/private visibility, so
+ * "others" is a superset of it.
+ */
+const OWNER_FILTERS = [
+  { value: "any", label: "Anyone" },
+  { value: "mine", label: "Mine" },
+  { value: "others", label: "Everyone else" },
+  { value: "shared", label: "Shared with me" },
+] as const;
+
+type LibraryOwnerFilter = (typeof OWNER_FILTERS)[number]["value"];
 
 /**
  * Lifecycle filter, applied ORTHOGONALLY to the view chips.
@@ -371,6 +380,8 @@ function LibraryChips({
   tag,
   onTag,
   tagSuggestions,
+  owner,
+  onOwner,
   status,
   onStatus,
   actor,
@@ -382,6 +393,8 @@ function LibraryChips({
   tag: string;
   onTag: (v: string) => void;
   tagSuggestions: string[];
+  owner: LibraryOwnerFilter;
+  onOwner: (v: LibraryOwnerFilter) => void;
   status: LibraryStatusFilter;
   onStatus: (v: LibraryStatusFilter) => void;
   actor: LibraryActorFilter;
@@ -413,6 +426,19 @@ function LibraryChips({
           chip row's overflow scrolling on narrow screens. Two fixed, tiny
           option lists need no combobox.
         */}
+        <select
+          aria-label="Filter by owner"
+          className="mer-chip-select"
+          value={owner}
+          onChange={(e) => onOwner(e.target.value as LibraryOwnerFilter)}
+          data-testid="library-owner-filter"
+        >
+          {OWNER_FILTERS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
         <select
           aria-label="Filter by status"
           className="mer-chip-select"
@@ -482,7 +508,6 @@ function LibraryChips({
  */
 function viewToFilter(view: LibraryFilterView): {
   kind?: ContentKind;
-  owner?: "shared" | "mine" | "others";
   status?: "archived";
   filed?: "unfiled";
   favorite?: true;
@@ -492,12 +517,6 @@ function viewToFilter(view: LibraryFilterView): {
       return { kind: "document" };
     case "artifact":
       return { kind: "artifact" };
-    case "shared":
-      return { owner: "shared" };
-    case "mine":
-      return { owner: "mine" };
-    case "others":
-      return { owner: "others" };
     case "favorites":
       return { favorite: true };
     case "unfiled":
@@ -563,7 +582,6 @@ function resolveView(
 ): {
   effectiveView: LibraryFilterView;
   kind?: ContentKind;
-  owner?: "shared" | "mine" | "others";
   status?: "archived";
   filed?: "unfiled";
   favorite?: true;
@@ -749,6 +767,32 @@ function useLibrarySelection() {
   return { selected, clearSelection, toggleSelect, removeFromSelection };
 }
 
+/**
+ * Translate a home band's "see all" target into filter state.
+ *
+ * "mine" is no longer a VIEW — ownership became an orthogonal select so it can
+ * combine with Docs/Artifacts — so the band's intent is expressed as the pair
+ * it always meant: the full grid, filtered to this person's content.
+ *
+ * Extracted from `LibraryView` to keep it under the max-lines lint.
+ */
+function useSeeAllHandler(
+  setView: (v: LibraryFilterView) => void,
+  setOwnerFilter: (v: LibraryOwnerFilter) => void
+): (target: "all" | "mine" | "unfiled" | "favorites") => void {
+  return useCallback(
+    (target) => {
+      if (target === "mine") {
+        setView("all");
+        setOwnerFilter("mine");
+        return;
+      }
+      setView(target);
+    },
+    [setView, setOwnerFilter]
+  );
+}
+
 export interface LibraryViewProps {
   /**
    * The cross-origin sandbox render URL, resolved SERVER-SIDE
@@ -781,6 +825,7 @@ export function LibraryView({
   const [tag, setTag] = useState("");
   const [search, setSearch] = useState("");
   // Orthogonal to the view chips — see STATUS_FILTERS / ACTOR_FILTERS.
+  const [ownerFilter, setOwnerFilter] = useState<LibraryOwnerFilter>("any");
   const [statusFilter, setStatusFilter] = useState<LibraryStatusFilter>("any");
   const [actorFilter, setActorFilter] = useState<LibraryActorFilter>("any");
   const searchRef = useRef<HTMLInputElement>(null);
@@ -815,7 +860,7 @@ export function LibraryView({
   } = useLibraryCreate(collectionId);
 
   // Derive the server filter from the active chip.
-  const { effectiveView, kind, owner, status, filed, favorite, archivedView, homeView } =
+  const { effectiveView, kind, status, filed, favorite, archivedView, homeView } =
     resolveView(view, searching);
 
   // The Archived VIEW wins over the status SELECT: it is itself a status
@@ -826,6 +871,8 @@ export function LibraryView({
     : statusFilter === "any"
       ? undefined
       : statusFilter;
+
+  const handleSeeAll = useSeeAllHandler(setView, setOwnerFilter);
 
   const tagSuggestions = useTagSuggestions(debouncedTag);
 
@@ -842,7 +889,7 @@ export function LibraryView({
   } = useLibraryPage({
       collectionId: collectionId ?? undefined,
       kind,
-      owner,
+      owner: ownerFilter === "any" ? undefined : ownerFilter,
       status: effectiveStatus,
       filed,
       favorite,
@@ -907,6 +954,8 @@ export function LibraryView({
           tag={tag}
           onTag={setTag}
           tagSuggestions={tagSuggestions}
+          owner={ownerFilter}
+          onOwner={setOwnerFilter}
           status={statusFilter}
           onStatus={setStatusFilter}
           actor={actorFilter}
@@ -915,7 +964,7 @@ export function LibraryView({
         />
 
         {homeView ? (
-          <LibraryHome onSeeAll={setView} />
+          <LibraryHome onSeeAll={handleSeeAll} />
         ) : (
           <>
         <LibraryBulkBar

--- a/components/atrium/SectionSettingsDialog.tsx
+++ b/components/atrium/SectionSettingsDialog.tsx
@@ -20,7 +20,7 @@
  * need an admin; restructuring it still does.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Settings2 } from "lucide-react";
 import {
@@ -79,44 +79,70 @@ function readFileAsDataUrl(file: File): Promise<string> {
 }
 
 /**
- * The section's header image: upload one, generate one, or remove it.
+ * All hero-image state and side effects, for `HeroImageEditor`.
  *
- * Its own component with its own state, and it applies changes IMMEDIATELY
- * rather than participating in the dialog's Save. Image work is slow (a
- * generation call is several seconds) and independently fallible (no model
- * configured, a provider refusal, an oversized file) — folding it into Save
- * would let an image failure discard the description edits made beside it, and
+ * Changes apply IMMEDIATELY rather than participating in the dialog's Save.
+ * Image work is slow (generation takes seconds) and independently fallible (no
+ * model configured, a provider refusal, an oversized file) — folding it into
+ * Save would let an image failure discard the description edits beside it, and
  * would make Save's latency unpredictable.
+ *
+ * Split from the component so the component is markup only and both stay under
+ * the max-lines lint.
  */
-function HeroImageEditor({
-  collectionId,
-  hasHeroImage,
-  initialAlt,
-}: {
-  collectionId: string;
-  hasHeroImage: boolean;
-  initialAlt: string | null;
-}): React.JSX.Element {
+function useHeroImage(
+  collectionId: string,
+  hasHeroImage: boolean,
+  initialAlt: string | null
+) {
   const router = useRouter();
   const [prompt, setPrompt] = useState("");
   const [alt, setAlt] = useState(initialAlt ?? "");
   const [busy, setBusy] = useState(false);
+  const [busyLabel, setBusyLabel] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [present, setPresent] = useState(hasHeroImage);
+  /**
+   * Cache-buster for the preview `src`.
+   *
+   * The hero route sets `immutable` and each write stores a NEW key, so the URL
+   * is stable while its bytes change. Without a changing query the browser
+   * keeps showing the OLD image after a replace — which reads as "nothing
+   * happened", the single most confusing thing about the first version of this
+   * control.
+   */
+  const [previewSeq, setPreviewSeq] = useState(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const apply = useCallback(
-    async (input: { dataUrl?: string; prompt?: string; clear?: boolean }) => {
+    async (
+      input: { dataUrl?: string; prompt?: string; clear?: boolean },
+      label: string,
+      /**
+       * Alt text to send. Generation passes the PROMPT when the author has not
+       * written alt text separately — the prompt already describes the image,
+       * so demanding it twice was pure friction.
+       */
+      altToSend: string
+    ) => {
       setBusy(true);
+      setBusyLabel(label);
       setError(null);
+      setNotice(null);
       try {
         const res = await setCollectionHeroImageAction(collectionId, {
           ...input,
-          alt,
+          alt: altToSend,
         });
         if (res.isSuccess) {
           setPresent(!input.clear);
-          if (input.clear) setAlt("");
+          setAlt(input.clear ? "" : altToSend);
           setPrompt("");
+          setPreviewSeq((n) => n + 1);
+          setNotice(
+            input.clear ? "Header image removed." : "Header image updated."
+          );
           // The hero is server-rendered; re-run the server components in place
           // rather than reloading the document.
           router.refresh();
@@ -131,8 +157,9 @@ function HeroImageEditor({
         });
       }
       setBusy(false);
+      setBusyLabel("");
     },
-    [collectionId, alt, router]
+    [collectionId, router]
   );
 
   const onPickFile = useCallback(
@@ -148,24 +175,123 @@ function HeroImageEditor({
         );
         return;
       }
+      // An UPLOAD has no prompt to borrow, so alt text is genuinely required.
+      // Say so on the attempt rather than disabling the control — a dead button
+      // with a hint underneath reads as "broken", which is exactly how the
+      // first version of this was received.
+      if (alt.trim().length === 0) {
+        setError(
+          "Add a short description of the image first — screen readers need it."
+        );
+        return;
+      }
       void (async () => {
         try {
-          await apply({ dataUrl: await readFileAsDataUrl(file) });
+          await apply(
+            { dataUrl: await readFileAsDataUrl(file) },
+            "Uploading…",
+            alt.trim()
+          );
         } catch {
           setError("Could not read that file");
         }
       })();
     },
-    [apply]
+    [apply, alt]
   );
 
-  // Alt text is required by the server on both set paths, so the controls are
-  // disabled until it exists rather than letting the request fail.
-  const needsAlt = alt.trim().length === 0;
+  const onGenerate = useCallback(() => {
+    const description = prompt.trim();
+    if (description.length < 3) {
+      setError("Describe the image you want in a few more words.");
+      return;
+    }
+    // The prompt IS a description of the image, so it doubles as alt text when
+    // the author has not written their own. Requiring both was asking the same
+    // question twice.
+    void apply({ prompt: description }, "Generating…", alt.trim() || description);
+  }, [apply, prompt, alt]);
+
+  return {
+    prompt, setPrompt, alt, setAlt, busy, busyLabel, error, notice, present,
+    previewSeq, fileInputRef, apply, onPickFile, onGenerate,
+  };
+}
+
+function HeroImageEditor({
+  collectionId,
+  hasHeroImage,
+  initialAlt,
+}: {
+  collectionId: string;
+  hasHeroImage: boolean;
+  initialAlt: string | null;
+}): React.JSX.Element {
+  const {
+    prompt, setPrompt, alt, setAlt, busy, busyLabel, error, notice, present,
+    previewSeq, fileInputRef, apply, onPickFile, onGenerate,
+  } = useHeroImage(collectionId, hasHeroImage, initialAlt);
 
   return (
     <div className="space-y-2">
-      <Label htmlFor="section-hero-alt">Header image</Label>
+      <Label>Header image</Label>
+
+      {/*
+        PREVIEW. The first version showed nothing at all: the hero renders on
+        the page BEHIND this modal, so generating produced no visible change
+        and looked like a no-op even when it had worked. `previewSeq` busts the
+        immutable cache so a replacement actually appears.
+      */}
+      {present ? (
+        <img
+          src={`/api/atrium/collections/${collectionId}/hero?v=${previewSeq}`}
+          alt={alt || "Current header image"}
+          className="mer-hero-preview"
+          data-testid="section-hero-preview"
+        />
+      ) : (
+        <p className="mer-hero-preview mer-hero-preview--empty">
+          No header image yet
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {/*
+          A real button. This was a bare <input type="file">, which macOS
+          renders as the unstyled text "Choose File / No file chosen" — it did
+          not read as clickable and was routinely missed. The input is still
+          the thing that opens the picker (that cannot be synthesised
+          accessibly), just visually hidden behind a label styled as a button.
+        */}
+        <label className="mer-btn" data-testid="section-hero-upload-label">
+          Upload image…
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            className="sr-only"
+            disabled={busy}
+            onChange={(e) => {
+              onPickFile(e.target.files?.[0]);
+              // Reset so picking the SAME file again still fires onChange.
+              if (fileInputRef.current) fileInputRef.current.value = "";
+            }}
+            data-testid="section-hero-upload"
+          />
+        </label>
+        {present && (
+          <button
+            type="button"
+            className="mer-btn"
+            disabled={busy}
+            onClick={() => void apply({ clear: true }, "Removing…", "")}
+            data-testid="section-hero-remove"
+          >
+            Remove image
+          </button>
+        )}
+      </div>
+
       <input
         id="section-hero-alt"
         className="h-9 w-full rounded-md border bg-background px-3 text-sm"
@@ -174,30 +300,10 @@ function HeroImageEditor({
         disabled={busy}
         placeholder="Describe the image for screen readers"
         onChange={(e) => setAlt(e.target.value)}
+        aria-label="Describe the image for screen readers"
         data-testid="section-hero-alt"
       />
-      <div className="flex flex-wrap items-center gap-2">
-        <input
-          type="file"
-          accept="image/png,image/jpeg,image/webp,image/gif"
-          className="text-xs"
-          disabled={busy || needsAlt}
-          onChange={(e) => onPickFile(e.target.files?.[0])}
-          aria-label="Upload a header image"
-          data-testid="section-hero-upload"
-        />
-        {present && (
-          <button
-            type="button"
-            className="mer-btn"
-            disabled={busy}
-            onClick={() => void apply({ clear: true })}
-            data-testid="section-hero-remove"
-          >
-            Remove image
-          </button>
-        )}
-      </div>
+
       <div className="flex flex-wrap items-center gap-2">
         <input
           className="h-9 min-w-0 flex-1 rounded-md border bg-background px-3 text-sm"
@@ -208,19 +314,30 @@ function HeroImageEditor({
           onChange={(e) => setPrompt(e.target.value)}
           data-testid="section-hero-prompt"
         />
+        {/*
+          Enabled whenever there is a prompt. It used to also require the alt
+          field, which meant pressing it after typing a prompt did NOTHING and
+          gave no reason why. The prompt now doubles as the alt text.
+        */}
         <button
           type="button"
           className="mer-btn"
-          disabled={busy || prompt.trim().length < 3 || needsAlt}
-          onClick={() => void apply({ prompt })}
+          disabled={busy}
+          onClick={onGenerate}
           data-testid="section-hero-generate"
         >
-          {busy ? "Working…" : "Generate"}
+          {busy && busyLabel === "Generating…" ? "Generating…" : "Generate"}
         </button>
       </div>
-      {needsAlt && (
-        <p className="text-xs text-muted-foreground">
-          Add a description above before uploading or generating.
+
+      {busy && (
+        <p className="text-xs text-muted-foreground" role="status">
+          {busyLabel} This can take a few seconds.
+        </p>
+      )}
+      {notice && !busy && (
+        <p className="text-xs text-muted-foreground" role="status">
+          {notice}
         </p>
       )}
       {error && (

--- a/lib/content/collection-hero-service.ts
+++ b/lib/content/collection-hero-service.ts
@@ -234,8 +234,12 @@ export async function generateHeroImage(
     // approach the agent `images.generate` tool takes with `agent-{requestId}`.
     conversationId: `atrium-collection-${collectionId}`,
     userId: String(userId),
-    // Wide, because it renders as a banner across the top of a section page.
-    size: "1792x1024",
+    // NO explicit size. `1792x1024` is a DALL·E-era dimension and the current
+    // gpt-image models reject it, which failed generation for a banner shape we
+    // do not actually need: `.mer-section-hero-image` crops to 16/5 with
+    // `object-fit: cover`, so a square render looks identical once placed.
+    // Letting each provider use its own default keeps this working across
+    // whichever image model the deployment has configured.
   });
 
   // Read the bytes back through the presigned URL the generation service

--- a/styles/meridian-core.css
+++ b/styles/meridian-core.css
@@ -994,6 +994,28 @@
 /* Section hero art (migration 178). A fixed aspect band rather than the
    image's natural height, so a portrait upload cannot push the section's title
    and contents below the fold. */
+/* Hero preview inside the section-settings dialog. Same 16/5 crop the real
+   hero uses, so what you see here is what the page will show. Without a
+   preview the dialog gave no feedback at all — the hero it was editing sat on
+   the page behind the modal. */
+.mer-hero-preview {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 5;
+  object-fit: cover;
+  border-radius: var(--mer-r-card, 10px);
+  background: var(--mer-canvas-sunken);
+  border: 1px solid var(--mer-line);
+}
+.mer-hero-preview--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12.5px;
+  color: var(--mer-ink-muted);
+  border-style: dashed;
+}
+
 .mer-section-hero-image {
   display: block;
   width: 100%;

--- a/tests/e2e/atrium-meridian-library.spec.ts
+++ b/tests/e2e/atrium-meridian-library.spec.ts
@@ -7,7 +7,7 @@ import { mkdirSync } from "node:fs";
  *
  * Drives the restyled `/atrium` library as an authenticated capability holder:
  * the Meridian search field (⌘K-focusable), the filter chips (All / Docs /
- * Artifacts / Shared with me — the last exercising the new server `owner:
+ * Artifacts, plus the orthogonal owner select exercising the server `owner:
  * "shared"` filter), the content card grid, and the dashed "Create with the
  * agent" card. Screenshots land in docs/verification/meridian/.
  *
@@ -45,7 +45,7 @@ test.describe("Atrium Meridian library (authenticated)", () => {
       // Filter chips.
       const chips = page.getByRole("group", { name: "Filter content" });
       await expect(chips).toBeVisible();
-      for (const label of ["All", "Docs", "Artifacts", "Shared with me"]) {
+      for (const label of ["All", "Docs", "Artifacts"]) {
         await expect(chips.getByRole("button", { name: label })).toBeVisible();
       }
 
@@ -84,12 +84,25 @@ test.describe("Atrium Meridian library (authenticated)", () => {
       await page.keyboard.press("Meta+k");
       await expect(search).toBeFocused();
 
-      // "Shared with me" chip is a live filter (reloads without error).
-      const sharedChip = chips.getByRole("button", { name: "Shared with me" });
-      await sharedChip.click();
-      await expect(sharedChip).toHaveAttribute("aria-pressed", "true");
-      // The grid re-queries; the create card is always present (proves no crash /
-      // no error state after the owner-scoped reload).
+      // Ownership is an ORTHOGONAL select, not a chip: chips are single-select,
+      // so "Mine" as a chip meant giving up "Docs" and could never answer "show
+      // me MY docs". Combining the two is the point, so drive both and assert
+      // the grid survives the owner-scoped reload.
+      const ownerFilter = page.getByTestId("library-owner-filter");
+      await expect(ownerFilter).toBeVisible();
+      await ownerFilter.selectOption("shared");
+      await expect(ownerFilter).toHaveValue("shared");
+
+      // Owner + kind together — the combination the chip row could not express.
+      await ownerFilter.selectOption("mine");
+      await chips.getByRole("button", { name: "Docs" }).click();
+      await expect(ownerFilter).toHaveValue("mine");
+      await expect(chips.getByRole("button", { name: "Docs" })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+
+      // The create card is always present (proves no crash / no error state).
       await expect(
         page.getByRole("button", { name: /New interactive page/i })
       ).toBeVisible();

--- a/tests/unit/atrium-collection-hero-action.test.ts
+++ b/tests/unit/atrium-collection-hero-action.test.ts
@@ -122,6 +122,44 @@ describe("hero image — authorize before spending", () => {
   });
 });
 
+describe("hero image — alt text", () => {
+  it("uses the generation prompt as alt text when none was written", async () => {
+    // The prompt already describes the image. Demanding alt text separately
+    // meant the Generate button sat disabled after you had typed a perfectly
+    // good description into the field right next to it, doing nothing when
+    // pressed and explaining nothing.
+    await setCollectionHeroImageAction(COLLECTION, {
+      prompt: "a quiet school library at golden hour",
+    });
+
+    expect(updateMock).toHaveBeenCalledWith(USER, COLLECTION, {
+      heroImageKey: "atrium/collections/x/hero/gen.png",
+      heroImageAlt: "a quiet school library at golden hour",
+    });
+  });
+
+  it("prefers explicit alt text over the prompt when both are given", async () => {
+    await setCollectionHeroImageAction(COLLECTION, {
+      prompt: "a quiet school library at golden hour",
+      alt: "Students reading by a window",
+    });
+
+    expect(updateMock).toHaveBeenCalledWith(USER, COLLECTION, {
+      heroImageKey: "atrium/collections/x/hero/gen.png",
+      heroImageAlt: "Students reading by a window",
+    });
+  });
+
+  it("still requires alt text for an upload, which has no prompt to borrow", async () => {
+    const result = await setCollectionHeroImageAction(COLLECTION, {
+      dataUrl: "data:image/png;base64,aGk=",
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(storeMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("hero image — superseded object cleanup", () => {
   it("deletes the previous image only after the row points at the new one", async () => {
     assertMaySetSectionCopyMock.mockResolvedValue({


### PR DESCRIPTION
## Why

Follow-up to #1641, from actually using the UI it shipped. Every problem here is the same shape: the code was correct and the interface gave no way to tell.

Reported verbatim: *"the button to upload a picture doesn't exist"*, *"I pushed generate, but have no idea if it's going to work"*, *"the generate never actually produces an image"*, and *"you added a mine button, but I should be able to select that and documents… It shouldn't be an either or."*

## The header-image control

Four distinct causes, all real:

**1. There was no preview.** The dialog edits a hero that renders on the page *behind* the modal, so a successful generate changed nothing visible and looked like a no-op. There's now a preview in the dialog, cropped 16/5 exactly as the page crops it. Its `src` carries a counter because the hero route sets `immutable` — without it the browser keeps showing the **old** image after a replace, which is the same "nothing happened" failure wearing a different hat.

**2. The upload control was not a button.** It was a bare `<input type="file">`, which macOS renders as the unstyled text "Choose File / No file chosen" — see the screenshot in the issue thread. It's now a label styled as a button with the input visually hidden (the input still opens the picker; that can't be synthesised accessibly). It also resets after each pick, so choosing the *same* file twice still fires.

**3. Generate was disabled until alt text existed — silently.** Pressing it after typing a prompt did nothing and explained nothing, with only a small hint below. A dead button reads as broken. The prompt **is** a description of the image, so it now doubles as the alt text. Defaulted in the **action**, not just the client, so every caller behaves the same and the accessibility requirement still always holds. An upload has no prompt to borrow, so alt text stays required there — but it's now reported on the attempt rather than by disabling the control.

**4. The requested image size was wrong.** `1792x1024` is a DALL·E-era dimension that current gpt-image models reject, so generation could fail outright on the configured model. No size is requested now: the hero crops to 16/5 with `object-fit: cover`, so a square render is indistinguishable once placed, and each provider can use its own default.

Progress and outcome are now stated plainly — "Generating… This can take a few seconds", then "Header image updated." — instead of a pause and an unchanged screen.

> Checked before assuming: `gpt-image-1.5` is active and `parseCapabilities` maps the DB's `image_generation` to `imageGeneration`, so model resolution was never the problem.

## Ownership vs. kind

Chips are single-select, so "Mine" as a chip meant giving up "Docs" — and *"show me my docs"*, the first question anyone asks of a district-wide library, was the one combination the bar could not express. This is the same mistake #1641 fixed for status and creator and then failed to apply to ownership.

Mine / Everyone else / Shared with me move out of the chip row into an orthogonal owner select beside status and creator. Chips go back to what they're good at: kind and lifecycle. The home band's "see all" for recent work now sets the pair it always meant (all content, owned by me) rather than selecting a view that no longer exists.

## Tests

- Three new cases in `atrium-collection-hero-action.test.ts`: the prompt is used as alt text when none was written, explicit alt still wins, and an upload without alt is still refused.
- `atrium-meridian-library.spec.ts` drives the owner select instead of the removed chip and asserts owner **+** kind together — the combination that motivated the change. It passed in every local run.

## Verification

- `bun run typecheck` clean
- `bun run lint` clean at `--max-warnings 0`
- **5607 unit tests passing**
- Local authenticated Playwright: **319 passing across three separate runs**

The local E2E gate was skipped for this push, with the repo owner's explicit sign-off. Three consecutive full runs each failed a *different* single spec — `nexus-chat-pii`, then two rooms specs, then the artifact embed picker — every one a **timeout**, never a wrong assertion, and none touching this diff. `nexus-chat-pii` was run in isolation and passed in **6.2s** versus timing out at 2.1m under load. Clearing 245 accumulated content objects / 440 graph nodes / 108 collections did not stop it, so this is machine contention rather than anything in the change. CI's own Test/Lint/Typecheck job runs independently here.
