### PR TITLE
fix(quartile): extract raw pairs, compute quartiles locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,9 @@ jobs:
           infra/agent-image/test_report.py \
           infra/agent-image/test_tts_synthesize.py \
           infra/agent-image/skills/psd-last30days/scripts/test_last30days.py \
-          infra/agent-image/skills/psd-observances/tools/test_nspra_markdown.py
+          infra/agent-image/skills/psd-observances/tools/test_nspra_markdown.py \
+          infra/agent-image/skills/quartile-growth-report/scripts/test_norms_values.py \
+          infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
 
     - name: Run model-UID isolation test as root
       run: |

--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -29,9 +29,29 @@ as a "summary" row or a note next to a number.
 
 1. Resolve the school. Confirm back which school and year you are running.
 2. Discover the roster: `GR0x` homeroom sections + lead teachers + counts.
-3. Per grade, run the measure blocks (see `references/sql.md`).
+3. Per grade, **extract then aggregate** (see `references/sql.md`):
+   - run the extraction query — raw matched pairs, no `NTILE`, no norms join,
+     no `GROUPING SETS`
+   - pipe those rows through `scripts/aggregate.py`, which applies the national
+     norms and computes every quartile scope
 4. Build ONE spreadsheet with `psd-workspace`: a tab per grade + Definitions.
 5. Share it and paste the bare URL on its own line.
+
+**Never put a window function or the norms lookup in SQL.** Window functions do
+not complete against `dibels_scores` on this MCP server at any size — a bare
+`NTILE(4)` over ~1,100 rows times out, while the same query without it runs in
+seconds (isolated 2026-08-15, Evergreen Elementary). The extraction query is a
+plain indexed read and returned 2,232 rows for grade K in about 3 seconds.
+
+Do not try to make `NTILE` work by simplifying around it. That was attempted
+over several passes — dropping the norms join, dropping the classroom
+breakdown, splitting the partitions — and produced no report at all. If an
+extraction query times out, simplify the extraction; never move arithmetic back
+into it.
+
+**One extraction query per grade, not per measure.** The `IN (…)` list takes
+every measure for the grade at once. Per-measure querying turns 6 grades into
+30+ round trips and is what makes this report feel endless.
 
 ### How to run it
 

--- a/infra/agent-image/skills/quartile-growth-report/references/sql.md
+++ b/infra/agent-image/skills/quartile-growth-report/references/sql.md
@@ -17,94 +17,112 @@ enrollment per student; teacher is `role_name = 'Lead Teacher'`. Never filter on
 `priorityorder` — it is often null. `LEFT JOIN teachers`; an unresolvable id is
 labeled `(Not on file)`.
 
-## Core pattern — local quartiles + national PR
+## Core pattern — extract raw pairs, aggregate locally
 
-Generate the `norms` body first:
+**The warehouse returns matched pairs. Quartiles and national PR are computed
+on this box.** Do not put `NTILE`, norms, or `GROUPING SETS` in the query.
 
-```bash
-/opt/agentcore-venv/bin/python3 /opt/psd-skills/quartile-growth-report/scripts/norms_values.py \
-  --grade 3 --period Fall --period Spring \
-  --measure ORF-WRC --measure NWF-CLS --as "<warehouse name>" --as "<warehouse name>"
-```
+That is not a style preference. **Window functions do not complete against
+`dibels_scores` on this MCP server at any size.** Isolated on 2026-08-15
+(Evergreen Elementary 2025-26): a bare `NTILE(4)` over ~1,100 rows, with no
+norms join and no classroom breakdown, timed out; the same query without the
+window ran in seconds. Row count is not the variable — a 2,200-row window
+function should be instant.
+
+The extraction query below returned **2,232 matched rows for grade K in about
+3 seconds**, confirmed in the same session.
+
+So the split is not an optimization to tune, it is the only shape that runs. Do
+not try to make `NTILE` work here by simplifying around it — that was tried
+across several passes and cost hours without producing a report.
+
+### Step 1 — the query (ONE per grade, covering every measure)
+
+`assessment_group IN (…)` takes the whole measure list for the grade in a single
+call. Do not run this per measure: that turns 6 grades into 30+ round trips for
+no benefit, and pass count is what makes this report feel endless.
+
+Student ids are pulled because the quartile tiebreak needs them. They stay in
+the local rows and in `aggregate.py`; only aggregated cells reach the workbook
+or the reply.
 
 ```sql
-WITH norms(meas0, per, cut, pr) AS (VALUES /* paste generated rows */),
-stu AS (  -- one row per student/measure/window; AVG neutralizes retests
+WITH stu AS (  -- one row per student/measure/window; AVG neutralizes retests
   SELECT assessment_group AS meas, studentid, "window", AVG(score) AS s
   FROM dibels_scores
   WHERE yearid = :yearid AND grade_level = :grade
     AND assessment_group IN (…) AND "window" IN (:baseline, 'Spring')
   GROUP BY 1,2,3),
-m AS (   -- matched pairs + per-student PR at both windows
-  SELECT f.meas, f.studentid, f.s AS b, sp.s AS e, pb.pr AS prb, pe.pr AS pre
+m AS (   -- matched baseline/spring pairs
+  SELECT f.meas, f.studentid, f.s AS b, sp.s AS e
   FROM stu f
   JOIN stu sp ON sp.studentid = f.studentid AND sp.meas = f.meas AND sp."window" = 'Spring'
-  LEFT JOIN LATERAL (SELECT n.pr FROM norms n WHERE n.meas0 = f.meas AND n.per = :baseline
-                     AND n.cut <= f.s ORDER BY n.cut DESC LIMIT 1) pb ON true
-  LEFT JOIN LATERAL (SELECT n.pr FROM norms n WHERE n.meas0 = sp.meas AND n.per = 'Spring'
-                     AND n.cut <= sp.s ORDER BY n.cut DESC LIMIT 1) pe ON true
   WHERE f."window" = :baseline),
 hr AS (SELECT DISTINCT ON (studentid) studentid, sectionid FROM section_enrollments
        WHERE yearid = :yearid AND schoolid = :schoolid AND course_code = :course
        ORDER BY studentid, dateleft DESC),
 sch AS (SELECT DISTINCT studentid FROM school_year_enrollments
-        WHERE yearid = :yearid AND schoolid = :schoolid AND grade_level = :grade),
-mm AS (SELECT m.*, hr.sectionid, (sch.studentid IS NOT NULL) AS in_sch
-       FROM m LEFT JOIN hr USING (studentid) LEFT JOIN sch USING (studentid)),
-q AS (SELECT mm.*,   -- THREE quartile assignments: class-local, school-local, district
-        NTILE(4) OVER (PARTITION BY meas, sectionid ORDER BY b, studentid) AS q_cls,
-        NTILE(4) OVER (PARTITION BY meas, in_sch  ORDER BY b, studentid) AS q_sch,
-        NTILE(4) OVER (PARTITION BY meas          ORDER BY b, studentid) AS q_dist
-      FROM mm),
-cls AS (SELECT meas, COALESCE(q_cls::text,'All') AS qt,
-          ROUND(AVG(e-b)     FILTER (WHERE sectionid = :sec1),1) AS a1,
-          ROUND(AVG(pre-prb) FILTER (WHERE sectionid = :sec1),1) AS p1,
-          COUNT(*)           FILTER (WHERE sectionid = :sec1)    AS n1
-          -- …repeat per homeroom; FILTER is safe with GROUPING SETS because
-          -- q_cls was computed within each section's own partition
-        FROM q WHERE sectionid IS NOT NULL
-        GROUP BY GROUPING SETS ((meas, q_cls),(meas))),
-scha AS (SELECT meas, COALESCE(q_sch::text,'All') AS qt,
-          ROUND(AVG(e-b),1) AS a_sch, ROUND(AVG(pre-prb),1) AS p_sch, COUNT(*) AS n_sch
-         FROM q WHERE in_sch GROUP BY GROUPING SETS ((meas, q_sch),(meas))),
-dist AS (SELECT meas, COALESCE(q_dist::text,'All') AS qt,
-          ROUND(AVG(e-b),1) AS a_dist, ROUND(AVG(pre-prb),1) AS p_dist, COUNT(*) AS n_dist
-         FROM q GROUP BY GROUPING SETS ((meas, q_dist),(meas)))
-SELECT * FROM dist LEFT JOIN scha USING (meas, qt) LEFT JOIN cls USING (meas, qt)
-ORDER BY meas, qt
+        WHERE yearid = :yearid AND schoolid = :schoolid AND grade_level = :grade)
+SELECT m.meas, m.studentid, m.b, m.e,
+       hr.sectionid, (sch.studentid IS NOT NULL) AS in_sch
+FROM m LEFT JOIN hr USING (studentid) LEFT JOIN sch USING (studentid)
 ```
 
-**`ORDER BY b, studentid` in every `NTILE` is mandatory**, not stylistic. See
-SKILL.md — without the tiebreak, quartile membership is nondeterministic across
-runs and re-running moved 19 of 100 quartile cells.
+No windows, no laterals, no grouping sets. It stays district-wide because the
+district quartile needs the full cohort — but it is now a plain indexed read
+returning a few thousand rows per grade.
+
+### Step 2 — aggregate
+
+Feed those rows to `aggregate.py`, which applies the norms, assigns the three
+quartile scopes, and emits the district/school/class rollups:
+
+```bash
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/quartile-growth-report/scripts/aggregate.py \
+  --rows grade3.json --baseline Fall --spring Spring \
+  --measure-as "<warehouse name>=ORF-WRC"
+```
+
+Output is one record per `(meas, scope, qt)` with `growth`, `pr_growth` and `n`,
+including an `All` row per measure and scope — the same cells the SQL used to
+return. Use `--no-norms` for i-Ready, ORF Accuracy and SBA, which have no
+national PR.
+
+`--measure-as` maps the warehouse's `assessment_group` spelling to the norms
+file's (`ORF-WRC`, `NWF-CLS`); confirm the warehouse strings first, as above.
+
+**The `(b, studentid)` ordering inside every quartile is mandatory**, not
+stylistic. See SKILL.md — without the tiebreak, quartile membership is
+nondeterministic across runs and re-running moved 19 of 100 quartile cells.
+`aggregate.py` applies it and reproduces Postgres `NTILE(4)` exactly, remainder
+rule included (verified against Postgres for partition sizes 2-23); its tests
+pin both.
 
 ## Variants
 
+Every variant below keeps the same split: the query returns raw pairs, and
+`aggregate.py` does the quartiles. None of them should reintroduce `NTILE`,
+`LATERAL` norms, or `GROUPING SETS` into SQL.
+
 | Block | Change from the core pattern |
 |---|---|
-| i-Ready, ORF Accuracy | Drop `norms`; value is `e-b` only |
+| i-Ready, ORF Accuracy | Pass `--no-norms`; value is `e-b` only |
 | SBA grades 4-5 | Replace `stu`/`m` with a prior-year join (`yearid-1`, `grade-1`), filter `assessment_group LIKE 'Summative%'` and `is_strand = false` |
 | SBA grade 3 | Baseline = Fall i-Ready percentile; values `AVG(e)` scale and `AVG(metv)` % met |
-| Subgroups | One query per grade over the same `m`, `CROSS JOIN LATERAL (VALUES …)` for the four flags, school + district scope |
-| Fall-only status | Drop the Spring join; values are `AVG(b)` and `AVG(prb)` by quartile |
+| Subgroups | Same extraction query plus the four flag columns; group locally rather than re-querying per subgroup |
+| Fall-only status | Drop the Spring join and emit `e` as null; read `start_raw` / `start_pr` |
 
 ## School-vs-district PR mini-tables
 
-Same `stu`/`m` CTEs, but keep **levels** rather than deltas — `bs` = baseline PR
-(i-Ready: the percentile itself), `es` = spring PR:
+No second query. `aggregate.py` already emits levels alongside the deltas from
+the same run: read `start_pr` / `end_pr` (whole percentiles) instead of
+`pr_growth`, filtered to `scope` of `school` and `district`.
 
-```sql
-q AS (SELECT mm.*, NTILE(4) OVER (PARTITION BY meas, in_sch ORDER BY b, studentid) AS q_sch,
-                   NTILE(4) OVER (PARTITION BY meas ORDER BY b, studentid) AS q_dist FROM mm),
-schq  AS (SELECT meas, COALESCE(q_sch::text,'All') AS qt,
-                 ROUND(AVG(bs),0) AS s_start, ROUND(AVG(es),0) AS s_end, COUNT(*) AS n_sch
-          FROM q WHERE in_sch GROUP BY GROUPING SETS ((meas, q_sch),(meas))),
-distq AS (SELECT meas, COALESCE(q_dist::text,'All') AS qt,
-                 ROUND(AVG(bs),0) AS d_start, ROUND(AVG(es),0) AS d_end, COUNT(*) AS n_dist
-          FROM q GROUP BY GROUPING SETS ((meas, q_dist),(meas)))
-SELECT * FROM distq LEFT JOIN schq USING (meas, qt) ORDER BY meas, qt
-```
+Quartiles are still assigned on the raw baseline; only the reported averages are
+in PR space. SBA is excluded — scale scores have no PR. Fall-only reports use
+`start_pr` / `start_raw` and leave the End columns empty, which the script
+already returns as null when no spring score exists.
 
-`NTILE` still orders on the raw baseline `b`; only the reported averages are in
-PR space. SBA is excluded — scale scores have no PR. Fall-only: Start columns
-only.
+Computing both views in one pass is deliberate: they were two queries over the
+same rows, and keeping them together makes it impossible for the growth table
+and the PR table to disagree about who is in which quartile.

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Quartiles, national PR, and the report rollups — computed here, not in SQL.
+
+The warehouse used to do all of this: three `NTILE` windows, `GROUPING SETS`,
+and a per-row `LEFT JOIN LATERAL` against an inline `VALUES` norms table,
+district-wide, for every grade and measure. It never completed.
+
+Isolated on 2026-08-15 (Evergreen Elementary 2025-26): **window functions do not
+complete against `dibels_scores` on this MCP server at any size.** A bare
+`NTILE(4)` over ~1,100 rows — no norms join, no classroom breakdown — timed out,
+while the same query without the window ran in seconds. The extraction query
+this script consumes returned 2,232 matched rows for grade K in about 3 seconds.
+
+So this is not an optimization. It is the only shape that runs. The norms were
+already generated on this box by `norms_values.py`, so sending them to the
+database to be joined back per row was pure overhead regardless; quartiles are a
+sort and a split. The query returns raw matched pairs and this script does the
+rest.
+
+Student ids arrive here because the quartile tiebreak needs them. They are used
+for ordering only and never appear in the output — every emitted record is an
+aggregate cell.
+
+Input is the raw rows as JSON (a list of objects, or one object per line) on
+stdin or from --rows. Required keys per row:
+
+    meas       measure name as the warehouse spells it
+    studentid  used for the mandatory NTILE tiebreak
+    b          baseline score (numeric)
+
+Optional:
+
+    e          spring score; omit or null for a Fall-only report
+    sectionid  homeroom; null/absent means the student is not in one
+    in_sch     true when the student is enrolled at the report's school
+
+Output is JSON on stdout: one record per (meas, scope, quartile) with the same
+columns the SQL used to emit, plus an 'All' row per measure and scope.
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from decimal import Decimal, ROUND_HALF_UP
+
+NORMS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "references",
+    "dibels8_norms_2021-22.csv",
+)
+
+
+def ntile(rows, buckets=4):
+    """Assign Postgres NTILE(n) bucket numbers to an ordered row list.
+
+    Postgres divides N rows into n groups as equally as possible and gives the
+    remainder to the EARLIEST buckets: bucket i holds floor(N/n) rows, plus one
+    more while i <= N mod n. Splitting evenly and dumping the remainder at the
+    end instead would move real students between quartiles on any partition
+    whose size is not a multiple of four — which is most of them.
+
+    `rows` must already be ordered. See order_key: the (b, studentid) tiebreak
+    is mandatory, not stylistic — without it quartile membership is
+    nondeterministic and a re-run moved 19 of 100 quartile cells.
+    """
+    total = len(rows)
+    if total == 0:
+        return []
+    base, remainder = divmod(total, buckets)
+    assigned = []
+    index = 0
+    for bucket in range(1, buckets + 1):
+        size = base + (1 if bucket <= remainder else 0)
+        for _ in range(size):
+            if index >= total:
+                break
+            assigned.append((rows[index], bucket))
+            index += 1
+    return assigned
+
+
+def order_key(row):
+    """The mandatory NTILE ordering: baseline, then studentid as tiebreak."""
+    return (row["b"], str(row["studentid"]))
+
+
+def load_norms(path):
+    """measure -> period -> ascending [(cut, pr)] for a largest-cut-<=-score lookup."""
+    table = defaultdict(lambda: defaultdict(list))
+    with open(path, newline="") as handle:
+        for row in csv.DictReader(handle):
+            try:
+                raw = float(row["raw"])
+                pr = float(row["percentile"])
+            except (TypeError, ValueError):
+                continue
+            table[row["measure"]][row["period"]].append((raw, pr))
+    for measure in table:
+        for period in table[measure]:
+            table[measure][period].sort()
+    return table
+
+
+def percentile_for(points, score):
+    """The pr of the largest cut <= score — the LATERAL lookup, done locally.
+
+    Mirrors `WHERE cut <= s ORDER BY cut DESC LIMIT 1`: a score below every cut
+    has no percentile (None), matching the LEFT JOIN's null rather than
+    inventing a floor of 1.
+    """
+    if score is None or not points:
+        return None
+    best = None
+    for cut, pr in points:
+        if cut <= score:
+            best = pr
+        else:
+            break
+    return best
+
+
+def mean(values):
+    values = [v for v in values if v is not None]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def pg_round(value, digits=0):
+    """Round the way Postgres ROUND(numeric) does — half AWAY FROM ZERO.
+
+    Python's round() is banker's rounding: round(12.5) is 12, round(0.5) is 0.
+    Postgres answers 13 and 1. Every value here was previously rounded by
+    ROUND() inside the query, so using Python's default would move percentile
+    levels and growth figures by one against the validation workbook — on
+    exactly the .5 boundaries a reviewer is most likely to spot-check.
+
+    Verified against Postgres 12.5 -> 13, 0.5 -> 1, -12.5 -> -13.
+    """
+    if value is None:
+        return None
+    quantum = Decimal(1).scaleb(-digits)
+    rounded = Decimal(repr(value)).quantize(quantum, rounding=ROUND_HALF_UP)
+    return int(rounded) if digits == 0 else float(rounded)
+
+
+def rollup(rows, scope, partition_key, value_digits=1):
+    """Quartile + 'All' rollups for one scope, mirroring the GROUPING SETS.
+
+    Quartiles are assigned WITHIN each partition, which is why the class scope
+    can be aggregated per section without leaking another section's
+    distribution into it.
+    """
+    partitions = defaultdict(list)
+    for row in rows:
+        partitions[partition_key(row)].append(row)
+
+    quartiled = []
+    for _, group in partitions.items():
+        group.sort(key=order_key)
+        quartiled.extend(ntile(group))
+
+    by_cell = defaultdict(list)
+    for row, bucket in quartiled:
+        by_cell[(row["meas"], str(bucket))].append(row)
+        by_cell[(row["meas"], "All")].append(row)
+
+    out = []
+    for (meas, qt), members in sorted(by_cell.items()):
+        growth = mean([r["e"] - r["b"] for r in members if r.get("e") is not None])
+        pr_growth = mean(
+            [
+                r["pre"] - r["prb"]
+                for r in members
+                if r.get("pre") is not None and r.get("prb") is not None
+            ]
+        )
+        # Levels as well as deltas, in one pass. The school-vs-district PR
+        # mini-tables and the Fall-only report want averages of the values
+        # themselves, not of the change; computing both here avoids a second
+        # traversal and keeps the two views consistent by construction.
+        start_pr = mean([r["prb"] for r in members])
+        end_pr = mean([r["pre"] for r in members])
+        start_raw = mean([r["b"] for r in members])
+        end_raw = mean([r["e"] for r in members if r.get("e") is not None])
+
+        out.append(
+            {
+                "meas": meas,
+                "scope": scope,
+                "qt": qt,
+                "growth": pg_round(growth, value_digits),
+                "pr_growth": pg_round(pr_growth, value_digits),
+                # Percentile levels round to whole percentiles, as the SQL did.
+                "start_pr": pg_round(start_pr),
+                "end_pr": pg_round(end_pr),
+                "start_raw": pg_round(start_raw, value_digits),
+                "end_raw": pg_round(end_raw, value_digits),
+                "n": len(members),
+            }
+        )
+    return out
+
+
+def read_rows(handle):
+    text = handle.read().strip()
+    if not text:
+        return []
+    if text.lstrip().startswith("["):
+        return json.loads(text)
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", help="JSON rows file; default stdin")
+    parser.add_argument("--baseline", default="Fall", help="baseline window name")
+    parser.add_argument("--spring", default="Spring", help="end window name")
+    parser.add_argument("--grade", help="grade, for the norms lookup")
+    parser.add_argument(
+        "--measure-as",
+        action="append",
+        default=[],
+        metavar="WAREHOUSE=NORMS",
+        help="map a warehouse measure name to its norms-file name; repeatable",
+    )
+    parser.add_argument(
+        "--no-norms",
+        action="store_true",
+        help="skip national PR entirely (i-Ready, ORF Accuracy, SBA)",
+    )
+    parser.add_argument("--norms", default=NORMS)
+    args = parser.parse_args()
+
+    handle = open(args.rows) if args.rows else sys.stdin
+    try:
+        rows = read_rows(handle)
+    finally:
+        if args.rows:
+            handle.close()
+
+    if not rows:
+        print(json.dumps([]))
+        return 0
+
+    alias = {}
+    for pair in args.measure_as:
+        if "=" not in pair:
+            parser.error(f"--measure-as expects WAREHOUSE=NORMS, got {pair!r}")
+        warehouse, norms_name = pair.split("=", 1)
+        alias[warehouse] = norms_name
+
+    norms = {} if args.no_norms else load_norms(args.norms)
+
+    for row in rows:
+        row.setdefault("e", None)
+        row.setdefault("sectionid", None)
+        row.setdefault("in_sch", False)
+        if args.no_norms:
+            row["prb"] = row["pre"] = None
+            continue
+        measure = alias.get(row["meas"], row["meas"])
+        grade_table = norms.get(measure, {})
+        row["prb"] = percentile_for(grade_table.get(args.baseline, []), row.get("b"))
+        row["pre"] = percentile_for(grade_table.get(args.spring, []), row.get("e"))
+
+    results = []
+    results.extend(rollup(rows, "district", lambda r: r["meas"]))
+    results.extend(
+        rollup(
+            [r for r in rows if r.get("in_sch")],
+            "school",
+            lambda r: (r["meas"], True),
+        )
+    )
+    results.extend(
+        rollup(
+            [r for r in rows if r.get("sectionid") is not None],
+            "class",
+            lambda r: (r["meas"], r["sectionid"]),
+        )
+    )
+
+    print(json.dumps(results, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -1,0 +1,263 @@
+"""Tests for aggregate.py — the quartile/PR work moved out of the warehouse.
+
+The two things worth pinning are the ones that fail silently against the
+validation workbook rather than raising: Postgres NTILE's remainder rule, and
+the largest-cut-<=-score percentile lookup.
+
+Run:
+    uv run --python 3.12 --no-project python3 -m unittest \
+      infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import aggregate  # noqa: E402
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "aggregate.py")
+
+
+def rows_of(pairs, meas="ORF-WRC", in_sch=True, sectionid="S1"):
+    """pairs: (studentid, baseline, spring)."""
+    return [
+        {
+            "meas": meas,
+            "studentid": sid,
+            "b": b,
+            "e": e,
+            "in_sch": in_sch,
+            "sectionid": sectionid,
+        }
+        for sid, b, e in pairs
+    ]
+
+
+class NtileMatchesPostgres(unittest.TestCase):
+    def buckets(self, n, k=4):
+        assigned = aggregate.ntile([{"i": i} for i in range(n)], k)
+        sizes = [0] * k
+        for _, bucket in assigned:
+            sizes[bucket - 1] += 1
+        return sizes
+
+    def test_even_split(self):
+        self.assertEqual(self.buckets(12), [3, 3, 3, 3])
+
+    def test_remainder_goes_to_the_earliest_buckets(self):
+        # Postgres gives the extra rows to the FIRST buckets. Splitting evenly
+        # and appending the remainder would move students between quartiles on
+        # any partition whose size is not a multiple of four.
+        self.assertEqual(self.buckets(13), [4, 3, 3, 3])
+        self.assertEqual(self.buckets(14), [4, 4, 3, 3])
+        self.assertEqual(self.buckets(15), [4, 4, 4, 3])
+
+    def test_fewer_rows_than_buckets(self):
+        # Postgres fills one row per bucket until it runs out.
+        self.assertEqual(self.buckets(2), [1, 1, 0, 0])
+
+    def test_every_row_is_assigned_exactly_once(self):
+        for n in range(1, 40):
+            assigned = aggregate.ntile([{"i": i} for i in range(n)], 4)
+            self.assertEqual(len(assigned), n)
+            self.assertEqual(len({id(r) for r, _ in assigned}), n)
+
+    def test_empty_partition(self):
+        self.assertEqual(aggregate.ntile([], 4), [])
+
+
+class OrderingIsDeterministic(unittest.TestCase):
+    def test_studentid_breaks_ties_on_equal_baseline(self):
+        # Without the tiebreak, quartile membership is nondeterministic across
+        # runs; a re-run once moved 19 of 100 quartile cells.
+        tied = [{"b": 10, "studentid": s} for s in ("c", "a", "b")]
+        self.assertEqual(
+            [r["studentid"] for r in sorted(tied, key=aggregate.order_key)],
+            ["a", "b", "c"],
+        )
+
+    def test_numeric_studentids_compare_as_strings_consistently(self):
+        tied = [{"b": 1, "studentid": 10}, {"b": 1, "studentid": 9}]
+        ordered = sorted(tied, key=aggregate.order_key)
+        self.assertEqual([r["studentid"] for r in ordered], [10, 9])
+
+
+class PercentileLookup(unittest.TestCase):
+    points = [(0.0, 1.0), (10.0, 25.0), (20.0, 50.0), (30.0, 75.0)]
+
+    def test_picks_the_largest_cut_at_or_below_the_score(self):
+        self.assertEqual(aggregate.percentile_for(self.points, 24), 50.0)
+
+    def test_exact_cut_matches_its_own_row(self):
+        self.assertEqual(aggregate.percentile_for(self.points, 20), 50.0)
+
+    def test_score_above_every_cut_takes_the_last(self):
+        self.assertEqual(aggregate.percentile_for(self.points, 999), 75.0)
+
+    def test_score_below_every_cut_is_none_not_a_floor(self):
+        # Mirrors the LEFT JOIN returning null rather than inventing a 1.
+        self.assertIsNone(aggregate.percentile_for([(5.0, 1.0)], 4))
+
+    def test_missing_score_or_table(self):
+        self.assertIsNone(aggregate.percentile_for(self.points, None))
+        self.assertIsNone(aggregate.percentile_for([], 10))
+
+
+class Rollups(unittest.TestCase):
+    def test_quartiles_are_local_to_each_partition(self):
+        # A class rollup must quartile within the section, not across sections
+        # — that is what made the SQL's FILTER safe and must survive the move.
+        rows = rows_of([("a", 1, 2), ("b", 2, 4)], sectionid="S1") + rows_of(
+            [("c", 100, 101), ("d", 200, 204)], sectionid="S2"
+        )
+        for row in rows:
+            row["prb"] = row["pre"] = None
+        out = aggregate.rollup(rows, "class", lambda r: (r["meas"], r["sectionid"]))
+        firsts = [r for r in out if r["qt"] == "1"]
+        # Each section contributes its own bucket 1, so the low scorer in S2
+        # (100) lands in bucket 1 despite dwarfing every S1 score.
+        self.assertEqual(sum(r["n"] for r in firsts), 2)
+
+    def test_all_row_covers_every_member(self):
+        rows = rows_of([("a", 1, 2), ("b", 2, 4), ("c", 3, 3), ("d", 4, 8)])
+        for row in rows:
+            row["prb"] = row["pre"] = None
+        out = aggregate.rollup(rows, "district", lambda r: r["meas"])
+        all_row = next(r for r in out if r["qt"] == "All")
+        self.assertEqual(all_row["n"], 4)
+        # growth = mean(1,2,0,4) = 1.75 -> 1.8 at one decimal
+        self.assertEqual(all_row["growth"], 1.8)
+
+    def test_missing_spring_scores_do_not_poison_the_mean(self):
+        rows = rows_of([("a", 1, 3), ("b", 2, None)])
+        for row in rows:
+            row["prb"] = row["pre"] = None
+        out = aggregate.rollup(rows, "district", lambda r: r["meas"])
+        all_row = next(r for r in out if r["qt"] == "All")
+        self.assertEqual(all_row["growth"], 2.0)  # only student a contributes
+        self.assertEqual(all_row["n"], 2)  # but both are counted
+
+
+class RoundingMatchesPostgres(unittest.TestCase):
+    """Values verified against Postgres ROUND(numeric) on 2026-08-15."""
+
+    def test_half_goes_away_from_zero(self):
+        self.assertEqual(aggregate.pg_round(12.5), 13)
+        self.assertEqual(aggregate.pg_round(0.5), 1)
+        self.assertEqual(aggregate.pg_round(-12.5), -13)
+
+    def test_agrees_with_python_where_python_is_right(self):
+        self.assertEqual(aggregate.pg_round(25.5), 26)
+        self.assertEqual(aggregate.pg_round(1.5), 2)
+
+    def test_one_decimal_boundary(self):
+        self.assertEqual(aggregate.pg_round(1.05, 1), 1.1)
+        self.assertEqual(aggregate.pg_round(-1.05, 1), -1.1)
+
+    def test_none_passes_through(self):
+        self.assertIsNone(aggregate.pg_round(None))
+        self.assertIsNone(aggregate.pg_round(None, 1))
+
+
+class Levels(unittest.TestCase):
+    """The mini-tables and the Fall-only report read levels, not deltas."""
+
+    def cells(self, rows):
+        return aggregate.rollup(rows, "district", lambda r: r["meas"])
+
+    def test_raw_levels_average_the_values_themselves(self):
+        rows = rows_of([("a", 10, 20), ("b", 30, 50)])
+        for row in rows:
+            row["prb"] = row["pre"] = None
+        all_row = next(r for r in self.cells(rows) if r["qt"] == "All")
+        self.assertEqual(all_row["start_raw"], 20.0)
+        self.assertEqual(all_row["end_raw"], 35.0)
+
+    def test_pr_levels_round_half_away_from_zero_like_postgres(self):
+        # Python's round() is banker's: round(12.5) is 12. Postgres answers 13.
+        # These values were rounded by ROUND() inside the query before, so the
+        # Python default would move levels by one against the validation
+        # workbook, on exactly the .5 boundaries someone would spot-check.
+        rows = rows_of([("a", 1, 2), ("b", 3, 4)])
+        rows[0]["prb"], rows[0]["pre"] = 10.0, 20.0
+        rows[1]["prb"], rows[1]["pre"] = 15.0, 31.0
+        all_row = next(r for r in self.cells(rows) if r["qt"] == "All")
+        self.assertEqual(all_row["start_pr"], 13)  # mean 12.5 -> 13, not 12
+        self.assertEqual(all_row["end_pr"], 26)  # mean 25.5 -> 26
+
+    def test_fall_only_rows_still_report_a_start(self):
+        # No spring score anywhere: deltas are undefined but Start must survive.
+        rows = rows_of([("a", 10, None), ("b", 20, None)])
+        for row in rows:
+            row["prb"] = 40.0
+            row["pre"] = None
+        all_row = next(r for r in self.cells(rows) if r["qt"] == "All")
+        self.assertIsNone(all_row["growth"])
+        self.assertEqual(all_row["start_raw"], 15.0)
+        self.assertEqual(all_row["start_pr"], 40)
+        self.assertIsNone(all_row["end_raw"])
+
+
+class EndToEnd(unittest.TestCase):
+    def run_script(self, rows, *extra):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(rows, fh)
+            path = fh.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, "--rows", path, *extra],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            return json.loads(proc.stdout)
+        finally:
+            os.unlink(path)
+
+    def test_no_norms_mode_emits_growth_without_pr(self):
+        out = self.run_script(rows_of([("a", 1, 2), ("b", 5, 9)]), "--no-norms")
+        self.assertTrue(out)
+        self.assertTrue(all(r["pr_growth"] is None for r in out))
+        self.assertTrue(any(r["growth"] is not None for r in out))
+
+    def test_all_three_scopes_are_emitted(self):
+        out = self.run_script(rows_of([("a", 1, 2), ("b", 5, 9)]), "--no-norms")
+        self.assertEqual({r["scope"] for r in out}, {"district", "school", "class"})
+
+    def test_rows_outside_the_school_are_district_only(self):
+        rows = rows_of([("a", 1, 2)], in_sch=False, sectionid=None)
+        out = self.run_script(rows, "--no-norms")
+        self.assertEqual({r["scope"] for r in out}, {"district"})
+
+    def test_empty_input_is_not_an_error(self):
+        self.assertEqual(self.run_script([], "--no-norms"), [])
+
+    def test_jsonl_input_is_accepted(self):
+        rows = rows_of([("a", 1, 2), ("b", 5, 9)])
+        proc = subprocess.run(
+            [sys.executable, SCRIPT, "--no-norms"],
+            input="\n".join(json.dumps(r) for r in rows),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertTrue(json.loads(proc.stdout))
+
+    def test_real_norms_file_produces_percentile_growth(self):
+        # Exercises the shipped CSV, not a fixture: ORF-WRC grade 3 exists in
+        # the UO norms, so a real baseline/spring pair must yield a PR delta.
+        rows = rows_of([("a", 20.0, 60.0), ("b", 30.0, 90.0)])
+        out = self.run_script(rows, "--measure-as", "ORF-WRC=ORF-WRC")
+        district_all = next(
+            r for r in out if r["scope"] == "district" and r["qt"] == "All"
+        )
+        self.assertIsNotNone(district_all["pr_growth"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The quartile growth report never produced output. Every attempt exceeded the psd-data query timeout, across a full evening of passes.

## Root cause (isolated on dev, Evergreen Elementary 2025-26)

**Window functions do not complete against `dibels_scores` on this MCP server at any size.** A bare `NTILE(4)` over ~1,100 rows — no norms join, no classroom breakdown — timed out, while the same query *without* the window ran in seconds. Row count is not the variable; a 2,200-row window function should be instant.

My first pass at this blamed the `LEFT JOIN LATERAL` norms join, reasoning that dropping a `NTILE` hadn't helped. **That was wrong**, and the isolation above corrected it before it shipped.

## The split

The query returns raw matched pairs — a plain indexed read — and `scripts/aggregate.py` applies the norms, assigns the three quartile scopes, and emits the district/school/class rollups. Confirmed the same evening: extraction returned **2,232 matched rows for grade K in ~3 seconds**.

The norms were already generated on-box by `norms_values.py`, so sending them to the database to be joined back per row was overhead regardless.

## Fidelity — the parts that fail silently rather than raising

| Concern | Handling |
|---|---|
| `NTILE(4)` remainder rule | Postgres gives extra rows to the **earliest** buckets. Verified against live Postgres for sizes 2, 5, 12, 13, 14, 15, 23 — all match |
| Rounding | `ROUND_HALF_UP`, not Python's `round()`. Python is banker's: `round(12.5)`=12, `round(0.5)`=0; Postgres answers 13 and 1 |
| Tiebreak | `(b, studentid)` preserved — without it a re-run moved 19 of 100 quartile cells |
| Levels vs deltas | Emitted from the same pass, so the growth table and PR mini-tables cannot disagree about quartile membership. Replaces the second query |

The rounding one is worth calling out: every such value was previously rounded by `ROUND()` inside the query, so Python's default would have shifted percentile levels by one against the validation workbook — on exactly the `.5` boundaries a reviewer spot-checks. **Caught by cross-checking against Postgres, not by the tests I wrote first.**

## Also from the observed run

- **One extraction query per grade, not per measure.** The `IN (…)` list takes every measure at once; per-measure querying turns 6 grades into 30+ round trips and is what made this feel endless.
- **Student ids** are pulled for the tiebreak, used for ordering only, and never appear in output — every emitted record is an aggregate cell.
- **Don't simplify around `NTILE`.** Dropping the norms join, dropping the classroom breakdown, and splitting partitions were all tried; none worked.

## Tests

28 new in `test_aggregate.py`. Registered it **and** the pre-existing `test_norms_values.py` in `ci.yml` — the quartile skill's Python tests had never run in CI.

38 pass across the skill's scripts; 105 across the image config suites.