### PR TITLE
fix(quartile): scope the norms lookup by grade and sort ids numerically

### DIFF
--- a/infra/agent-image/skills/quartile-growth-report/references/sql.md
+++ b/infra/agent-image/skills/quartile-growth-report/references/sql.md
@@ -79,7 +79,7 @@ quartile scopes, and emits the district/school/class rollups:
 
 ```bash
 /opt/agentcore-venv/bin/python3 /opt/psd-skills/quartile-growth-report/scripts/aggregate.py \
-  --rows grade3.json --baseline Fall --spring Spring \
+  --rows grade3.json --grade 3 --baseline Fall --spring Spring \
   --measure-as "<warehouse name>=ORF-WRC"
 ```
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -102,7 +102,10 @@ def order_key(row):
         )
     sid = row["studentid"]
     try:
-        return (row["b"], 0, int(str(sid).strip()), "")
+        # via float() so a JSON-decoded 10.0 still sorts as 10: int("10.0")
+        # raises, which would drop an integer id into the string branch below
+        # and sort it lexically — the exact tiebreak bug this function fixes.
+        return (row["b"], 0, int(float(str(sid).strip())), "")
     except (TypeError, ValueError):
         return (row["b"], 1, 0, str(sid))
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -83,13 +83,53 @@ def ntile(rows, buckets=4):
 
 
 def order_key(row):
-    """The mandatory NTILE ordering: baseline, then studentid as tiebreak."""
-    return (row["b"], str(row["studentid"]))
+    """The mandatory NTILE ordering: baseline, then studentid as tiebreak.
+
+    The id sorts NUMERICALLY when it is numeric. Postgres orders a numeric
+    `studentid` column as a number — 9 before 10 — while `str()` would order it
+    lexically and put 10 first. On any baseline tie involving multi-digit ids
+    that picks a different student for the quartile boundary, which is the
+    "19 of 100 quartile cells moved" failure this ordering exists to prevent,
+    reintroduced one level down.
+
+    The (kind, value) pair keeps numeric and non-numeric ids from being
+    compared against each other; a real column is one or the other.
+    """
+    if row.get("b") is None:
+        raise ValueError(
+            f"row for student {row.get('studentid')!r} has no baseline score; "
+            "the extraction query must not return null b"
+        )
+    sid = row["studentid"]
+    try:
+        return (row["b"], 0, int(str(sid).strip()), "")
+    except (TypeError, ValueError):
+        return (row["b"], 1, 0, str(sid))
+
+
+def normalize_grade(value):
+    """'3', '3.0', 3 -> '3'. The CSV stores grade as a float-ish string."""
+    text = str(value).strip()
+    try:
+        return str(int(float(text)))
+    except (TypeError, ValueError):
+        return text
 
 
 def load_norms(path):
-    """measure -> period -> ascending [(cut, pr)] for a largest-cut-<=-score lookup."""
-    table = defaultdict(lambda: defaultdict(list))
+    """measure -> grade -> period -> ascending [(cut, pr)].
+
+    Grade is part of the key, not an afterthought: the same measure has
+    different cut points per grade — Fall ORF-WRC is 188 cuts topping at raw
+    187 for grade 3, and 206 cuts topping at 205 for grade 5. Merging grades
+    into one sorted list makes `percentile_for` return whichever grade's cut
+    happened to be the largest one at or below the score, producing percentiles
+    that are silently wrong rather than raising.
+
+    `norms_values.py` filters by grade before emitting its rows, which is why
+    the SQL this replaces never mixed them.
+    """
+    table = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     with open(path, newline="") as handle:
         for row in csv.DictReader(handle):
             try:
@@ -97,10 +137,12 @@ def load_norms(path):
                 pr = float(row["percentile"])
             except (TypeError, ValueError):
                 continue
-            table[row["measure"]][row["period"]].append((raw, pr))
+            grade = normalize_grade(row["grade"])
+            table[row["measure"]][grade][row["period"]].append((raw, pr))
     for measure in table:
-        for period in table[measure]:
-            table[measure][period].sort()
+        for grade in table[measure]:
+            for period in table[measure][grade]:
+                table[measure][grade][period].sort()
     return table
 
 
@@ -219,7 +261,12 @@ def main() -> int:
     parser.add_argument("--rows", help="JSON rows file; default stdin")
     parser.add_argument("--baseline", default="Fall", help="baseline window name")
     parser.add_argument("--spring", default="Spring", help="end window name")
-    parser.add_argument("--grade", help="grade, for the norms lookup")
+    # Required, matching norms_values.py's contract. The same measure has
+    # different cut points per grade, so a norms lookup without a grade is not
+    # a lookup — it silently mixes them.
+    parser.add_argument(
+        "--grade", help="grade for the norms lookup; required unless --no-norms"
+    )
     parser.add_argument(
         "--measure-as",
         action="append",
@@ -253,7 +300,22 @@ def main() -> int:
         warehouse, norms_name = pair.split("=", 1)
         alias[warehouse] = norms_name
 
+    if not args.no_norms and not args.grade:
+        parser.error("--grade is required unless --no-norms (cut points differ by grade)")
+
     norms = {} if args.no_norms else load_norms(args.norms)
+    grade = normalize_grade(args.grade) if args.grade else None
+
+    if not args.no_norms:
+        measures = {alias.get(r["meas"], r["meas"]) for r in rows}
+        for measure in sorted(measures):
+            if measure in norms and grade not in norms[measure]:
+                # Loud, not silent: an unmatched grade would otherwise yield a
+                # null percentile for every student and look like missing data.
+                parser.error(
+                    f"no norms for measure {measure!r} at grade {grade!r}; "
+                    f"available grades: {sorted(norms[measure])}"
+                )
 
     for row in rows:
         row.setdefault("e", None)
@@ -263,9 +325,9 @@ def main() -> int:
             row["prb"] = row["pre"] = None
             continue
         measure = alias.get(row["meas"], row["meas"])
-        grade_table = norms.get(measure, {})
-        row["prb"] = percentile_for(grade_table.get(args.baseline, []), row.get("b"))
-        row["pre"] = percentile_for(grade_table.get(args.spring, []), row.get("e"))
+        periods = norms.get(measure, {}).get(grade, {})
+        row["prb"] = percentile_for(periods.get(args.baseline, []), row.get("b"))
+        row["pre"] = percentile_for(periods.get(args.spring, []), row.get("e"))
 
     results = []
     results.extend(rollup(rows, "district", lambda r: r["meas"]))

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -108,7 +108,12 @@ def order_key(row):
 
 
 def normalize_grade(value):
-    """'3', '3.0', 3 -> '3'. The CSV stores grade as a float-ish string."""
+    """'3', '3.0', 3 -> '3'.
+
+    The shipped `dibels8_norms_2021-22.csv` stores grade as a plain integer
+    (0-5); the float-tolerant parse is defensive, for a norms file or a
+    `--grade` argument that arrives in the '3.0' form instead.
+    """
     text = str(value).strip()
     try:
         return str(int(float(text)))
@@ -309,9 +314,17 @@ def main() -> int:
     if not args.no_norms:
         measures = {alias.get(r["meas"], r["meas"]) for r in rows}
         for measure in sorted(measures):
-            if measure in norms and grade not in norms[measure]:
-                # Loud, not silent: an unmatched grade would otherwise yield a
-                # null percentile for every student and look like missing data.
+            # Loud, not silent, at both levels: an unmatched measure or grade
+            # would otherwise yield a null percentile for every student and
+            # look like missing data rather than a wrong invocation.
+            if measure not in norms:
+                parser.error(
+                    f"no norms for measure {measure!r}; "
+                    f"available measures: {sorted(norms)}. "
+                    "Map it with --measure-as WAREHOUSE=NORMS, or pass "
+                    "--no-norms to skip percentiles entirely."
+                )
+            if grade not in norms[measure]:
                 parser.error(
                     f"no norms for measure {measure!r} at grade {grade!r}; "
                     f"available grades: {sorted(norms[measure])}"

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -119,6 +119,13 @@ def normalize_grade(value):
     The shipped `dibels8_norms_2021-22.csv` stores grade as a plain integer
     (0-5); the float-tolerant parse is defensive, for a norms file or a
     `--grade` argument that arrives in the '3.0' form instead.
+
+    Lockstep means the K mapping and the numeric normalization, not the
+    invalid-input path, which intentionally differs: `norms_values.py` raises
+    on `--grade banana` because nothing downstream would catch it, while here
+    the unparsed text falls through to the no-norms-at-that-grade guard in
+    `main()` and fails there with the measures listed. Do not "fix" this
+    divergence into a raise without moving that guard.
     """
     text = str(value).strip()
     if text.upper() == "K":
@@ -306,6 +313,20 @@ def main() -> int:
         print(json.dumps([]))
         return 0
 
+    # `order_key` raises on a null baseline too — that is the sort's own
+    # invariant and stays — but it fires from inside `sorted()` deep in
+    # `rollup`, so the operator (an agent reading stderr, per SKILL.md) gets a
+    # traceback rather than something diagnosable. Same loud failure, checked
+    # up front in this file's parser.error style.
+    no_baseline = [r for r in rows if r.get("b") is None]
+    if no_baseline:
+        parser.error(
+            f"{len(no_baseline)} of {len(rows)} rows have a null baseline "
+            f"score (first: student {no_baseline[0].get('studentid')!r}); the "
+            "extraction query must not return null b — filter those rows out "
+            "in SQL, or use the Fall-only status view if there is no baseline."
+        )
+
     alias = {}
     for pair in args.measure_as:
         if "=" not in pair:
@@ -323,7 +344,7 @@ def main() -> int:
         measures = sorted({alias.get(r["meas"], r["meas"]) for r in rows})
         unnormed = [m for m in measures if grade not in norms.get(m, {})]
 
-        if unnormed == measures:
+        if len(unnormed) == len(measures):
             # Nothing in this run can be scored at all — a wrong --grade, a
             # mistyped --measure-as, or the wrong norms file. Loud, not a null
             # percentile for every student in the report, which reads as

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -108,13 +108,21 @@ def order_key(row):
 
 
 def normalize_grade(value):
-    """'3', '3.0', 3 -> '3'.
+    """'3', '3.0', 3 -> '3'; 'K' -> '0'.
+
+    Kindergarten is why this must stay in lockstep with `norms_values.py`'s
+    function of the same name: SKILL.md labels the tabs K-5, so `--grade K` is
+    the natural thing for an agent to pass, but the norms file stores
+    kindergarten as grade 0. The two scripts key the same CSV on the same
+    domain concept; a divergence here scores kindergarten against nothing.
 
     The shipped `dibels8_norms_2021-22.csv` stores grade as a plain integer
     (0-5); the float-tolerant parse is defensive, for a norms file or a
     `--grade` argument that arrives in the '3.0' form instead.
     """
     text = str(value).strip()
+    if text.upper() == "K":
+        return "0"
     try:
         return str(int(float(text)))
     except (TypeError, ValueError):
@@ -312,23 +320,35 @@ def main() -> int:
     grade = normalize_grade(args.grade) if args.grade else None
 
     if not args.no_norms:
-        measures = {alias.get(r["meas"], r["meas"]) for r in rows}
-        for measure in sorted(measures):
-            # Loud, not silent, at both levels: an unmatched measure or grade
-            # would otherwise yield a null percentile for every student and
-            # look like missing data rather than a wrong invocation.
-            if measure not in norms:
-                parser.error(
-                    f"no norms for measure {measure!r}; "
-                    f"available measures: {sorted(norms)}. "
-                    "Map it with --measure-as WAREHOUSE=NORMS, or pass "
-                    "--no-norms to skip percentiles entirely."
-                )
-            if grade not in norms[measure]:
-                parser.error(
-                    f"no norms for measure {measure!r} at grade {grade!r}; "
-                    f"available grades: {sorted(norms[measure])}"
-                )
+        measures = sorted({alias.get(r["meas"], r["meas"]) for r in rows})
+        unnormed = [m for m in measures if grade not in norms.get(m, {})]
+
+        if unnormed == measures:
+            # Nothing in this run can be scored at all — a wrong --grade, a
+            # mistyped --measure-as, or the wrong norms file. Loud, not a null
+            # percentile for every student in the report, which reads as
+            # missing data rather than a wrong invocation.
+            have = ", ".join(f"{m} {sorted(norms[m])}" for m in sorted(norms))
+            parser.error(
+                f"no norms at grade {grade!r} for any requested measure "
+                f"({', '.join(measures)}); the norms file has {have}. "
+                "Map warehouse names with --measure-as WAREHOUSE=NORMS, or "
+                "pass --no-norms to skip percentiles entirely."
+            )
+
+        for measure in unnormed:
+            # Partial coverage is normal, not an error: LNF and PSF stop after
+            # grade 1, MAZE does not start until 2. SKILL.md is explicit that a
+            # measure-window missing from the file emits raw change only "and
+            # say so" — so one unnormed measure must not abort the measures
+            # that can be scored. Still loud: named on stderr so the null PR is
+            # attributable rather than mistaken for missing data.
+            print(
+                f"warning: no norms for measure {measure!r} at grade {grade!r} "
+                f"(available grades: {sorted(norms.get(measure, {})) or 'none'}); "
+                "emitting raw change only for it",
+                file=sys.stderr,
+            )
 
     for row in rows:
         row.setdefault("e", None)

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -445,6 +445,19 @@ class EndToEnd(unittest.TestCase):
         self.assertIsNone(by_meas["LNF"]["start_pr"])
         self.assertIsNotNone(by_meas["LNF"]["start_raw"])
 
+    def test_a_null_baseline_is_diagnosable_not_a_traceback(self):
+        # order_key still raises (its own invariant, unit-tested above), but
+        # the operator is an agent reading stderr — a traceback out of
+        # sorted() is not actionable, so main() catches it up front.
+        rows = rows_of([("a", 20.0, 60.0)]) + [
+            {"meas": "ORF-WRC", "studentid": "b", "b": None, "e": 40.0,
+             "in_sch": True, "sectionid": "S1"}
+        ]
+        err = self.run_expecting_failure(rows, "--grade", "3")
+        self.assertIn("null baseline", err)
+        self.assertIn("extraction query must not return null b", err)
+        self.assertNotIn("Traceback", err)
+
     def test_an_unnormed_measure_still_runs_under_no_norms(self):
         # --no-norms remains the documented escape hatch for i-Ready/SBA, so
         # the new guard must not fire there.

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -81,10 +81,61 @@ class OrderingIsDeterministic(unittest.TestCase):
             ["a", "b", "c"],
         )
 
-    def test_numeric_studentids_compare_as_strings_consistently(self):
+    def test_numeric_studentids_sort_numerically_like_postgres(self):
+        # Postgres orders a numeric studentid column as a number: 9 before 10.
+        # str() would order lexically and put 10 first, picking a different
+        # student at the quartile boundary on any baseline tie.
         tied = [{"b": 1, "studentid": 10}, {"b": 1, "studentid": 9}]
         ordered = sorted(tied, key=aggregate.order_key)
-        self.assertEqual([r["studentid"] for r in ordered], [10, 9])
+        self.assertEqual([r["studentid"] for r in ordered], [9, 10])
+
+    def test_numeric_strings_also_sort_numerically(self):
+        tied = [{"b": 1, "studentid": "100"}, {"b": 1, "studentid": "99"}]
+        ordered = sorted(tied, key=aggregate.order_key)
+        self.assertEqual([r["studentid"] for r in ordered], ["99", "100"])
+
+    def test_alphanumeric_ids_still_sort(self):
+        tied = [{"b": 1, "studentid": "b7"}, {"b": 1, "studentid": "a3"}]
+        ordered = sorted(tied, key=aggregate.order_key)
+        self.assertEqual([r["studentid"] for r in ordered], ["a3", "b7"])
+
+    def test_null_baseline_raises_instead_of_TypeError(self):
+        with self.assertRaises(ValueError):
+            aggregate.order_key({"b": None, "studentid": "a"})
+
+
+class NormsAreScopedByGrade(unittest.TestCase):
+    """The same measure has different cut points per grade.
+
+    Fall ORF-WRC is 188 cuts topping at raw 187 for grade 3, and 206 topping at
+    205 for grade 5. A lookup that ignores grade returns whichever grade's cut
+    happened to be largest at or below the score — silently wrong, never
+    raising. Asserting only that a percentile is non-null would not catch it,
+    so these pin actual values from the shipped CSV.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.norms = aggregate.load_norms(aggregate.NORMS)
+
+    def test_the_same_score_scores_differently_by_grade(self):
+        g3 = self.norms["ORF-WRC"]["3"]["Fall"]
+        g5 = self.norms["ORF-WRC"]["5"]["Fall"]
+        score = 100.0
+        self.assertNotEqual(
+            aggregate.percentile_for(g3, score),
+            aggregate.percentile_for(g5, score),
+            "grade 3 and grade 5 must not share a cut table",
+        )
+
+    def test_grade_tables_have_their_own_ceilings(self):
+        self.assertEqual(max(c for c, _ in self.norms["ORF-WRC"]["3"]["Fall"]), 187.0)
+        self.assertEqual(max(c for c, _ in self.norms["ORF-WRC"]["5"]["Fall"]), 205.0)
+
+    def test_grade_is_normalized_from_the_csvs_float_form(self):
+        self.assertEqual(aggregate.normalize_grade("3.0"), "3")
+        self.assertEqual(aggregate.normalize_grade(3), "3")
+        self.assertEqual(aggregate.normalize_grade("K"), "K")
 
 
 class PercentileLookup(unittest.TestCase):
@@ -252,11 +303,56 @@ class EndToEnd(unittest.TestCase):
         # Exercises the shipped CSV, not a fixture: ORF-WRC grade 3 exists in
         # the UO norms, so a real baseline/spring pair must yield a PR delta.
         rows = rows_of([("a", 20.0, 60.0), ("b", 30.0, 90.0)])
-        out = self.run_script(rows, "--measure-as", "ORF-WRC=ORF-WRC")
+        out = self.run_script(rows, "--grade", "3", "--measure-as", "ORF-WRC=ORF-WRC")
         district_all = next(
             r for r in out if r["scope"] == "district" and r["qt"] == "All"
         )
         self.assertIsNotNone(district_all["pr_growth"])
+
+    def test_the_same_scores_score_differently_at_a_different_grade(self):
+        # End-to-end proof that --grade is actually threaded through: identical
+        # input, different --grade, different percentile growth. Before this
+        # fix --grade was parsed and never used, so both runs agreed.
+        rows = rows_of([("a", 20.0, 60.0), ("b", 30.0, 90.0)])
+        args = ("--measure-as", "ORF-WRC=ORF-WRC")
+        g3 = self.run_script(rows, "--grade", "3", *args)
+        g5 = self.run_script(rows, "--grade", "5", *args)
+        pr3 = next(r for r in g3 if r["scope"] == "district" and r["qt"] == "All")
+        pr5 = next(r for r in g5 if r["scope"] == "district" and r["qt"] == "All")
+        self.assertNotEqual(pr3["pr_growth"], pr5["pr_growth"])
+
+    def test_missing_grade_is_refused_rather_than_guessed(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(rows_of([("a", 20.0, 60.0)]), fh)
+            path = fh.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, "--rows", path],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("--grade is required", proc.stderr)
+        finally:
+            os.unlink(path)
+
+    def test_a_grade_with_no_norms_fails_loudly(self):
+        # A silent null percentile for every student would read as missing
+        # data rather than a wrong invocation.
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(rows_of([("a", 20.0, 60.0)]), fh)
+            path = fh.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, "--rows", path, "--grade", "42",
+                 "--measure-as", "ORF-WRC=ORF-WRC"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("no norms for measure", proc.stderr)
+        finally:
+            os.unlink(path)
 
 
 if __name__ == "__main__":

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -354,6 +354,49 @@ class EndToEnd(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def run_expecting_failure(self, rows, *extra):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(rows, fh)
+            path = fh.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, "--rows", path, *extra],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(proc.returncode, 0, proc.stdout)
+            return proc.stderr
+        finally:
+            os.unlink(path)
+
+    def test_a_measure_with_no_norms_fails_loudly(self):
+        # The same silent-null failure as an unmatched grade, one level up: a
+        # measure the norms file has never heard of scored every student null.
+        err = self.run_expecting_failure(
+            rows_of([("a", 20.0, 60.0)], meas="I-READY-READING"), "--grade", "3"
+        )
+        self.assertIn("no norms for measure 'I-READY-READING'", err)
+        self.assertIn("available measures:", err)
+
+    def test_a_mistyped_measure_alias_fails_loudly(self):
+        # A typo in --measure-as is the likeliest way to reach the above.
+        err = self.run_expecting_failure(
+            rows_of([("a", 20.0, 60.0)]),
+            "--grade", "3",
+            "--measure-as", "ORF-WRC=ORF_WRC",
+        )
+        self.assertIn("no norms for measure 'ORF_WRC'", err)
+        self.assertIn("--no-norms", err)
+
+    def test_an_unnormed_measure_still_runs_under_no_norms(self):
+        # --no-norms remains the documented escape hatch for i-Ready/SBA, so
+        # the new guard must not fire there.
+        out = self.run_script(
+            rows_of([("a", 1, 2), ("b", 5, 9)], meas="I-READY-READING"), "--no-norms"
+        )
+        self.assertTrue(out)
+        self.assertTrue(all(r["pr_growth"] is None for r in out))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -94,6 +94,19 @@ class OrderingIsDeterministic(unittest.TestCase):
         ordered = sorted(tied, key=aggregate.order_key)
         self.assertEqual([r["studentid"] for r in ordered], ["99", "100"])
 
+    def test_float_shaped_ids_sort_numerically_too(self):
+        # A JSON-decoded studentid can arrive as 10.0. int("10.0") raises, so
+        # without the float() hop these fall into the string branch and sort
+        # lexically — 10.0 before 9.0, the tiebreak bug one form further out.
+        tied = [{"b": 1, "studentid": 10.0}, {"b": 1, "studentid": 9.0}]
+        ordered = sorted(tied, key=aggregate.order_key)
+        self.assertEqual([r["studentid"] for r in ordered], [9.0, 10.0])
+        # and a float-shaped id ties with its integer form, not against it
+        self.assertEqual(
+            aggregate.order_key({"b": 1, "studentid": "10.0"}),
+            aggregate.order_key({"b": 1, "studentid": 10}),
+        )
+
     def test_alphanumeric_ids_still_sort(self):
         tied = [{"b": 1, "studentid": "b7"}, {"b": 1, "studentid": "a3"}]
         ordered = sorted(tied, key=aggregate.order_key)

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -135,7 +135,17 @@ class NormsAreScopedByGrade(unittest.TestCase):
     def test_grade_is_normalized_from_the_csvs_float_form(self):
         self.assertEqual(aggregate.normalize_grade("3.0"), "3")
         self.assertEqual(aggregate.normalize_grade(3), "3")
-        self.assertEqual(aggregate.normalize_grade("K"), "K")
+
+    def test_grade_K_is_kindergarten_not_a_literal_K(self):
+        # The norms file stores kindergarten as grade 0 and SKILL.md labels the
+        # tabs K-5, so --grade K is what an agent passes. Returning a literal
+        # "K" keys nothing in the table — every K report would fail.
+        # norms_values.py has the same mapping; the two must not diverge.
+        self.assertEqual(aggregate.normalize_grade("K"), "0")
+        self.assertEqual(aggregate.normalize_grade("k"), "0")
+        self.assertEqual(
+            aggregate.normalize_grade("K"), aggregate.normalize_grade("0")
+        )
 
 
 class PercentileLookup(unittest.TestCase):
@@ -350,7 +360,8 @@ class EndToEnd(unittest.TestCase):
                 text=True,
             )
             self.assertNotEqual(proc.returncode, 0)
-            self.assertIn("no norms for measure", proc.stderr)
+            self.assertIn("no norms at grade '42'", proc.stderr)
+            self.assertIn("ORF-WRC", proc.stderr)
         finally:
             os.unlink(path)
 
@@ -375,8 +386,11 @@ class EndToEnd(unittest.TestCase):
         err = self.run_expecting_failure(
             rows_of([("a", 20.0, 60.0)], meas="I-READY-READING"), "--grade", "3"
         )
-        self.assertIn("no norms for measure 'I-READY-READING'", err)
-        self.assertIn("available measures:", err)
+        self.assertIn("I-READY-READING", err)
+        self.assertIn("no norms at grade '3' for any requested measure", err)
+        # The message must show what the file does have, so the operator can
+        # see the name it expected rather than guessing.
+        self.assertIn("ORF-WRC", err)
 
     def test_a_mistyped_measure_alias_fails_loudly(self):
         # A typo in --measure-as is the likeliest way to reach the above.
@@ -385,8 +399,51 @@ class EndToEnd(unittest.TestCase):
             "--grade", "3",
             "--measure-as", "ORF-WRC=ORF_WRC",
         )
-        self.assertIn("no norms for measure 'ORF_WRC'", err)
+        self.assertIn("ORF_WRC", err)
+        self.assertIn("no norms at grade '3' for any requested measure", err)
         self.assertIn("--no-norms", err)
+
+    def test_grade_K_scores_against_kindergarten_norms(self):
+        # End-to-end counterpart: --grade K must behave exactly like --grade 0,
+        # not die in the no-norms guard. LNF is a K measure in the shipped file.
+        rows = rows_of([("a", 10.0, 40.0), ("b", 20.0, 55.0)], meas="LNF")
+        args = ("--measure-as", "LNF=LNF")
+        k = self.run_script(rows, "--grade", "K", *args)
+        zero = self.run_script(rows, "--grade", "0", *args)
+        self.assertEqual(k, zero)
+        district_all = next(
+            r for r in k if r["scope"] == "district" and r["qt"] == "All"
+        )
+        self.assertIsNotNone(district_all["pr_growth"])
+
+    def test_one_unnormed_measure_does_not_abort_the_normed_ones(self):
+        # LNF has no grade-3 norms, ORF-WRC does. SKILL.md: a measure-window
+        # missing from the file emits raw change only "and say so" — so the
+        # run must survive, warn on stderr, and still score ORF-WRC.
+        rows = rows_of([("a", 20.0, 60.0)]) + rows_of([("b", 30.0, 50.0)], meas="LNF")
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(rows, fh)
+            path = fh.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, "--rows", path, "--grade", "3"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("no norms for measure 'LNF' at grade '3'", proc.stderr)
+            self.assertIn("raw change only", proc.stderr)
+            out = json.loads(proc.stdout)
+        finally:
+            os.unlink(path)
+        by_meas = {
+            r["meas"]: r
+            for r in out
+            if r["scope"] == "district" and r["qt"] == "All"
+        }
+        self.assertIsNotNone(by_meas["ORF-WRC"]["start_pr"])
+        self.assertIsNone(by_meas["LNF"]["start_pr"])
+        self.assertIsNotNone(by_meas["LNF"]["start_raw"])
 
     def test_an_unnormed_measure_still_runs_under_no_norms(self):
         # --no-norms remains the documented escape hatch for i-Ready/SBA, so


### PR DESCRIPTION
Two correctness bugs in #1649, caught by claude-review **after** it merged. Both are the silent-divergence kind that PR's own fidelity table was written to guard against — and neither was in it.

## 🔴 Grade-mixing — silently wrong percentiles

`load_norms()` keyed on `measure -> period` with no grade dimension, though the CSV has a `grade` column and cut points differ by grade. Confirmed against the shipped file:

| | Fall ORF-WRC |
|---|---|
| grade 3 | 188 cuts, max raw **187** |
| grade 5 | 206 cuts, max raw **205** |

Merging them made `percentile_for()` return whichever grade's cut happened to be largest at or below the score. `main()` accepted `--grade` and **never used it** — parsed, then dead. The `sql.md` example didn't pass it either.

This was a regression against the code it replaced: `norms_values.py` filters by grade before emitting rows, which is why the old SQL join never mixed them. Every `start_pr`/`end_pr`/`pr_growth` would have been computed against a contaminated cross-grade table.

Now keyed `measure -> grade -> period`; `--grade` required unless `--no-norms`; and a grade with no norms for a measure **fails loudly** rather than returning null percentiles for every student, which would read as missing data.

## 🟡 Tiebreak order — wrong student at the quartile boundary

`order_key()` compared `studentid` as a string, so `10` sorted before `9`. Postgres orders a numeric column numerically. On any baseline tie with multi-digit ids that picks a different student for the boundary — the same *"19 of 100 quartile cells moved"* failure this ordering exists to prevent, reintroduced one level down.

Ids now sort numerically when numeric, with a non-numeric fallback that never compares the two kinds against each other.

Also: a null baseline raised an opaque `TypeError` from the sort. It now raises `ValueError` naming the student and the contract the extraction query broke.

## Why the tests missed it

`test_real_norms_file_produces_percentile_growth` exercised the real CSV but only asserted `pr_growth is not None` — a contaminated-but-present percentile passes that happily. The reviewer's point exactly.

37 tests now, up from 28, pinning **actual values** from the shipped CSV:

- same score scores differently at grade 3 vs grade 5
- end-to-end proof `--grade` is threaded through (identical input, different grade, different result — before the fix both runs agreed)
- per-grade ceilings (187 vs 205)
- numeric / numeric-string / alphanumeric id ordering
- missing `--grade` refused; unknown grade refused

47 pass across the skill's scripts.

## Note

No image was built with #1649's bugs — I killed the in-flight build when the review landed.