### PR TITLE
fix(quartile): cast export columns to text and parse them back

### DIFF
--- a/infra/agent-image/skills/quartile-growth-report/references/sql.md
+++ b/infra/agent-image/skills/quartile-growth-report/references/sql.md
@@ -72,6 +72,22 @@ No windows, no laterals, no grouping sets. It stays district-wide because the
 district quartile needs the full cohort — but it is now a plain indexed read
 returning a few thousand rows per grade.
 
+**Cast every non-text column to `::text`.** psd-data's export mode fails on
+decimal, integer and boolean columns; the rows come back malformed rather than
+erroring cleanly. Casting fixes it, and the cast must be *inside* each
+aggregate, not only at the final select — `AVG(score)::text` is wrong, it needs
+the cast applied to the aggregate's result where the export sees it. The
+boolean needs it too:
+
+```sql
+SELECT m.meas, m.studentid::text, m.b::text, m.e::text,
+       hr.sectionid::text, (sch.studentid IS NOT NULL)::text AS in_sch
+```
+
+`aggregate.py` parses the numbers back, so the casts cost nothing downstream.
+Skipping them cost roughly ten round trips of trial and error per run on
+2026-08-15 — the agent rediscovered this the hard way, one column at a time.
+
 ### Step 2 — aggregate
 
 Feed those rows to `aggregate.py`, which applies the norms, assigns the three

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -270,6 +270,37 @@ def rollup(rows, scope, partition_key, value_digits=1):
     return out
 
 
+TRUE_TEXT = {"true", "t", "yes", "y", "1"}
+
+
+def coerce_row(row):
+    """Parse the ::text columns the extraction query is required to emit.
+
+    psd-data's export mode fails on decimal, integer and boolean columns, so
+    references/sql.md casts every one of them to text. That means `b`, `e` and
+    `in_sch` arrive here as strings, and a string baseline would sort
+    lexically — '9' after '100' — silently reordering the quartile boundary
+    rather than raising. Numbers are parsed back before anything compares them.
+
+    Values that are already numeric or boolean pass through untouched, so rows
+    from a non-export path behave the same.
+    """
+    for key in ("b", "e"):
+        value = row.get(key)
+        if isinstance(value, str):
+            text = value.strip()
+            row[key] = None if text == "" else float(text)
+
+    flag = row.get("in_sch")
+    if isinstance(flag, str):
+        row["in_sch"] = flag.strip().lower() in TRUE_TEXT
+
+    section = row.get("sectionid")
+    if isinstance(section, str) and section.strip() == "":
+        row["sectionid"] = None
+    return row
+
+
 def read_rows(handle):
     text = handle.read().strip()
     if not text:
@@ -378,6 +409,7 @@ def main() -> int:
         row.setdefault("e", None)
         row.setdefault("sectionid", None)
         row.setdefault("in_sch", False)
+        coerce_row(row)
         if args.no_norms:
             row["prb"] = row["pre"] = None
             continue

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -483,3 +483,69 @@ class EndToEnd(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TextCastColumnsAreParsedBack(unittest.TestCase):
+    """references/sql.md casts every numeric and boolean column to ::text.
+
+    psd-data's export mode fails on decimal, integer and boolean columns, so
+    the extraction query is required to cast them. That means b/e/in_sch arrive
+    as strings — and a string baseline sorts lexically ('9' after '100'),
+    silently reordering the quartile boundary instead of raising.
+    """
+
+    def test_numeric_strings_become_numbers(self):
+        row = aggregate.coerce_row({"b": "12.5", "e": "20"})
+        self.assertEqual(row["b"], 12.5)
+        self.assertEqual(row["e"], 20.0)
+
+    def test_string_baselines_would_otherwise_sort_lexically(self):
+        rows = [{"b": "100", "studentid": 1}, {"b": "9", "studentid": 2}]
+        for row in rows:
+            aggregate.coerce_row(row)
+        ordered = sorted(rows, key=aggregate.order_key)
+        self.assertEqual([r["b"] for r in ordered], [9.0, 100.0])
+
+    def test_boolean_text_forms(self):
+        for text in ("true", "t", "TRUE", "yes", "1"):
+            self.assertIs(aggregate.coerce_row({"b": 1, "in_sch": text})["in_sch"], True)
+        for text in ("false", "f", "FALSE", "no", "0", ""):
+            self.assertIs(
+                aggregate.coerce_row({"b": 1, "in_sch": text})["in_sch"], False
+            )
+
+    def test_empty_text_becomes_null_not_zero(self):
+        # An empty spring score must stay missing; 0.0 would be a real score
+        # and would drag every growth average toward a fabricated decline.
+        self.assertIsNone(aggregate.coerce_row({"b": "1", "e": ""})["e"])
+        self.assertIsNone(aggregate.coerce_row({"b": "1", "sectionid": ""})["sectionid"])
+
+    def test_already_typed_values_pass_through(self):
+        row = aggregate.coerce_row({"b": 1.5, "e": None, "in_sch": True})
+        self.assertEqual(row["b"], 1.5)
+        self.assertIsNone(row["e"])
+        self.assertIs(row["in_sch"], True)
+
+    def test_end_to_end_with_every_column_as_text(self):
+        rows = [
+            {"meas": "ORF-WRC", "studentid": "9", "b": "10", "e": "20",
+             "in_sch": "true", "sectionid": "S1"},
+            {"meas": "ORF-WRC", "studentid": "100", "b": "30", "e": "50",
+             "in_sch": "t", "sectionid": "S1"},
+        ]
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(rows, fh)
+            path = fh.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, "--rows", path, "--no-norms"],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            out = json.loads(proc.stdout)
+            school = [r for r in out if r["scope"] == "school"]
+            self.assertTrue(school, "in_sch text must resolve to a real boolean")
+            all_row = next(r for r in school if r["qt"] == "All")
+            self.assertEqual(all_row["growth"], 15.0)
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
The report now runs, then stalls rediscovering a psd-data quirk one column at a time.

## The quirk

**psd-data's export mode fails on decimal, integer and boolean columns** — rows come back malformed rather than erroring cleanly. Roughly ten round trips per run went into finding that `::text` casts fix it, including the non-obvious part: the cast must be applied where the export sees the **aggregate's result**, not only at the final select (observed dev 2026-08-15, Evergreen grade K).

`references/sql.md` now states it with the worked SELECT, boolean included.

## The half that would have broken it

Casting means `b`, `e` and `in_sch` arrive at `aggregate.py` as **strings**. A string baseline sorts **lexically** — `"9"` after `"100"` — which silently reorders the quartile boundary rather than raising.

Documenting the casts without parsing them back would have traded a loud failure for a quiet wrong answer — the same trade this skill's other three bugs made.

`coerce_row()` handles it:

| Input | Result |
|---|---|
| `"12.5"` | `12.5` |
| `"true"`, `"t"`, `"yes"`, `"1"` | `True` |
| `""` (empty spring score) | `None`, **not** `0.0` |
| already-typed values | pass through untouched |

The empty-to-null case matters: `0.0` is a real score and would drag every growth average toward a fabricated decline.

## Tests

6 new, 51 total in `test_aggregate.py` — the lexical-sort trap end to end, every boolean text form, empty-to-null, and a full run with every column as text.

## Context

This is the fourth round on this skill. The previous three each shipped a bug that produced silently wrong numbers rather than raising: grade-mixing in the norms lookup, string-sorted student ids, and `K` not mapping to grade `0`. All were caught by review, not by my tests — which is why these tests pin actual values and exercise the failure path rather than asserting non-null.