### PR TITLE
fix(agent): stop the permission loop and remove the CSV glue script

### DIFF
--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -423,6 +423,29 @@ compromise:
 - So a long turn ends with the user getting the real answer. A promise ends with
   the user getting nothing.
 - Never end a turn whose last sentence is a promise of future work (also Rule 4).
+- **Never ask permission to continue work the user already asked for.** "Want me
+  to keep going, or hold here?" is not a courtesy — the user asked for the
+  finished thing, so the answer is always yes and asking only costs them a round
+  trip. If work remains, do it. Ask only when you need information you cannot
+  obtain, or before something destructive or irreversible.
+- **Never say you were paused, stopped, or interrupted unless the user said so
+  IN THIS TURN.** You cannot observe being stopped. A turn that ended, a
+  promotion to a background job, or a status line you wrote earlier are not the
+  user stopping you, and reporting them that way is a fabricated outcome
+  (Rule 3).
+
+  This is self-reinforcing, which is what makes it dangerous: once "I've paused"
+  is in the history, the next turn reads it and repeats it. On 2026-08-15 a
+  quartile report looped for four turns — the user said "keep going to
+  completion", then "Keep going", then "Yes, I told you to", and each reply said
+  "I've paused" / "Paused as requested" / "Stopped as requested" and asked again.
+  The runtime logs for that window contain no abort of any kind: nothing had
+  stopped it. Real work happened in every one of those turns and was then thrown
+  away on a question.
+
+  If you catch yourself writing "as requested" next to paused/stopped, check the
+  CURRENT user message. If it does not say stop, you are inventing it — delete
+  the sentence and finish the work.
 
 **Why:** "I'll notify you when it's done" is only true if the platform's own
 promotion path is doing the notifying. Running long composes with it. Anything
@@ -432,4 +455,4 @@ that ends your turn early — a promise, a spawned child, a deferral — breaks 
 
 ## Self-check before send
 
-Before every reply, confirm: no "Let me…"/scratchpad (R1); every URL is from a skill, and any `url` field is on its own line (R2/R9); no fabricated facts or outcomes (R3); did the work now, not an empty promise (R4); reply length matches information density and memory files updated (R5/R7); for any task a skill covers, called the skill (R9); called `psd-failure-report` if any part failed (R11); user-visible text is non-empty (R12); no non-reversible `gh`/`git push` unless the user authorized it this same turn (R13); long work ran to completion in THIS turn rather than being spawned out, deferred, sampled or shortened — subagents are unavailable, so there is nothing to wait on and nothing coming later (R15). If any is "no," fix the reply first.
+Before every reply, confirm: no "Let me…"/scratchpad (R1); every URL is from a skill, and any `url` field is on its own line (R2/R9); no fabricated facts or outcomes (R3); did the work now, not an empty promise (R4); reply length matches information density and memory files updated (R5/R7); for any task a skill covers, called the skill (R9); called `psd-failure-report` if any part failed (R11); user-visible text is non-empty (R12); no non-reversible `gh`/`git push` unless the user authorized it this same turn (R13); long work ran to completion in THIS turn rather than being spawned out, deferred, sampled or shortened — subagents are unavailable, so there is nothing to wait on and nothing coming later (R15); not asking permission to continue work already requested, and not claiming to be paused/stopped unless the CURRENT user message says so (R15). If any is "no," fix the reply first.

--- a/infra/agent-image/skills/quartile-growth-report/references/sql.md
+++ b/infra/agent-image/skills/quartile-growth-report/references/sql.md
@@ -90,12 +90,18 @@ Skipping them cost roughly ten round trips of trial and error per run on
 
 ### Step 2 — aggregate
 
-Feed those rows to `aggregate.py`, which applies the norms, assigns the three
-quartile scopes, and emits the district/school/class rollups:
+**Feed the exported CSV straight in. Do not write a converter.** `aggregate.py`
+reads the export as-is — CSV, a JSON array, or JSON lines, detected by content
+rather than extension. Writing a CSV→JSON glue script is where runs keep dying:
+the write tool emits literal `\n` into helper scripts, producing a SyntaxError
+and a retry loop that has burned parts of three sessions.
+
+`aggregate.py` applies the norms, assigns the three quartile scopes, and emits
+the district/school/class rollups:
 
 ```bash
 /opt/agentcore-venv/bin/python3 /opt/psd-skills/quartile-growth-report/scripts/aggregate.py \
-  --rows grade3.json --grade 3 --baseline Fall --spring Spring \
+  --rows grade3.csv --grade 3 --baseline Fall --spring Spring \
   --measure-as "<warehouse name>=ORF-WRC"
 ```
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -40,6 +40,7 @@ columns the SQL used to emit, plus an 'All' row per measure and scope.
 
 import argparse
 import csv
+import io
 import json
 import os
 import sys
@@ -302,12 +303,27 @@ def coerce_row(row):
 
 
 def read_rows(handle):
+    """Accept the export CSV as-is, or JSON, without being told which.
+
+    psd-data exports CSV. Requiring JSON here forced a hand-written CSV->JSON
+    converter on every run, and that glue is where runs kept dying: the write
+    tool emits literal `\\n` sequences into helper scripts, producing a
+    SyntaxError and a retry loop that has now burned parts of three sessions
+    (agent_failures 6804, and again 2026-08-15 mid-report).
+
+    The fix is to remove the need for the script rather than to warn about it
+    again. Detection is by content, not by extension, because the export
+    filename is not always .csv.
+    """
     text = handle.read().strip()
     if not text:
         return []
-    if text.lstrip().startswith("["):
-        return json.loads(text)
-    return [json.loads(line) for line in text.splitlines() if line.strip()]
+    if text.lstrip().startswith(("[", "{")):
+        if text.lstrip().startswith("["):
+            return json.loads(text)
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+    # CSV: a header line naming the extraction columns.
+    return list(csv.DictReader(io.StringIO(text)))
 
 
 def main() -> int:

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -549,3 +549,64 @@ class TextCastColumnsAreParsedBack(unittest.TestCase):
             self.assertEqual(all_row["growth"], 15.0)
         finally:
             os.unlink(path)
+
+
+class CsvInputNeedsNoGlueScript(unittest.TestCase):
+    """psd-data exports CSV; requiring JSON forced a hand-written converter.
+
+    That glue is where runs kept dying — the write tool emits literal \\n into
+    helper scripts, producing a SyntaxError and a retry loop (agent_failures
+    6804, and again mid-report 2026-08-15). Reading the export directly removes
+    the script rather than warning about it again.
+    """
+
+    def run_on(self, text, *extra, suffix=".csv"):
+        with tempfile.NamedTemporaryFile("w", suffix=suffix, delete=False) as fh:
+            fh.write(text)
+            path = fh.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, SCRIPT, "--rows", path, *extra],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            return json.loads(proc.stdout)
+        finally:
+            os.unlink(path)
+
+    CSV = (
+        "meas,studentid,b,e,sectionid,in_sch\n"
+        "ORF-WRC,9,10,20,S1,true\n"
+        "ORF-WRC,100,30,50,S1,t\n"
+    )
+
+    def test_csv_export_is_read_directly(self):
+        out = self.run_on(self.CSV, "--no-norms")
+        cell = next(r for r in out if r["scope"] == "district" and r["qt"] == "All")
+        self.assertEqual(cell["growth"], 15.0)
+        self.assertEqual(cell["n"], 2)
+
+    def test_csv_text_columns_are_coerced_like_json(self):
+        # Everything arrives as text from CSV, so the numeric/boolean coercion
+        # has to apply on this path too — otherwise b sorts lexically.
+        out = self.run_on(self.CSV, "--no-norms")
+        self.assertIn("school", {r["scope"] for r in out})
+
+    def test_detection_is_by_content_not_extension(self):
+        # The export filename is not always .csv.
+        out = self.run_on(self.CSV, "--no-norms", suffix=".txt")
+        self.assertTrue(out)
+
+    def test_json_array_still_works(self):
+        rows = rows_of([("a", 1, 2), ("b", 5, 9)])
+        out = self.run_on(json.dumps(rows), "--no-norms", suffix=".json")
+        self.assertTrue(out)
+
+    def test_jsonl_still_works(self):
+        rows = rows_of([("a", 1, 2), ("b", 5, 9)])
+        text = "\n".join(json.dumps(r) for r in rows)
+        out = self.run_on(text, "--no-norms", suffix=".jsonl")
+        self.assertTrue(out)
+
+    def test_empty_csv_header_only(self):
+        self.assertEqual(self.run_on("meas,studentid,b,e\n", "--no-norms"), [])


### PR DESCRIPTION
A quartile report looped for four turns without finishing.

> **You:** keep going to completion → **Agent:** "I've paused."
> **You:** Keep going → **Agent:** "Paused as requested."
> **You:** Yes, I told you to → **Agent:** "Stopped as requested."

Real work happened in each of those turns and was discarded on a question.

## Nothing had stopped it

The runtime logs for that window contain **no abort of any kind** — no `chat aborted`, no deadline expiry after the initial promotion, no failure record. Every turn was clean: pre-send abort (routine), then `turn ok`, 20-60s.

I first told Hagel the pre-send `chat.abort` was killing the work. **That was wrong**, and the logs disproved it before anything shipped.

The model was fabricating the interruption, then reading its own earlier *"I've paused"* out of session history and repeating it. Self-reinforcing — which is how one genuine interruption (the 18:32 promotion) became four dead turns.

### Rule 15 gains two clauses

- **Never ask permission to continue work already requested.** The user asked for the finished thing; the answer is always yes, and asking costs a round trip. Ask only for information you cannot obtain, or before something destructive.
- **Never claim to be paused/stopped unless the user said so IN THIS TURN.** A turn that ended, a promotion, or your own earlier status line are not the user stopping you — reporting them that way is a fabricated outcome (Rule 3). If you're about to write "as requested" next to *paused*, check the current user message.

Both added to the **pre-send checklist**, which is what the model actually re-reads.

## The glue script

The same report then died on:

> ⚠️ I couldn't finish that — my last write left a broken script (literal `\n` instead of a real newline)

That's the write tool emitting literal `\n` into helper scripts — a SyntaxError-and-retry loop that has cost parts of three sessions (`agent_failures` 6804, and twice today).

That script existed **only** to convert psd-data's CSV export into the JSON `aggregate.py` wanted. So `aggregate.py` now reads the export directly — CSV, JSON array, or JSON lines, detected by **content** rather than extension (the export filename isn't always `.csv`).

No converter, no class of failure. Warning about the write tool again wouldn't have helped; removing the reason to use it does.

## Tests

67 across the skill's scripts (6 new for CSV input), 105 across the image config suites, bootstrap budget clean.