### PR TITLE
fix(agent): deliver the agent's real question, and close the allowlist gaps

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -2027,19 +2027,33 @@ class OpenClawAdapter(HarnessAdapter):
                         q_data = q_payload.get("data")
                         if not isinstance(q_data, dict):
                             q_data = {}
-                        question_text = None
-                        # The gateway's exact field name is not pinned by any
-                        # contract we own, so probe the plausible carriers and
-                        # fall back to a generic prompt rather than returning
-                        # an empty turn.
-                        for source in (q_payload, q_data):
-                            for key in ("question", "text", "prompt", "message", "content"):
-                                candidate = self._extract_text(source.get(key))
-                                if candidate:
-                                    question_text = candidate
+                        # `questions` (PLURAL) is the shape the gateway actually
+                        # sends, confirmed from a live payload on 2026-08-15:
+                        #
+                        #   {"questions": [{"id": ..., "header": ...,
+                        #     "question": "...?",
+                        #     "options": [{"label": "Yes, finish it now"}, ...]}]}
+                        #
+                        # The probe below looked for singular `question`/`text`/
+                        # `prompt`/`message`/`content` and missed it entirely, so
+                        # every structured question the agent asked was replaced
+                        # by the generic fallback further down. The user saw "I
+                        # need a bit more information to continue" in place of a
+                        # real question that already had answer options, could
+                        # not answer it, and the agent asked again — a loop that
+                        # cost an entire report.
+                        question_text = self._render_questions(q_payload) or self._render_questions(q_data)
+                        # Legacy/alternate carriers stay as a fallback so a
+                        # differently-shaped event is still readable.
+                        if not question_text:
+                            for source in (q_payload, q_data):
+                                for key in ("question", "text", "prompt", "message", "content"):
+                                    candidate = self._extract_text(source.get(key))
+                                    if candidate:
+                                        question_text = candidate
+                                        break
+                                if question_text:
                                     break
-                            if question_text:
-                                break
                         if not question_text:
                             question_text = (
                                 "I need a bit more information to continue — "
@@ -2641,6 +2655,54 @@ class OpenClawAdapter(HarnessAdapter):
         if boundary_pending:
             return increment
         return accum + increment
+
+    @staticmethod
+    def _render_questions(payload: object) -> str:
+        """Render a `question.requested` payload's `questions` list for Chat.
+
+        The gateway sends the agent's structured ask as
+        `{"questions": [{"question": "...?", "header": ..., "options":
+        [{"label": "..."}]}]}`. Options are included because they are the
+        answer set the agent is waiting on — dropping them leaves the user
+        guessing at what a valid reply looks like, which is most of why the
+        question loop was unanswerable.
+        """
+        if not isinstance(payload, dict):
+            return ""
+        questions = payload.get("questions")
+        if not isinstance(questions, list):
+            return ""
+
+        blocks = []
+        for entry in questions:
+            if isinstance(entry, str):
+                blocks.append(entry.strip())
+                continue
+            if not isinstance(entry, dict):
+                continue
+            text = ""
+            for key in ("question", "text", "prompt"):
+                value = entry.get(key)
+                if isinstance(value, str) and value.strip():
+                    text = value.strip()
+                    break
+            if not text:
+                continue
+            labels = []
+            options = entry.get("options")
+            if isinstance(options, list):
+                for option in options:
+                    if isinstance(option, str) and option.strip():
+                        labels.append(option.strip())
+                    elif isinstance(option, dict):
+                        label = option.get("label") or option.get("value")
+                        if isinstance(label, str) and label.strip():
+                            labels.append(label.strip())
+            if labels:
+                text += "\n" + "\n".join(f"- {label}" for label in labels)
+            blocks.append(text)
+
+        return "\n\n".join(block for block in blocks if block)
 
     @staticmethod
     def _is_tool_activity_stream(stream: object, data: object) -> bool:

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -424,3 +424,78 @@ class ForeignRunsCannotAnswerThisTurn(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def asks_question(payload):
+    """A `question.requested` event, as the gateway actually sends it."""
+    return {"type": "event", "event": "question.requested", "payload": payload}
+
+
+REAL_PAYLOAD = {
+    "agentId": "main",
+    "id": "q1",
+    "runId": TURN_RUN_ID,
+    "sessionKey": "agent:main:replay",
+    "status": "pending",
+    "questions": [
+        {
+            "id": "continue_report",
+            "header": "Quartile report",
+            "question": "Your last run got interrupted while I was building the "
+            "Evergreen quartile growth Sheet. Want me to finish and post the link now?",
+            "options": [
+                {"label": "Yes, finish and share it now (Recommended)"},
+                {"label": "Hold off for now"},
+            ],
+        }
+    ],
+}
+
+
+class StructuredQuestionsReachTheUser(unittest.TestCase):
+    """`questions` (PLURAL) is the shape the gateway sends.
+
+    The extractor probed singular question/text/prompt/message/content and
+    missed it, so every structured ask was replaced by "I need a bit more
+    information to continue — could you clarify what you'd like me to do?".
+    The user could not answer a question they never saw, the agent asked
+    again, and the loop cost a whole report (dev 2026-08-15, payload_keys
+    ['agentId','createdAtMs','expiresAtMs','id','questions','runId',
+    'sessionKey','status']).
+    """
+
+    def test_the_real_question_text_reaches_the_user(self):
+        text = replay([asks_question(REAL_PAYLOAD)])
+        self.assertIn("Want me to finish and post the link now?", text)
+        self.assertNotIn("I need a bit more information", text)
+
+    def test_answer_options_are_included(self):
+        # Without the options the user is guessing at what a valid reply is.
+        text = replay([asks_question(REAL_PAYLOAD)])
+        self.assertIn("Yes, finish and share it now", text)
+        self.assertIn("Hold off for now", text)
+
+    def test_work_streamed_before_the_question_is_kept(self):
+        text = replay([says("Rollups are done."), asks_question(REAL_PAYLOAD)])
+        self.assertIn("Rollups are done.", text)
+        self.assertIn("Want me to finish", text)
+
+    def test_multiple_questions_all_render(self):
+        payload = {"questions": [{"question": "First?"}, {"question": "Second?"}]}
+        text = replay([asks_question(payload)])
+        self.assertIn("First?", text)
+        self.assertIn("Second?", text)
+
+    def test_plain_string_questions_render(self):
+        text = replay([asks_question({"questions": ["Just a string?"]})])
+        self.assertIn("Just a string?", text)
+
+    def test_legacy_singular_shape_still_works(self):
+        text = replay([asks_question({"question": "Legacy shape?"})])
+        self.assertIn("Legacy shape?", text)
+
+    def test_genuinely_empty_payload_still_falls_back(self):
+        # The fallback must remain for a shape we truly cannot read — but it
+        # is now the last resort, not the common path.
+        text = replay([asks_question({"questions": []})])
+        self.assertIn("I need a bit more information", text)

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -149,6 +149,15 @@ const ALLOWED_WRITES = new Set([
   "sheets spreadsheets create",
   "sheets spreadsheets values append",
   "sheets spreadsheets values update",
+  // The BULK form of values.update — one call writes many ranges. Building a
+  // workbook is inherently multi-range (a tab per grade), so without this the
+  // only route is one values.update per range: dozens of round trips for one
+  // report, on the slowest step of the slowest skill. A quartile report stalled
+  // here with an empty spreadsheet and every tab still to fill
+  // (dev 2026-08-15). It writes the same cells values.update already writes, to
+  // the same spreadsheet, under the same scope rules — the bulk spelling was
+  // simply missed when the singular one was added.
+  "sheets spreadsheets values batchupdate",
   "slides presentations batchupdate",
   "slides presentations create",
   "tasks tasks insert",
@@ -213,6 +222,11 @@ const AGENT_ONLY_WRITES = new Set([
   // boundary, and the helper is the spelling the model actually reaches for.
   "sheets +append",
   "sheets spreadsheets values update",
+  // Same reasoning as the singular form directly above: authored content, so
+  // it stays on the agent slot. Splitting the two spellings across the
+  // impersonation boundary is how `sheets +append` and its canonical form
+  // disagreed once already.
+  "sheets spreadsheets values batchupdate",
   "slides presentations batchupdate",
   "slides presentations create",
   "tasks tasks patch",

--- a/tests/unit/lib/agent-workspace/allowlist-closure.test.ts
+++ b/tests/unit/lib/agent-workspace/allowlist-closure.test.ts
@@ -1,0 +1,146 @@
+import { validateWorkspaceCommand } from "@/lib/agent-workspace/command-executor"
+
+/**
+ * Every Workspace capability gap found so far has had one shape: a sibling
+ * spelling of an operation that was ALREADY allowed got missed, so a
+ * capability the agent demonstrably had was refused in the form it actually
+ * reached for.
+ *
+ *   gmail users drafts create        allowed -> gmail +draft                 missed
+ *   sheets spreadsheets values append allowed -> sheets +append              missed
+ *   drive files create               allowed -> drive +upload                missed
+ *   tasks tasks insert               allowed -> tasks tasklists insert       missed
+ *   sheets spreadsheets values update allowed -> ...values batchupdate       missed
+ *
+ * Each cost a user-visible failure and a separate build to fix, one at a time,
+ * because nothing checked the allowlist for completeness — only that the
+ * entries present were spelled correctly.
+ *
+ * These tests close that loop. They do not enumerate Google's API surface;
+ * they assert that operations which are two spellings of the same act are
+ * allowed or refused TOGETHER. Adding one half of a pair now fails here rather
+ * than in production a week later.
+ */
+
+const CALLER = "hagelk@psd401.net"
+
+function allows(argv: string[], scope: "agent" | "user" = "agent"): boolean {
+  try {
+    validateWorkspaceCommand({ scope, argv }, CALLER)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** A minimal well-formed invocation for an operation, so only the allowlist decides. */
+function invocationFor(operation: string): string[] {
+  const tokens = operation.split(" ")
+  if (operation === "drive permissions create") {
+    return [
+      ...tokens,
+      "--json",
+      JSON.stringify({
+        fileId: "f",
+        type: "user",
+        role: "reader",
+        emailAddress: CALLER,
+      }),
+    ]
+  }
+  if (operation === "drive accessproposals resolve") {
+    return [
+      ...tokens,
+      "--params",
+      JSON.stringify({ fileId: "f", proposalId: "p" }),
+      "--json",
+      JSON.stringify({ action: "accept", role: "writer" }),
+    ]
+  }
+  if (operation === "gmail +draft") {
+    return ["gmail", "+draft", "--to", CALLER, "--subject", "x"]
+  }
+  return [...tokens, "--json", "{}"]
+}
+
+describe("bulk and singular spellings of one write travel together", () => {
+  // `batchUpdate` writes the same cells `update` writes, to the same resource,
+  // under the same scope rules. Allowing one without the other leaves the
+  // agent doing N round trips where the API offers one call — which is exactly
+  // how a workbook build stalled with an empty spreadsheet.
+  const PAIRS: Array<[string, string]> = [
+    ["sheets spreadsheets values update", "sheets spreadsheets values batchupdate"],
+  ]
+
+  it.each(PAIRS)("allows %s and %s together", (singular, bulk) => {
+    expect(allows(invocationFor(singular))).toBe(allows(invocationFor(bulk)))
+  })
+
+  it("allows the bulk form the workbook build needs", () => {
+    // Named explicitly: this is the one that stalled a report mid-build.
+    expect(allows(invocationFor("sheets spreadsheets values batchupdate"))).toBe(true)
+  })
+})
+
+describe("helper verbs and their canonical operations travel together", () => {
+  // A helper verb is the spelling the model actually reaches for, because it
+  // is what the skill documents. The canonical form is what gws implements.
+  // Allowing one without the other means the capability exists but the
+  // documented way to use it is refused — the `+draft` failure exactly.
+  const HELPERS: Array<[string, string]> = [
+    ["gmail +draft", "gmail users drafts create"],
+    ["sheets +append", "sheets spreadsheets values append"],
+    ["drive +upload", "drive files create"],
+  ]
+
+  it.each(HELPERS)("allows %s and %s together", (helper, canonical) => {
+    expect(allows(invocationFor(helper))).toBe(allows(invocationFor(canonical)))
+  })
+})
+
+describe("a resource family is usable end to end", () => {
+  // Creating items in a list you cannot create is not a capability. This is
+  // the `tasks tasklists insert` gap: five requests failed because the
+  // container for the allowed operation could not be made.
+  const FAMILIES: Array<[string, string]> = [
+    ["tasks tasks insert", "tasks tasklists insert"],
+    ["sheets spreadsheets values update", "sheets spreadsheets create"],
+  ]
+
+  it.each(FAMILIES)("allows %s alongside its container %s", (item, container) => {
+    expect(allows(invocationFor(item))).toBe(true)
+    expect(allows(invocationFor(container))).toBe(true)
+  })
+})
+
+describe("the workbook build path is allowlisted end to end", () => {
+  // The quartile report's final step, as one list. Any single refusal here
+  // strands a finished dataset in an unshareable spreadsheet, which is what
+  // happened on 2026-08-15 — data complete, Sheet empty.
+  const WORKBOOK_BUILD = [
+    "sheets spreadsheets create",
+    "sheets spreadsheets batchupdate", // add the per-grade tabs
+    "sheets spreadsheets values batchupdate", // fill them in one call
+    "sheets spreadsheets values update", // per-range fallback
+    "drive permissions create", // share it back to the caller
+  ]
+
+  it.each(WORKBOOK_BUILD)("allows %s", (operation) => {
+    expect(allows(invocationFor(operation))).toBe(true)
+  })
+})
+
+describe("closure does not widen the boundary", () => {
+  // The pairs above must not become an argument for allowing deletes or sends
+  // just because a sibling create is allowed. These stay refused.
+  const STILL_REFUSED = [
+    "drive files delete",
+    "gmail users messages send",
+    "sheets spreadsheets values clear",
+    "drive permissions delete",
+  ]
+
+  it.each(STILL_REFUSED)("still refuses %s", (operation) => {
+    expect(allows(invocationFor(operation))).toBe(false)
+  })
+})


### PR DESCRIPTION
Three fixes for one user-visible failure: a quartile report with all its data computed that could not be finished, across many turns.

## 1. The question the user never saw

The agent asked a well-formed question with answer options:

> Your last run got interrupted while I was building the Evergreen quartile growth Sheet (all data/aggregation done, just need to create the Sheet and share it). Want me to finish and post the link now?
> - Yes, finish and share it now (Recommended)
> - Hold off for now

The user was shown:

> I need a bit more information to continue — could you clarify what you'd like me to do?

**That sentence is ours** — a canned fallback in `harness_adapter.py`. The gateway sends structured asks under **`questions`** (plural, a list). The extractor probed singular `question`/`text`/`prompt`/`message`/`content`, matched nothing, and substituted the fallback. Confirmed from the live payload and the warning it logged:

```
payload_keys=['agentId','createdAtMs','expiresAtMs','id','questions','runId','sessionKey','status']
```

So the user could not answer a question they never saw, the agent asked again, and the loop cost the report. **The agent was never confused** — the harness discarded what it said.

`_render_questions` reads the real shape and renders the question **with its options**, since the options are the answer set being waited on. Old probes remain as a fallback; the canned line is now a last resort. 7 new replay tests, including the verbatim production payload.

I misread this twice before finding it — first as a Rule 15 violation, then as model non-adherence, and wrote prompt rules for both. It reads like canned text; I should have grepped for it the first time it appeared.

## 2. `sheets values batchUpdate` was not allowlisted

The next turn hit *"sheets values batchUpdate isn't allowlisted"* with the spreadsheet created and every tab empty. That's the bulk multi-range write — the only sane way to fill a tab-per-grade workbook.

It writes the same cells `values.update` already writes, to the same spreadsheet, under the same scope rules. Added to `ALLOWED_WRITES` and `AGENT_ONLY_WRITES`, matching the singular form's placement in both.

## 3. Why there was a third fix at all

Every Workspace gap found so far has the same shape — a sibling spelling of an already-allowed operation was missed:

| Allowed | Missed |
|---|---|
| `gmail users drafts create` | `gmail +draft` |
| `sheets spreadsheets values append` | `sheets +append` |
| `drive files create` | `drive +upload` |
| `tasks tasks insert` | `tasks tasklists insert` |
| `sheets spreadsheets values update` | `sheets spreadsheets values batchupdate` |

Each cost a user-visible failure and its own build, **one at a time**, because nothing checked the allowlist for *completeness* — only that entries present were spelled right. `allowlist-doc-drift` covers documented examples; none of these were documented.

`allowlist-closure.test.ts` asserts that two spellings of one act are allowed or refused **together**: bulk/singular, helper/canonical, item/container, plus the whole workbook-build path end to end.

It does not enumerate Google's API surface and does not widen the boundary — deletes and sends stay refused, and that's asserted too. Adding half a pair now fails here instead of in production a week later.

## Verification

typecheck clean, `eslint --max-warnings 0` clean, 310 tests across `tests/unit/lib/agent-workspace/` (16 new), 21 replay tests.
