### PR TITLE
fix(quartile): scope subgroups district-wide and tri-state the flags

### DIFF
--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -123,9 +123,18 @@ not administered), **Grade 1 ORF baseline = Winter** (ORF starts mid-year).
 | SBA grade 3 | spring scale + % met, by **Fall i-Ready quartile** (no prior SBA exists) |
 | SBA proficiency | % met standard among all tested, rows ELA/Math |
 
-Subgroups (School + District, "All" level): Low Income / Non-Low Income /
+**Subgroups** (School + District, "All" level): Low Income / Non-Low Income /
 Special Ed / Non-Special Ed, from `students_frl.frl` and
 `students_specialed.special_education`.
+
+**Join those flags district-wide, not just for this school**, and pass
+`--subgroup` to `aggregate.py` rather than grouping them yourself. A
+school-scoped join makes the District column a copy of the School column and
+dumps every unflagged district student into the negative class — it reads as
+real data. A student with no flag record is UNKNOWN and is excluded, never
+counted as negative. See `references/sql.md`. If `aggregate.py` warns that a
+district subgroup row matches its school row, the join is wrong; do not
+publish that workbook.
 
 ## National PR — the norms asset
 

--- a/infra/agent-image/skills/quartile-growth-report/references/sql.md
+++ b/infra/agent-image/skills/quartile-growth-report/references/sql.md
@@ -131,8 +131,43 @@ Every variant below keeps the same split: the query returns raw pairs, and
 | i-Ready, ORF Accuracy | Pass `--no-norms`; value is `e-b` only |
 | SBA grades 4-5 | Replace `stu`/`m` with a prior-year join (`yearid-1`, `grade-1`), filter `assessment_group LIKE 'Summative%'` and `is_strand = false` |
 | SBA grade 3 | Baseline = Fall i-Ready percentile; values `AVG(e)` scale and `AVG(metv)` % met |
-| Subgroups | Same extraction query plus the four flag columns; group locally rather than re-querying per subgroup |
+| Subgroups | Join the flags **district-wide** (below) and pass `--subgroup` to `aggregate.py` |
 | Fall-only status | Drop the Spring join and emit `e` as null; read `start_raw` / `start_pr` |
+
+## Subgroups — the flag join must be DISTRICT-WIDE
+
+Add the flag columns to the same extraction query, joined across the whole
+district cohort, not just the report's school:
+
+```sql
+LEFT JOIN students_frl f       ON f.studentid = m.studentid AND f.yearid = :yearid
+LEFT JOIN students_specialed sp ON sp.studentid = m.studentid AND sp.yearid = :yearid
+-- …and select them, cast like everything else:
+       f.frl::text                AS low_income,
+       sp.special_education::text AS special_ed
+```
+
+Then let `aggregate.py` do the rollups:
+
+```bash
+… --subgroup "low_income=Low Income|Non-Low Income" \
+  --subgroup "special_ed=Special Ed|Non-Special Ed"
+```
+
+**Do not scope the join to the school.** On 2026-08-15 every grade reported
+School and District identically — grade K showed 18/18 against a district
+cohort of 558 — because only Evergreen students carried a flag. The district
+cell WAS the school cell, and its complement silently absorbed all 540
+unflagged district students. Every number looked plausible.
+
+**A student with no flag record is UNKNOWN, not negative.** `aggregate.py`
+excludes them from both sides. Counting a missing record as "not low income"
+is what made the contamination invisible; smaller honest denominators beat a
+complete-looking wrong one.
+
+`aggregate.py` prints a warning to stderr when a subgroup's district row is
+identical to its school row, which is the fingerprint of this bug. Do not
+publish a workbook that emitted that warning.
 
 ## School-vs-district PR mini-tables
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -302,6 +302,82 @@ def coerce_row(row):
     return row
 
 
+UNKNOWN_FLAG = object()
+
+
+def flag_value(raw):
+    """Tri-state a subgroup flag: True, False, or UNKNOWN.
+
+    A student with NO flag record is UNKNOWN, never False. Defaulting a missing
+    record to the negative class is what made the district subgroup columns
+    wrong AND invisible on 2026-08-15: only Evergreen students carried an
+    FRL/SpEd record, so all 540 other district students silently became
+    "Non-Low Income", and the district row became a copy of the school row.
+    A missing record is not evidence that a student is not low income.
+    """
+    if raw is None:
+        return UNKNOWN_FLAG
+    if isinstance(raw, bool):
+        return raw
+    text = str(raw).strip().lower()
+    if text == "":
+        return UNKNOWN_FLAG
+    if text in TRUE_TEXT:
+        return True
+    if text in {"false", "f", "no", "n", "0"}:
+        return False
+    return UNKNOWN_FLAG
+
+
+def subgroup_rollups(rows, column, positive_label, negative_label):
+    """School and district rollups for one flag column, at the All level.
+
+    Students whose flag is UNKNOWN are excluded from BOTH sides rather than
+    swelling the negative class. That makes the denominators smaller and
+    honest; the alternative reports a number that looks complete and is not.
+    """
+    out = []
+    for scope, population in (
+        ("district", rows),
+        ("school", [r for r in rows if r.get("in_sch")]),
+    ):
+        for label, wanted in ((positive_label, True), (negative_label, False)):
+            members = [r for r in population if flag_value(r.get(column)) is wanted]
+            if not members:
+                continue
+            for cell in rollup(members, scope, lambda r: r["meas"]):
+                if cell["qt"] != "All":
+                    continue
+                cell["subgroup"] = label
+                out.append(cell)
+    return out
+
+
+def subgroup_scope_warning(records):
+    """Warn when a subgroup's district row is identical to its school row.
+
+    That is the fingerprint of a flag joined only for the report's own school:
+    the district cell is really the school cell, and its complement is
+    contaminated with every unflagged student in the district. It reads as
+    plausible data, which is exactly why it needs to be called out rather than
+    left for a reader to notice.
+    """
+    by_key = defaultdict(dict)
+    for record in records:
+        subgroup = record.get("subgroup")
+        if subgroup:
+            by_key[(record["meas"], subgroup)][record["scope"]] = record
+
+    suspect = []
+    for (meas, subgroup), scopes in sorted(by_key.items()):
+        school, district = scopes.get("school"), scopes.get("district")
+        if not school or not district:
+            continue
+        if school["n"] == district["n"] and school["growth"] == district["growth"]:
+            suspect.append(f"{meas}/{subgroup}")
+    return suspect
+
+
 def read_rows(handle):
     """Accept the export CSV as-is, or JSON, without being told which.
 
@@ -343,6 +419,14 @@ def main() -> int:
         default=[],
         metavar="WAREHOUSE=NORMS",
         help="map a warehouse measure name to its norms-file name; repeatable",
+    )
+    parser.add_argument(
+        "--subgroup",
+        action="append",
+        default=[],
+        metavar="COLUMN=POSITIVE|NEGATIVE",
+        help="emit School+District rollups for a flag column, e.g. "
+        "low_income='Low Income|Non-Low Income'; repeatable",
     )
     parser.add_argument(
         "--no-norms",
@@ -450,6 +534,29 @@ def main() -> int:
             lambda r: (r["meas"], r["sectionid"]),
         )
     )
+
+    for spec in args.subgroup:
+        if "=" not in spec or "|" not in spec:
+            parser.error(
+                f"--subgroup expects COLUMN='POSITIVE|NEGATIVE', got {spec!r}"
+            )
+        column, labels = spec.split("=", 1)
+        positive, negative = labels.split("|", 1)
+        results.extend(
+            subgroup_rollups(rows, column, positive.strip(), negative.strip())
+        )
+
+    suspect = subgroup_scope_warning(results)
+    if suspect:
+        print(
+            "WARNING: district subgroup rows are identical to school rows for: "
+            + ", ".join(suspect)
+            + ". The flag column is almost certainly joined only for this "
+            "school, so the district figure is the school figure and its "
+            "complement includes every unflagged district student. Join the "
+            "flags district-wide (see references/sql.md).",
+            file=sys.stderr,
+        )
 
     print(json.dumps(results, indent=1))
     return 0

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -610,3 +610,72 @@ class CsvInputNeedsNoGlueScript(unittest.TestCase):
 
     def test_empty_csv_header_only(self):
         self.assertEqual(self.run_on("meas,studentid,b,e\n", "--no-norms"), [])
+
+
+class SubgroupsAreScopedAndTriState(unittest.TestCase):
+    """District subgroup rows must not be copies of the school rows.
+
+    On 2026-08-15 every grade reported School and District identically for Low
+    Income and Special Ed — grade K showed 18/18 against a district cohort of
+    558. The flags were joined only for the report's own school, so the
+    district cell WAS the school cell and its complement silently absorbed all
+    540 unflagged district students. It looked like data.
+    """
+
+    ROWS = [
+        {"meas": "ORF", "studentid": 1, "b": 10, "e": 20, "in_sch": True, "low_income": True},
+        {"meas": "ORF", "studentid": 2, "b": 20, "e": 35, "in_sch": True, "low_income": False},
+        {"meas": "ORF", "studentid": 3, "b": 30, "e": 40, "in_sch": False, "low_income": True},
+        {"meas": "ORF", "studentid": 4, "b": 40, "e": 55, "in_sch": False, "low_income": None},
+    ]
+
+    def cells(self):
+        return aggregate.subgroup_rollups(
+            [dict(r, prb=None, pre=None) for r in self.ROWS],
+            "low_income", "Low Income", "Non-Low Income",
+        )
+
+    def test_district_is_wider_than_school(self):
+        cells = self.cells()
+        school = next(c for c in cells if c["scope"] == "school" and c["subgroup"] == "Low Income")
+        district = next(c for c in cells if c["scope"] == "district" and c["subgroup"] == "Low Income")
+        self.assertEqual(school["n"], 1)
+        self.assertEqual(district["n"], 2)
+        self.assertGreater(district["n"], school["n"])
+
+    def test_missing_flag_is_excluded_not_counted_as_negative(self):
+        # Student 4 has no flag record. Counting them as Non-Low Income is the
+        # bug; a missing record is not evidence of anything.
+        cells = self.cells()
+        negative = next(
+            c for c in cells
+            if c["scope"] == "district" and c["subgroup"] == "Non-Low Income"
+        )
+        self.assertEqual(negative["n"], 1)
+
+    def test_flag_value_tri_states(self):
+        self.assertIs(aggregate.flag_value(True), True)
+        self.assertIs(aggregate.flag_value("t"), True)
+        self.assertIs(aggregate.flag_value("false"), False)
+        self.assertIs(aggregate.flag_value(None), aggregate.UNKNOWN_FLAG)
+        self.assertIs(aggregate.flag_value(""), aggregate.UNKNOWN_FLAG)
+        self.assertIs(aggregate.flag_value("maybe"), aggregate.UNKNOWN_FLAG)
+
+    def test_identical_school_and_district_is_flagged(self):
+        # The fingerprint of a school-only flag join.
+        same = [
+            {"meas": "ORF", "scope": "school", "qt": "All", "subgroup": "Low Income",
+             "n": 18, "growth": 19.9},
+            {"meas": "ORF", "scope": "district", "qt": "All", "subgroup": "Low Income",
+             "n": 18, "growth": 19.9},
+        ]
+        self.assertEqual(aggregate.subgroup_scope_warning(same), ["ORF/Low Income"])
+
+    def test_properly_scoped_subgroups_are_not_flagged(self):
+        ok = [
+            {"meas": "ORF", "scope": "school", "qt": "All", "subgroup": "Low Income",
+             "n": 18, "growth": 19.9},
+            {"meas": "ORF", "scope": "district", "qt": "All", "subgroup": "Low Income",
+             "n": 402, "growth": 15.2},
+        ]
+        self.assertEqual(aggregate.subgroup_scope_warning(ok), [])


### PR DESCRIPTION
The first workbook this skill ever produced reported School and District **identically** for every subgroup, in every grade:

```
gK Low Income   school=19.9/11.4/18   district=19.9/11.4/18
g3 Low Income   school=24.9/-4.8/23   district=24.9/-4.8/23
```

Grade K's district cohort is **558** students, of whom exactly **18** — the school's 18 — were classed Low Income, and the other **540** became "Non-Low Income". The FRL/SpEd flags were joined only for the report's own school, so the District cell *was* the School cell and its complement absorbed every unflagged student in the district.

Nothing about the output looked wrong. The numbers were plausible, the counts summed to the district total, and only comparing the two columns revealed it.

## Three changes

1. **The flag join goes district-wide.** `references/sql.md` shows it, cast to `::text` like every other column, and states why the school-scoped version is wrong.

2. **A missing flag record is UNKNOWN, not negative.** `flag_value()` tri-states, and `subgroup_rollups()` excludes unknowns from *both* sides rather than swelling the negative class. A student with no FRL row is not evidence of a student who is not low income; treating it as one is what made the contamination invisible. Smaller honest denominators beat a complete-looking wrong number.

3. **Subgroups move into `aggregate.py`** (`--subgroup "col=Positive|Negative"`). They were computed ad-hoc by the model, which is why they were wrong and why nothing could test them.

## And a detector, because plausible-wrong is the failure mode here

`subgroup_scope_warning()` flags any subgroup whose district row matches its school row on both `n` and growth — the fingerprint of a school-scoped join — and `aggregate.py` prints it to stderr. `SKILL.md` and `sql.md` both say not to publish a workbook that emitted it.

Every bug in this skill has been silent-wrong rather than raising: cross-grade norms contamination, string-sorted student ids, `K` not mapping to grade `0`, and now this. A detector for the specific fingerprint is worth more than another instruction — the instruction is what failed.

## Verified against the real workbook

The rest of the report is sound, which is worth stating:

| Check | Result |
|---|---|
| `NTILE` remainder rule on live data | district n=558 → **140/140/139/139** (A→D); school n=54 → **14/14/13/13** — extras to earliest buckets, exactly Postgres |
| K tab percentiles | real values — the `K`→`0` mapping works |
| Growth by quartile | falls monotonically A → D, the expected regression pattern |
| Quartile counts | sum to their scope totals in every block |

Only the district subgroup columns were wrong.

62 tests in `test_aggregate.py` (6 new), 105 across the image config suites, bootstrap budget clean.
