### PR TITLE
fix(agent): give Rule 9a a repair step instead of a rewrite loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,8 @@ jobs:
           infra/agent-image/skills/psd-observances/tools/test_nspra_markdown.py \
           infra/agent-image/skills/quartile-growth-report/scripts/test_norms_values.py \
           infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py \
-          infra/agent-image/skills/quartile-growth-report/scripts/test_build_tab.py
+          infra/agent-image/skills/quartile-growth-report/scripts/test_build_tab.py \
+          infra/agent-image/skills/psd-rules/scripts/test_repair_literal_newlines.py
 
     - name: Run model-UID isolation test as root
       run: |

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -266,9 +266,28 @@ a differently-broken file, so the loop can repeat for many turns.
 2. If you genuinely need a script, `write` it to a real `.py`/`.js` file, then
    run that file. Never pass a multi-line program as a `-c` argument.
 3. After writing a script file and **before running it**, `head -5` the file.
-   If you see a literal `\n`, the write did not land as intended — rewrite it
-   as a file rather than adding another layer of escaping.
+   If you see a literal `\n`, the write did not land as intended. **Repair it —
+   do not rewrite it:**
+
+   ```bash
+   /opt/agentcore-venv/bin/python3 \
+     /opt/psd-skills/psd-rules/scripts/repair_literal_newlines.py <file>
+   ```
+
+   It prints `repaired` and the file is then runnable; `clean` means the
+   escapes are not your problem; `ambiguous` (exit 2) means the file has real
+   line structure and its `\n` are string literals in working code, so it was
+   left untouched.
+
+   **Rewriting is the trap.** This step used to say "rewrite it as a file" —
+   but it WAS a file, and `write` is what produced the literal `\n`. Rewriting
+   runs the tool that just failed, which is why this loop has consumed whole
+   turns repeatedly instead of ending. Repair once, then run.
 4. Never hand-author a heredoc (`<<'EOF'`) to build a file. Use `write`.
+5. **A shipped script always beats a written one.** If a skill ships a script
+   that does the step, call it — writing your own is Rule 9's "replicating the
+   skill" in a different costume, and it re-enters the failure above for no
+   reason. Only write a file when no shipped script covers the step.
 
 **Self-check:** does my command contain `python3 -c`, `node -e`, or `<<EOF`? If
 yes, replace it with a skill call or a written-out file before running it.

--- a/infra/agent-image/skills/psd-rules/scripts/repair_literal_newlines.py
+++ b/infra/agent-image/skills/psd-rules/scripts/repair_literal_newlines.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Repair a script file whose newlines arrived as literal backslash-n.
+
+Rule 9a's remedy for this was "rewrite it as a file" — but the file IS what
+failed. `write` is what produced the literal `\\n`, so rewriting runs the same
+tool that just broke it and the loop repeats. It has killed the quartile report
+four times and hit three separate users in one day on 2026-08-10, costing one
+of them about 50 minutes.
+
+This is the missing third option: repair what was written, in one CLI call,
+authoring nothing.
+
+    /opt/agentcore-venv/bin/python3 \\
+      /opt/psd-skills/psd-rules/scripts/repair_literal_newlines.py broken.py
+
+Exit 0 and "repaired"  -> the file was broken and is now fixed; run it.
+Exit 0 and "clean"     -> nothing to do; the problem is elsewhere.
+Exit 2                 -> ambiguous, left untouched (see below).
+
+SAFETY — why this will not corrupt a healthy script
+
+A Python or JS file legitimately contains `\\n` inside string literals
+(`print("a\\nb")`). Rewriting those would break working code, so the repair
+only fires on the SIGNATURE of the bug rather than on the sequence itself:
+the whole file arrived as essentially one line, with many literal `\\n` where
+the line breaks belonged.
+
+A file with real line structure is left alone even if it contains `\\n`, and
+says so, because a broken-looking file that is actually fine is a worse
+outcome than no repair.
+"""
+
+import argparse
+import sys
+
+# A healthy multi-line script has real newlines. The bug produces a file that
+# is one enormous line. Two or fewer real lines carrying several literal
+# escapes is the signature; anything more structured is treated as healthy.
+MAX_REAL_LINES_FOR_REPAIR = 2
+MIN_LITERAL_ESCAPES = 2
+
+
+def diagnose(text):
+    """(verdict, real_lines, literal_escapes) — verdict in clean/broken/ambiguous."""
+    real_lines = text.count("\n")
+    literal = text.count("\\n")
+
+    if literal == 0:
+        return "clean", real_lines, literal
+    if real_lines <= MAX_REAL_LINES_FOR_REPAIR and literal >= MIN_LITERAL_ESCAPES:
+        return "broken", real_lines, literal
+    # Real line structure AND literal escapes: almost certainly `\n` inside
+    # string literals in a working file. Touching it would corrupt it.
+    return "ambiguous", real_lines, literal
+
+
+def repair(text):
+    r"""Turn the literal two-character sequence \n into real newlines.
+
+    `\\n` (an escaped backslash followed by n) is left alone — that is a
+    deliberate literal in the source, not a mangled line break.
+    """
+    out = []
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "\\" and index + 1 < len(text):
+            nxt = text[index + 1]
+            if nxt == "\\":
+                out.append("\\\\")
+                index += 2
+                continue
+            if nxt == "n":
+                out.append("\n")
+                index += 2
+                continue
+            if nxt == "t":
+                out.append("\t")
+                index += 2
+                continue
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report only; do not modify the file",
+    )
+    args = parser.parse_args()
+
+    with open(args.path, encoding="utf-8") as handle:
+        text = handle.read()
+
+    verdict, real_lines, literal = diagnose(text)
+
+    if verdict == "clean":
+        print(f"clean: {args.path} has no literal newline escapes")
+        return 0
+
+    if verdict == "ambiguous":
+        print(
+            f"ambiguous: {args.path} has {real_lines} real lines and {literal} "
+            "literal escapes — it looks like working code whose strings contain "
+            "\\n, so it was NOT modified. If it really is broken, the escapes "
+            "are not the reason.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.check:
+        print(f"broken: {args.path} would be repaired ({literal} escapes)")
+        return 0
+
+    fixed = repair(text)
+    with open(args.path, "w", encoding="utf-8") as handle:
+        handle.write(fixed)
+    print(
+        f"repaired: {args.path} — {literal} literal escapes became real "
+        f"newlines ({fixed.count(chr(10))} lines). Run it now; do not rewrite it."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/agent-image/skills/psd-rules/scripts/test_repair_literal_newlines.py
+++ b/infra/agent-image/skills/psd-rules/scripts/test_repair_literal_newlines.py
@@ -1,0 +1,101 @@
+"""Tests for repair_literal_newlines.py — Rule 9a's missing third option.
+
+Rule 9a's remedy was "rewrite it as a file", but the file IS what failed:
+`write` produced the literal \\n. Rewriting reruns the tool that just broke it,
+which is why the loop consumed whole turns. These pin the repair AND the
+refusal to touch healthy code, because a corrupted working script is worse
+than no repair.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import repair_literal_newlines as rln  # noqa: E402
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                      "repair_literal_newlines.py")
+
+
+class Diagnose(unittest.TestCase):
+    def test_the_bug_signature_is_one_line_with_many_escapes(self):
+        text = 'import json\\nimport sys\\nprint("hi")\\n'
+        self.assertEqual(rln.diagnose(text)[0], "broken")
+
+    def test_a_file_with_no_escapes_is_clean(self):
+        self.assertEqual(rln.diagnose("import sys\nprint(1)\n")[0], "clean")
+
+    def test_working_code_with_n_in_a_string_is_ambiguous_not_broken(self):
+        # Rewriting this would corrupt a working script.
+        text = 'import sys\nprint("a\\nb")\nsys.exit(0)\n'
+        self.assertEqual(rln.diagnose(text)[0], "ambiguous")
+
+    def test_a_single_escape_on_one_line_is_not_enough_to_fire(self):
+        self.assertEqual(rln.diagnose('print("a\\nb")')[0], "ambiguous")
+
+
+class Repair(unittest.TestCase):
+    def test_literal_escapes_become_real_newlines(self):
+        self.assertEqual(rln.repair('a\\nb'), "a\nb")
+
+    def test_tabs_too(self):
+        self.assertEqual(rln.repair('a\\tb'), "a\tb")
+
+    def test_an_escaped_backslash_is_preserved(self):
+        # `\\n` in the source is a deliberate literal, not a mangled break.
+        self.assertEqual(rln.repair('a\\\\nb'), 'a\\\\nb')
+
+
+class EndToEnd(unittest.TestCase):
+    def run_on(self, text, *extra):
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+            fh.write(text)
+            path = fh.name
+        try:
+            proc = subprocess.run([sys.executable, SCRIPT, path, *extra],
+                                  capture_output=True, text=True)
+            with open(path) as handle:
+                return proc, handle.read()
+        finally:
+            os.unlink(path)
+
+    def test_a_broken_file_becomes_runnable(self):
+        proc, content = self.run_on('import sys\\nprint("ok")\\n')
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("repaired", proc.stdout)
+        compile(content, "<repaired>", "exec")  # would raise if still broken
+
+    def test_a_healthy_file_is_left_byte_identical(self):
+        original = 'import sys\nprint("a\\nb")\nsys.exit(0)\n'
+        proc, content = self.run_on(original)
+        self.assertEqual(proc.returncode, 2)
+        self.assertEqual(content, original)
+        self.assertIn("ambiguous", proc.stderr)
+
+    def test_check_mode_reports_without_modifying(self):
+        original = 'import sys\\nprint("ok")\\n'
+        proc, content = self.run_on(original, "--check")
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("broken", proc.stdout)
+        self.assertEqual(content, original)
+
+    def test_repair_is_idempotent(self):
+        proc, content = self.run_on('import sys\\nprint("ok")\\n')
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+            fh.write(content)
+            path = fh.name
+        try:
+            again = subprocess.run([sys.executable, SCRIPT, path],
+                                   capture_output=True, text=True)
+            self.assertEqual(again.returncode, 0)
+            self.assertIn("clean", again.stdout)
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -53,9 +53,16 @@ $P $S/aggregate.py --rows gradeK.csv --grade K --subgroup "low_income=Low Income
 
 This is not a style preference. Every file the model authors is a chance for
 the write tool to embed a literal `\n`, which produces a SyntaxError and a
-retry loop — it has killed this report three times, twice with every rollup
-already computed. If a step seems to need a script that does not exist, say so
-and stop; do not write one.
+retry loop — it has killed this report four times, twice with every rollup
+already computed.
+
+**If a step genuinely needs a script these do not cover**, psd-rules Rule 9a
+governs: write a real file (never a `-c` heredoc), `head -5` it, and if the
+newlines arrived literal run
+`scripts/repair_literal_newlines.py` on it rather than rewriting it. Rule 9a
+and this section agree — prefer a shipped script, and when you must write one,
+repair rather than retry. Do not read "author no files" as a reason to reach
+for `python3 -c` instead; that is the failure Rule 9a exists to prevent.
 
 **Never put a window function or the norms lookup in SQL.** Window functions do
 not complete against `dibels_scores` on this MCP server at any size — a bare


### PR DESCRIPTION
The quartile report died a **fourth** time on the literal-`\n` write bug — mid-run, after the spreadsheet was created and grades K–3 were done. Its own trace names the cause:

> "Right — write file per Rule 9a rather than -c heredoc."

## Two things were wrong, and I introduced one of them

**1. Rule 9a's remedy is circular.** Step 3 said: if the file has a literal `\n`, *"rewrite it as a file rather than adding another layer of escaping."*

But it **was** a file. `write` is what produced the literal `\n`. The rule's escape hatch runs the tool that just failed — which is why this loop eats whole turns instead of terminating. Four runs of this report, and three separate users in one day on 2026-08-10 (~50 minutes for one of them).

**2. I created a rule conflict.** `quartile-growth-report` said "author no files"; Rule 9a says write a file rather than a `-c` heredoc. The model resolved toward the system-prompt rule, wrote a file, and hit the bug.

That's the same two-instructions-in-conflict class I've been fixing all day — authored by me, a few hours ago.

## The missing third option

`scripts/repair_literal_newlines.py` repairs what was written, in one CLI call, authoring nothing:

```bash
/opt/agentcore-venv/bin/python3 \
  /opt/psd-skills/psd-rules/scripts/repair_literal_newlines.py <file>
```

Rule 9a step 3 now says **repair, not rewrite**, and says plainly why rewriting is the trap.

### The guard matters more than the repair

It fires only on the **signature** of the bug — a file that arrived as essentially one line carrying several literal escapes — never on the sequence itself.

| Input | Verdict |
|---|---|
| `import sys\nprint("ok")\n` (one line, 2 escapes) | **repaired**, compiles |
| working code whose string contains `\n` | **ambiguous**, exit 2, byte-identical |
| no escapes at all | **clean** |

Corrupting a healthy script would be worse than no repair, so the refusal path is tested as carefully as the fix.

## Also: Rule 9a step 5

**A shipped script always beats a written one.** Writing your own when the skill ships one is Rule 9's "replicating the skill" in a different costume, and it re-enters this failure for no reason. The quartile skill now *points at* Rule 9a for the genuine-gap case instead of contradicting it.

## Tests

11, including byte-identical preservation of healthy files and idempotent repair. Registered in `ci.yml`. Bootstrap budget clean.
