### PR TITLE
fix(agent): record workspace-restore failures instead of only logging them

### DIFF
--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -48,7 +48,7 @@ logger = logging.getLogger("agentcore_wrapper")
 
 from harness_adapter import OpenClawAdapter
 import workspace_sync
-from agent_failures import emit_agent_metric
+from agent_failures import emit_agent_metric, record_failure
 from check_bootstrap_budget import check_runtime_bootstrap
 
 # Runtime path OpenClaw reads its credential-free config and bootstrap files from.
@@ -1647,6 +1647,34 @@ def main():
                     "workspace mount/migration FAILED (%s) — push DISABLED for "
                     "this microVM to protect the remote workspace",
                     exc,
+                )
+                # Telemetry, not just a log line. This whole failure class was
+                # invisible in agent_failures — WorkspaceMigrationFailed had a
+                # lifetime count of ZERO while a real user hit it in prod on
+                # 2026-08-15 — because nothing in this file ever called
+                # record_failure. The user got a clear message and the Failures
+                # tab showed nothing, so the only way anyone learned about it
+                # was the user reporting it by hand.
+                #
+                # Best-effort by contract: record_failure never raises, so a
+                # telemetry problem cannot turn a handled workspace failure
+                # into an unhandled one.
+                record_failure(
+                    source="harness",
+                    severity="error",
+                    error_class="WorkspaceMigrationFailed",
+                    error_message=f"workspace restore failed: {str(exc)[:500]}",
+                    user_id=user_email,
+                    session_id=session_id,
+                    context={
+                        "phase": "workspace_restore",
+                        "workspace_prefix": workspace_prefix,
+                        # Push is off for this microVM, so the next invocation
+                        # must do an exact committed restore. Recorded because
+                        # it changes what a retry actually does.
+                        "push_disabled": True,
+                    },
+                    exc=exc,
                 )
                 yield {
                     "result": (

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -1790,3 +1790,40 @@ class TestSanitizeHeaderField(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class WorkspaceRestoreFailureIsRecorded(unittest.TestCase):
+    """The workspace-restore failure path must reach agent_failures.
+
+    Nothing in agentcore_wrapper.py called record_failure at all, so
+    WorkspaceMigrationFailed had a LIFETIME count of zero in the table while a
+    real user hit it in prod on 2026-08-15. They saw a clear message; the
+    Failures tab saw nothing; the only reason anyone found out was the user
+    reporting it by hand. Telemetry for a user-visible failure is not optional.
+    """
+
+    def test_the_wrapper_imports_record_failure(self):
+        self.assertTrue(callable(agentcore_wrapper.record_failure))
+
+    def test_the_restore_failure_path_calls_it(self):
+        # Pinned by source rather than by driving a full invocation: the call
+        # site sits inside an async generator behind a real workspace mount,
+        # and the thing worth guarding is simply that this path reports.
+        import inspect
+
+        source = inspect.getsource(agentcore_wrapper)
+        marker = 'error_class="WorkspaceMigrationFailed"'
+        self.assertIn(marker, source)
+        # …and that it is a record_failure call, not only the yielded metadata.
+        before = source[: source.index(marker)]
+        self.assertIn("record_failure(", before[-800:])
+
+    def test_it_records_the_user_and_session(self):
+        # A failure with no user attached cannot be chased down later.
+        import inspect
+
+        source = inspect.getsource(agentcore_wrapper)
+        window = source[source.index("record_failure(") :][:900]
+        self.assertIn("user_id=user_email", window)
+        self.assertIn("session_id=session_id", window)
+        self.assertIn("workspace_prefix", window)


### PR DESCRIPTION
A prod user hit *"I couldn't safely restore this agent's workspace"* on 2026-08-15. The Failures tab showed nothing — not a missing row, **an entire missing class**.

```
WorkspaceMigrationFailed  →  lifetime count in agent_failures: 0
agent_failures rows in the preceding 24h: 0
```

## Cause

`agentcore_wrapper.py` **never called `record_failure`** — not for this path, not anywhere. Zero occurrences in the file. Every failure originating in the wrapper (workspace restore, mount, migration) produced a clear user-facing message, a CloudWatch line, and **no telemetry**.

The only way anyone learned about this one was the user reporting it by hand.

## Fix

The restore path now records user, session, workspace prefix, the underlying exception, and `push_disabled=True` — the last because it changes what a retry *does*: this microVM's push is off to protect the remote workspace, so the next invocation performs an exact committed restore.

`record_failure` is best-effort and never raises by contract, so telemetry cannot turn a handled workspace failure into an unhandled one.

## What the incident itself was

**Transient, and it self-recovered.**

```
23:05:34  REJECTED — "Workspace finalization proof is invalid"
23:08:00  ensure-checkpoint ✅
23:08:00  15 × download     ✅
23:08:22  uploads           ✅
23:08:25  finalize-checkpoint ✅
```

The fail-closed design worked exactly as intended: it refused rather than risk her data, told her to retry, and the retry worked ~2.5 minutes later. She was never blocked and nothing was lost.

**Which is why the telemetry gap matters more than the 409 did.** A transient failure that recovers in three minutes is fine. A whole class of user-visible failure that reports nothing is not — the next one might not recover, and we'd find out the same way.

## Tests

3 new, **mutation-verified**: removing the `record_failure` call makes them fail. 64 pass in `test_agentcore_wrapper`.
