### PR TITLE
fix(agent): report every wrapper failure, not just the one a user reported

### DIFF
--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -1528,6 +1528,22 @@ def main():
                 "(session=%s)",
                 session_id,
             )
+            # Security-relevant and previously invisible: a rejected signed
+            # context is exactly the event that should be reviewable after the
+            # fact. user_email is deliberately NOT attached — the identity is
+            # what failed to verify, so recording it as fact would launder an
+            # unverified claim into telemetry.
+            record_failure(
+                source="harness",
+                severity="error",
+                error_class="InvocationContextInvalid",
+                error_message=(
+                    "signed invocation context missing or malformed; "
+                    "invocation rejected before any skill ran"
+                ),
+                session_id=session_id,
+                context={"phase": "verify_invocation_context"},
+            )
             yield {
                 "result": (
                     "I couldn't verify the identity for this request. "
@@ -1552,6 +1568,26 @@ def main():
                 "microVM (current=%s requested=%s)",
                 _current_workspace_prefix or "-",
                 workspace_prefix or "-",
+            )
+            # The cross-user boundary guard firing. Rare by design, and if it
+            # ever stops being rare that is a containment problem nobody would
+            # see from the Failures tab today. Both prefixes are recorded so a
+            # reviewer can tell which pair collided.
+            record_failure(
+                source="harness",
+                severity="error",
+                error_class="WorkspaceAuthorityChanged",
+                error_message=(
+                    "workspace prefix changed in a live runtime; invocation "
+                    "rejected to keep one microVM bound to one workspace"
+                ),
+                user_id=user_email,
+                session_id=session_id,
+                context={
+                    "phase": "bind_workspace_prefix",
+                    "bound_prefix": _current_workspace_prefix,
+                    "requested_prefix": workspace_prefix,
+                },
             )
             yield {
                 "result": (
@@ -1726,6 +1762,22 @@ def main():
                 _workspace_prefix_hydrated = True
         except Exception as exc:  # noqa: BLE001
             logger.error("OpenClaw gateway start FAILED: %s", exc)
+            # Distinct from the restore failure above: the workspace came back
+            # fine and the gateway did not start. Same telemetry gap, different
+            # cause, and telling them apart matters when triaging.
+            record_failure(
+                source="harness",
+                severity="error",
+                error_class="OpenClawStartupFailed",
+                error_message=f"OpenClaw gateway start failed: {str(exc)[:500]}",
+                user_id=user_email,
+                session_id=session_id,
+                context={
+                    "phase": "gateway_start",
+                    "workspace_prefix": workspace_prefix,
+                },
+                exc=exc,
+            )
             yield {
                 "result": (
                     "I restored this agent's workspace but couldn't start its "

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -1823,7 +1823,66 @@ class WorkspaceRestoreFailureIsRecorded(unittest.TestCase):
         import inspect
 
         source = inspect.getsource(agentcore_wrapper)
-        window = source[source.index("record_failure(") :][:900]
+        # Anchored on THIS failure's call site, not "the first record_failure
+        # in the file" — the wrapper now has several, and the identity one
+        # deliberately omits user_id.
+        start = source.index('error_class="WorkspaceMigrationFailed"')
+        window = source[max(0, start - 400) : start + 900]
         self.assertIn("user_id=user_email", window)
         self.assertIn("session_id=session_id", window)
         self.assertIn("workspace_prefix", window)
+
+
+class EveryWrapperFailureIsRecorded(unittest.TestCase):
+    """No user-visible failure in the wrapper may be telemetry-silent.
+
+    The restore path was fixed after a prod user reported one by hand. Three
+    more paths had the identical gap — a clear message to the user, a log
+    line, and nothing in agent_failures. This asserts the invariant rather than
+    the four instances, so a fifth failure path added later cannot reintroduce
+    it quietly.
+    """
+
+    def source(self):
+        import inspect
+
+        return inspect.getsource(agentcore_wrapper)
+
+    def test_every_failed_yield_is_paired_with_a_record_failure(self):
+        source = self.source()
+        yields = source.count('"failed": True')
+        calls = source.count("record_failure(")
+        self.assertGreater(yields, 0, "no failure yields found — test is stale")
+        self.assertGreaterEqual(
+            calls, yields,
+            f"{yields} user-visible failure yields but only {calls} "
+            "record_failure calls — a failure path is telemetry-silent",
+        )
+
+    def test_each_known_failure_class_reports(self):
+        source = self.source()
+        for error_class in (
+            "WorkspaceMigrationFailed",
+            "InvocationContextInvalid",
+            "WorkspaceAuthorityChanged",
+            "OpenClawStartupFailed",
+        ):
+            marker = f'error_class="{error_class}"'
+            self.assertIn(marker, source, f"{error_class} never reaches record_failure")
+
+    def test_identity_failure_does_not_launder_an_unverified_user(self):
+        # InvocationContextInvalid means the signed identity FAILED to verify.
+        # Recording user_email there would turn an unverified claim into a
+        # stored fact.
+        source = self.source()
+        start = source.index('error_class="InvocationContextInvalid"')
+        window = source[max(0, start - 700) : start + 400]
+        self.assertNotIn("user_id=user_email", window)
+
+    def test_authority_change_records_both_prefixes(self):
+        # Which pair collided is the whole diagnostic value of this event.
+        source = self.source()
+        start = source.index('error_class="WorkspaceAuthorityChanged"')
+        window = source[start : start + 700]
+        self.assertIn("bound_prefix", window)
+        self.assertIn("requested_prefix", window)


### PR DESCRIPTION
The restore-path gap fixed in #1657 wasn't the only instance. The sweep found **three more** user-visible failures in `agentcore_wrapper.py` that gave the user a clear message, wrote a log line, and recorded nothing:

| Class | What it means |
|---|---|
| `InvocationContextInvalid` | the signed identity failed to verify |
| `WorkspaceAuthorityChanged` | a live runtime asked to serve a second workspace prefix — the **cross-user boundary guard** |
| `OpenClawStartupFailed` | workspace restored, gateway never came up |

All three now call `record_failure`.

## Two deliberate details

**`InvocationContextInvalid` does not attach `user_email`.** The identity is the thing that failed to verify — recording it as fact would launder an unverified claim into telemetry. `session_id` only.

**`WorkspaceAuthorityChanged` records both prefixes** (bound and requested). Which pair collided is the entire diagnostic value of that event, and it's the one failure here with cross-user implications: rare by design, and if it ever stops being rare, nobody would see it from the Failures tab today.

`OpenClawStartupFailed` is kept **distinct** from `WorkspaceMigrationFailed` rather than folded together — restore-succeeded-then-gateway-died and restore-itself-failed have different causes and different fixes.

## The test asserts the invariant, not the four instances

`test_every_failed_yield_is_paired_with_a_record_failure` counts `"failed": True` yields against `record_failure` calls and fails when one is unpaired:

```
AssertionError: 3 not greater than or equal to 4 : 4 user-visible failure
yields but only 3 record_failure calls — a failure path is telemetry-silent
```

A fifth failure path added later can't go silent without failing CI. That's the difference between fixing four bugs and closing the class.

Mutation-verified: deleting any one call fails it. 68 tests pass.

## Same lesson as this morning

This is the allowlist closure test again — when one instance of a gap surfaces, enumerate the rest instead of waiting for a user to find the next one. Here the *user was the detector* for a path that had never reported once in its entire existence.
