### PR TITLE
fix(quartile): include the partition in the cell key so teacher columns exist

### DIFF
--- a/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/aggregate.py
@@ -229,13 +229,30 @@ def rollup(rows, scope, partition_key, value_digits=1):
         group.sort(key=order_key)
         quartiled.extend(ntile(group))
 
+    # The partition is part of the cell identity, not just of the quartile
+    # assignment. Keying on (meas, qt) alone merged every homeroom's rows into
+    # one cell: quartiles were still computed per section, but the OUTPUT
+    # collapsed across them, `sectionid` became ambiguous and resolved to None,
+    # and build_tab rendered ZERO teacher columns — the breakdown this report
+    # exists for, silently absent rather than wrong.
+    #
+    # Found by the agent while running Minter Creek and self-reported as
+    # failure 793, with a synthetic two-section repro. My own partition test
+    # missed it because it asserted member COUNTS, which stay correct when
+    # cells merge.
+    #
+    # `partition_key(row)` is exactly what quartiles were computed within, so
+    # using it here keeps the two in lockstep by construction.
     by_cell = defaultdict(list)
     for row, bucket in quartiled:
-        by_cell[(row["meas"], str(bucket))].append(row)
-        by_cell[(row["meas"], "All")].append(row)
+        partition = partition_key(row)
+        by_cell[(row["meas"], str(bucket), partition)].append(row)
+        by_cell[(row["meas"], "All", partition)].append(row)
 
     out = []
-    for (meas, qt), members in sorted(by_cell.items()):
+    for (meas, qt, _partition), members in sorted(
+        by_cell.items(), key=lambda item: (item[0][0], item[0][1], str(item[0][2]))
+    ):
         growth = mean([r["e"] - r["b"] for r in members if r.get("e") is not None])
         pr_growth = mean(
             [

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py
@@ -679,3 +679,59 @@ class SubgroupsAreScopedAndTriState(unittest.TestCase):
              "n": 402, "growth": 15.2},
         ]
         self.assertEqual(aggregate.subgroup_scope_warning(ok), [])
+
+
+class MultipleSectionsStaySeparate(unittest.TestCase):
+    """Two homerooms must produce two sets of class cells, not one merged set.
+
+    Keying cells on (meas, qt) alone merged every section's rows together:
+    quartiles were still computed per section, but the OUTPUT collapsed across
+    them, sectionid became ambiguous and resolved to None, and build_tab
+    rendered ZERO teacher columns. Silently absent, not wrong — which is why
+    a member-count assertion did not catch it.
+
+    Found by the agent while running Minter Creek (self-reported failure 793,
+    with a synthetic two-section repro).
+    """
+
+    ROWS = [
+        {"meas": "ORF", "studentid": i, "b": b, "e": b + 5,
+         "in_sch": True, "sectionid": sec, "prb": None, "pre": None}
+        for i, (b, sec) in enumerate(
+            [(10, "S1"), (20, "S1"), (30, "S1"), (40, "S1"),
+             (15, "S2"), (25, "S2"), (35, "S2"), (45, "S2")], start=1
+        )
+    ]
+
+    def cells(self):
+        return aggregate.rollup(
+            [dict(r) for r in self.ROWS], "class", lambda r: (r["meas"], r["sectionid"])
+        )
+
+    def test_each_section_gets_its_own_cells(self):
+        sections = {c["sectionid"] for c in self.cells()}
+        self.assertEqual(sections, {"S1", "S2"})
+
+    def test_sectionid_is_never_none_when_sections_are_partitioned(self):
+        # None is the symptom build_tab sees: it cannot name a column for a
+        # cell whose section is unknown, so the column disappears.
+        self.assertTrue(all(c["sectionid"] is not None for c in self.cells()))
+
+    def test_each_section_has_its_own_All_row(self):
+        alls = [c for c in self.cells() if c["qt"] == "All"]
+        self.assertEqual(len(alls), 2)
+        self.assertEqual({c["n"] for c in alls}, {4})
+
+    def test_a_merged_key_would_have_produced_one_All_of_eight(self):
+        # Pins the actual bug shape: before the fix this was a single cell of 8.
+        alls = [c for c in self.cells() if c["qt"] == "All"]
+        self.assertNotEqual([c["n"] for c in alls], [8])
+
+    def test_district_scope_still_collapses_to_one_cell(self):
+        # The fix must not split scopes that are meant to be single-partition.
+        cells = aggregate.rollup(
+            [dict(r) for r in self.ROWS], "district", lambda r: r["meas"]
+        )
+        alls = [c for c in cells if c["qt"] == "All"]
+        self.assertEqual(len(alls), 1)
+        self.assertEqual(alls[0]["n"], 8)


### PR DESCRIPTION
**The agent found this itself**, while running Minter Creek, and self-reported it as failure 793 with a synthetic two-section repro:

> `rollup()` groups class-scope output by `(meas, qt)` only, dropping `sectionid` from the `by_cell` key. For any grade with >1 homeroom section, per-classroom quartile cells silently merge across sections and `sectionid` comes back null, so `build_tab.py` renders zero teacher columns.

That diagnosis is exactly right. Quartiles were computed *per section* — the partitioning was correct — but the **output** collapsed across sections, so the section set held more than one id, resolved to `None`, and `build_tab` couldn't name a column for a cell whose section is unknown.

**The per-teacher breakdown — the reason this report exists — was silently absent rather than wrong.**

It also correctly declined to patch the skill itself under Rule 9, carried on with School/District columns, and noted the gap on the Definitions tab. That's the behavior the rules ask for.

## The fix

The partition is part of a cell's **identity**, not just of the quartile assignment. `by_cell` is now keyed on `(meas, qt, partition_key(row))` — the same value quartiles were computed within, so the two stay in lockstep by construction rather than by agreement.

District and school scopes are unaffected: their partition key is constant, so they still collapse to one cell each. That's asserted rather than assumed.

## Why my tests missed it

`test_quartiles_are_local_to_each_partition` asserted member **counts** — and counts stay correct when cells merge. 4 + 4 is still 8.

The five new tests assert cell **identity** instead:

- two sections produce two sets of cells
- `sectionid` is never `None` under a section partition
- each section gets its own `All` row
- the pre-fix shape (one `All` of 8) is pinned as a negative
- district scope still collapses to a single cell

Mutation-verified: removing the partition from the key fails four of them. 67 tests pass.
