### PR TITLE
fix(agent): answer the pending question instead of aborting it

### DIFF
--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -186,6 +186,15 @@ _INVOCATION_CONTEXT_RE = re.compile(
     r"^v1\.[A-Za-z0-9_-]{40,3500}\.[A-Za-z0-9_-]{43}$"
 )
 _REQUEST_PROOF_KEY_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+# Serializes every turn in this container, and is LOAD-BEARING beyond this
+# file: `adapter` below is a module-level singleton shared by every user, and
+# harness_adapter's `_pending_questions` / `_gateway_token` are plain
+# unsynchronized attributes on it that rely on this lock for their safety.
+# Narrowing its scope, or moving to multiple workers, needs those to grow
+# their own synchronization first — the interleaving is only ever sequential
+# today, so no test would catch it. Cross-referenced in
+# harness_adapter._remember_pending_question so a grep for either name finds
+# both halves.
 _invocation_lock = asyncio.Lock()
 FINAL_WORKSPACE_FLUSH_SECONDS = 120
 # Interactive and cron callers run inside a 900-second Lambda. A stuck

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1272,18 +1272,31 @@ class OpenClawAdapter(HarnessAdapter):
         return result.latency_ms <= UPSTREAM_RETRY_MAX_LATENCY_MS
 
 
-    def _remember_pending_question(self, session_id, pending_id, question_ids):
+    def _remember_pending_question(
+        self, session_id, pending_id, question_ids, run_id
+    ):
         """Hold one pending question per session, oldest evicted first.
 
         Bounded because a session that asks and never answers would otherwise
         leave its entry here for the life of the container. Eviction is safe:
         the gateway expires questions on its own, and a dropped entry only
         costs us the resolve, falling back to a normal chat.send.
+
+        `run_id` is the run that ASKED, and therefore the run that resumes when
+        the question is answered. The answering turn has no chat.send to learn
+        a run id from, so without this the run fence would have nothing to
+        compare against — see _process_once.
+
+        Access is unsynchronized: agentcore_wrapper serializes the whole
+        entrypoint behind `_invocation_lock`, so no two turns are ever inside
+        _process_once at once. That invariant lives in another file; if the
+        lock is ever narrowed or removed, this dict needs its own.
         """
         self._pending_questions.pop(session_id, None)
         self._pending_questions[session_id] = {
             "id": pending_id,
             "question_ids": question_ids,
+            "run_id": run_id,
         }
         while len(self._pending_questions) > MAX_PENDING_QUESTIONS:
             evicted, _ = next(iter(self._pending_questions.items()))
@@ -1306,12 +1319,16 @@ class OpenClawAdapter(HarnessAdapter):
             { id, answers: { answers: { <questionId>: [<text>] } }, resolvedBy }
         which is the same shape OpenClaw's own plain-text claim path sends.
 
-        Returns `(answered, frames)`. `answered` is True when the gateway
+        Returns `(answered, frames, run_id)`. `answered` is True when the gateway
         accepted the answer, meaning the ORIGINAL run resumes and this turn
         must listen to it rather than starting a new one; False for anything
         else — expired, cancelled, unknown id, transport error — so the caller
         falls back to a normal chat.send. A question we cannot answer must
         never block the user's message.
+
+        `run_id` is the run that asked and is now resuming — the answering
+        turn issues no chat.send, so this is the only place the run fence can
+        learn which run this turn's reply may be built from.
 
         `frames` are raw messages that arrived while waiting for the resolve
         ack. The resumed run streams onto this same socket, so those frames
@@ -1323,7 +1340,7 @@ class OpenClawAdapter(HarnessAdapter):
         # Only this session's question, and only ever consumed once.
         pending = self._pending_questions.pop(session_id, None)
         if not pending:
-            return False, []
+            return False, [], None
 
         # Kill switch, matching OPENCLAW_PRESEND_ABORT on the path this one
         # replaces. Disabling it restores the previous behaviour exactly —
@@ -1331,15 +1348,14 @@ class OpenClawAdapter(HarnessAdapter):
         # operator can back this out without shipping an image.
         if os.environ.get("OPENCLAW_QUESTION_RESOLVE", "1") == "0":
             logger.info("question.resolve disabled by OPENCLAW_QUESTION_RESOLVE=0")
-            return False, []
+            return False, [], None
 
         question_ids = pending.get("question_ids") or []
         if not question_ids:
-            return False, []
+            return False, [], None
         answers = {qid: [message] for qid in question_ids}
 
         buffered: list = []
-        overflowed = False
         resolve_id = str(uuid.uuid4())
         try:
             ws.send(json.dumps({
@@ -1382,28 +1398,34 @@ class OpenClawAdapter(HarnessAdapter):
                     # Frames only matter when the run actually resumes. On any
                     # other outcome the caller aborts and re-sends, so keeping
                     # them would replay a dead run's events into a new turn.
-                    return answered, (buffered if answered else [])
+                    return (
+                        answered,
+                        buffered if answered else [],
+                        pending.get("run_id") if answered else None,
+                    )
                 # Not the ack — the resumed run's own output, arriving ahead of
                 # or interleaved with it. Bounded so a chatty gateway cannot
                 # grow this without limit inside the ack window.
-                if len(buffered) < MAX_RESOLVE_BUFFERED_FRAMES:
-                    buffered.append(raw)
-                elif not overflowed:
-                    # Said once, loudly. Silently truncating here would surface
-                    # later as a reply missing its middle, with nothing in the
-                    # logs to connect it to this cap.
-                    overflowed = True
+                if len(buffered) >= MAX_RESOLVE_BUFFERED_FRAMES:
+                    # Do NOT keep reading and discarding. Dropping frames here
+                    # is the same bug this buffer was added to fix: the final
+                    # event goes with them and the turn hangs to its full
+                    # deadline, answering "the agent stalled". Giving up on the
+                    # resolve instead falls back to abort + chat.send, which
+                    # costs the in-flight work but answers the user.
                     logger.warning(
-                        "question.resolve buffer full at %d frames; further "
-                        "resumed-run output before the ack is being dropped",
+                        "question.resolve buffer hit %d frames before the ack; "
+                        "abandoning the resume and falling back to chat.send",
                         MAX_RESOLVE_BUFFERED_FRAMES,
                     )
+                    return False, [], None
+                buffered.append(raw)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "question.resolve failed (falling back to chat.send): %s",
                 str(exc)[:200],
             )
-        return False, []
+        return False, [], None
 
     def _process_once(
         self,
@@ -1594,7 +1616,11 @@ class OpenClawAdapter(HarnessAdapter):
                 # Answer the gateway's pending question BEFORE anything can
                 # cancel it. The pre-send abort below is exactly what used to
                 # kill it, so the two are mutually exclusive by construction.
-                answered_pending, resumed_frames = self._resolve_pending_question(
+                (
+                    answered_pending,
+                    resumed_frames,
+                    resumed_run_id,
+                ) = self._resolve_pending_question(
                     ws, websocket, message, session_id
                 )
                 if answered_pending:
@@ -1756,7 +1782,24 @@ class OpenClawAdapter(HarnessAdapter):
                 # answered with that stale run's text, and the user's actual
                 # request was never processed. A confidently wrong answer is a
                 # worse failure than an error, so this fences by run id.
-                turn_run_id: Optional[str] = None
+                #
+                # A resumed-question turn sends no chat.send, so it never sees
+                # a `started` res and would leave this None — and both fences
+                # below are gated on it being truthy, so the whole mechanism
+                # would be OFF for exactly the turns that listen longest to a
+                # socket carrying other runs. Seed it from the run that asked;
+                # that is the run resuming, and it is the only run whose output
+                # belongs in this reply.
+                turn_run_id: Optional[str] = (
+                    resumed_run_id if answered_pending else None
+                )
+                if answered_pending and not turn_run_id:
+                    # Fails open, deliberately — an unfenced reply beats no
+                    # reply — but it is the pre-fix exposure, so say so.
+                    logger.warning(
+                        "resumed question carried no run id; this turn's reply "
+                        "is not run-fenced"
+                    )
                 # Counted, not silent: if this is ever large the gateway is
                 # delivering someone else's traffic and we want that visible in
                 # the turn log rather than inferred from a wrong answer.
@@ -2290,8 +2333,15 @@ class OpenClawAdapter(HarnessAdapter):
                                 if isinstance(entry, dict)
                                 and isinstance(entry.get("id"), str)
                             ]
+                            # The run that asked is the run that resumes. Prefer
+                            # what the event says; fall back to this turn's own
+                            # run, which is the same run by construction — the
+                            # question came from it.
+                            asked_by = q_payload.get("runId")
+                            if not (isinstance(asked_by, str) and asked_by):
+                                asked_by = turn_run_id
                             self._remember_pending_question(
-                                session_id, pending_id, question_ids
+                                session_id, pending_id, question_ids, asked_by
                             )
                         got_final = True
                         break

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1729,7 +1729,10 @@ class OpenClawAdapter(HarnessAdapter):
                 # times out and falls back has already burned the ack wait and
                 # the abort drain, and restarting the clock afterwards would
                 # report the slowest turns as the fastest.
-                attempted_resolve = session_id in self._pending_questions
+                # "Had a pending entry", not "sent a resolve": with
+                # OPENCLAW_QUESTION_RESOLVE=0 the helper pops the entry and
+                # returns before any ws.send, and this is still True.
+                had_pending_question = session_id in self._pending_questions
                 resolve_started_at = time.time()
                 (
                     answered_pending,
@@ -1808,7 +1811,7 @@ class OpenClawAdapter(HarnessAdapter):
                 # ws.send so we don't count our own serialization.
                 #
                 chat_send_at = (
-                    resolve_started_at if attempted_resolve else time.time()
+                    resolve_started_at if had_pending_question else time.time()
                 )
                 if answered_pending:
                     # No chat.send: listen for the resumed run. The loop below

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -351,7 +351,16 @@ def _frames_from_run(frames, run_id) -> bool:
     Used as proof that a run has resumed. This socket carries every run in the
     container, so "some frames arrived" proves nothing on its own — the run id
     is what makes it evidence rather than a guess.
+
+    An unknown run id is never evidence. Without this, a None run_id matches
+    any payload that also lacks one — two unknowns comparing equal into "it
+    resumed", which is the answer that skips the fallback and strands the
+    user's message. The only caller guards against it today; the guard is 100
+    lines away and this function decides whether a turn re-runs, so it defends
+    itself.
     """
+    if not run_id:
+        return False
     for raw in frames:
         try:
             payload = (json.loads(raw) or {}).get("payload") or {}
@@ -1334,8 +1343,10 @@ class OpenClawAdapter(HarnessAdapter):
             # or an abuse pattern, not routine churn. At info it would be lost
             # in normal log volume.
             logger.warning(
-                "evicted pending question for an idle session; %d sessions "
-                "were holding one", MAX_PENDING_QUESTIONS,
+                "evicted pending question for session %s; %d sessions are "
+                "holding one (cap %d)",
+                str(evicted)[:12], len(self._pending_questions),
+                MAX_PENDING_QUESTIONS,
             )
 
     def _resolve_pending_question(self, ws, websocket, message, session_id):
@@ -1388,6 +1399,15 @@ class OpenClawAdapter(HarnessAdapter):
         question_ids = pending.get("question_ids") or []
         if not question_ids:
             return False, [], None
+        # One free-text reply, N sub-questions: every id gets the same text.
+        #
+        # OUR CHOICE, not a verified mirror of upstream's plain-text path —
+        # the pinned bundle was not available to check when this was written,
+        # and it is recorded that way rather than implied to be authoritative.
+        # The reasoning: answering only the first id leaves the rest unanswered,
+        # and a partial resolve the gateway refuses puts us straight back on
+        # the abort-and-cancel path this whole mechanism removes. A redundant
+        # answer the agent can parse beats a refused one.
         answers = {qid: [message] for qid in question_ids}
 
         # Popped before every failure branch below, including a transport

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -332,6 +332,12 @@ MAX_PENDING_QUESTIONS = 256
 # anything beyond this is a gateway misbehaving, not a run to reassemble.
 MAX_RESOLVE_BUFFERED_FRAMES = 200
 
+# Past that cap, chat-channel frames are STILL kept — they carry the run's
+# terminal state, and losing it stalls the turn to its full deadline. They are
+# a handful of state transitions, not a stream, so this second allowance is
+# small on purpose.
+MAX_RESOLVE_TERMINAL_FRAMES = 16
+
 # How long to wait for the question.resolve ack before giving up and falling
 # back to a normal chat.send. Small on purpose: this sits in front of the
 # user's turn, and every path out of it is safe.
@@ -1356,6 +1362,7 @@ class OpenClawAdapter(HarnessAdapter):
         answers = {qid: [message] for qid in question_ids}
 
         buffered: list = []
+        overflowed = False
         resolve_id = str(uuid.uuid4())
         try:
             ws.send(json.dumps({
@@ -1406,20 +1413,45 @@ class OpenClawAdapter(HarnessAdapter):
                 # Not the ack — the resumed run's own output, arriving ahead of
                 # or interleaved with it. Bounded so a chatty gateway cannot
                 # grow this without limit inside the ack window.
-                if len(buffered) >= MAX_RESOLVE_BUFFERED_FRAMES:
-                    # Do NOT keep reading and discarding. Dropping frames here
-                    # is the same bug this buffer was added to fix: the final
-                    # event goes with them and the turn hangs to its full
-                    # deadline, answering "the agent stalled". Giving up on the
-                    # resolve instead falls back to abort + chat.send, which
-                    # costs the in-flight work but answers the user.
+                if len(buffered) < MAX_RESOLVE_BUFFERED_FRAMES:
+                    buffered.append(raw)
+                    continue
+
+                if not overflowed:
+                    overflowed = True
                     logger.warning(
                         "question.resolve buffer hit %d frames before the ack; "
-                        "abandoning the resume and falling back to chat.send",
+                        "narration past this point is dropped, terminal state "
+                        "is not",
                         MAX_RESOLVE_BUFFERED_FRAMES,
                     )
-                    return False, [], None
-                buffered.append(raw)
+
+                # Two bad options here, and the third one is what this does.
+                #
+                # Give up and fall back to abort + chat.send: the ONLY thing
+                # that floods this window is a run already streaming, which
+                # means the gateway already accepted the answer. Aborting and
+                # re-sending the same text then runs the user's answer TWICE —
+                # once as the accepted resolve whose side effects are already
+                # partly done, once as a fresh prompt. Duplicate spreadsheets,
+                # duplicate writes, and no way for the user to know.
+                #
+                # Keep reading and discarding everything: the run's terminal
+                # chat event goes with it, so the turn waits for a final that
+                # already passed and stalls to its full deadline.
+                #
+                # So: drop the narration, never the chat channel. It carries
+                # the state transitions (final/error/aborted) and is a handful
+                # of frames, not a stream. Worst case is a reply missing its
+                # middle — visibly truncated, logged, and honest — rather than
+                # a silent double-execution or a stall.
+                is_chat_frame = (
+                    reply.get("type") == "event" and reply.get("event") == "chat"
+                )
+                if is_chat_frame and len(buffered) < (
+                    MAX_RESOLVE_BUFFERED_FRAMES + MAX_RESOLVE_TERMINAL_FRAMES
+                ):
+                    buffered.append(raw)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "question.resolve failed (falling back to chat.send): %s",

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -6,6 +6,7 @@ without changing the AgentCore wrapper. Each adapter implements the same interfa
 """
 
 import abc
+import collections
 import dataclasses
 import json
 import logging
@@ -1385,6 +1386,12 @@ class OpenClawAdapter(HarnessAdapter):
             return False, [], None
         answers = {qid: [message] for qid in question_ids}
 
+        # Popped before every failure branch below, including a transport
+        # error, and never restored. That is deliberate rather than an
+        # oversight: on any path out of here that is not "answered", the
+        # caller's pre-send chat.abort fires and cancels the question on the
+        # gateway anyway, so a retained entry would only point at something
+        # already destroyed — and would resolve a stale id on the NEXT turn.
         buffered: list = []
         overflowed = False
         resolve_id = str(uuid.uuid4())
@@ -1692,8 +1699,13 @@ class OpenClawAdapter(HarnessAdapter):
                 # Answer the gateway's pending question BEFORE anything can
                 # cancel it. The pre-send abort below is exactly what used to
                 # kill it, so the two are mutually exclusive by construction.
-                # Before the resolve, so a resumed turn's latency includes
-                # the ack wait the user actually waited through.
+                # Before the resolve, so a turn that answers a pending
+                # question counts the ack wait the user actually waited
+                # through. Recorded for the FAILURE path too: a resolve that
+                # times out and falls back has already burned the ack wait and
+                # the abort drain, and restarting the clock afterwards would
+                # report the slowest turns as the fastest.
+                attempted_resolve = session_id in self._pending_questions
                 resolve_started_at = time.time()
                 (
                     answered_pending,
@@ -1702,6 +1714,9 @@ class OpenClawAdapter(HarnessAdapter):
                 ) = self._resolve_pending_question(
                     ws, websocket, message, session_id
                 )
+                # deque, not list: the event loop drains this from the front,
+                # and popping index 0 off a list is O(n) each time.
+                resumed_frames = collections.deque(resumed_frames)
                 if answered_pending:
                     logger.info(
                         "pending question answered; resuming the original run "
@@ -1768,12 +1783,9 @@ class OpenClawAdapter(HarnessAdapter):
                 # the gateway. final_state event stops it. Captured before
                 # ws.send so we don't count our own serialization.
                 #
-                # On a resumed turn the message was handed over at
-                # question.resolve, and the ack wait already elapsed. Starting
-                # the clock here instead would report resumed turns as faster
-                # than the user experienced them — and those are precisely the
-                # turns whose latency we most need to be able to trust.
-                chat_send_at = resolve_started_at if answered_pending else time.time()
+                chat_send_at = (
+                    resolve_started_at if attempted_resolve else time.time()
+                )
                 if answered_pending:
                     # No chat.send: listen for the resumed run. The loop below
                     # ends on the chat `final` event, which that run still
@@ -1903,7 +1915,7 @@ class OpenClawAdapter(HarnessAdapter):
                         # waiting for the question.resolve ack. Drained first
                         # and in order, so the continuation this turn returns
                         # is not missing its opening events.
-                        raw = resumed_frames.pop(0)
+                        raw = resumed_frames.popleft()
                     else:
                         try:
                             raw = ws.recv()

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1481,25 +1481,12 @@ class OpenClawAdapter(HarnessAdapter):
                         MAX_RESOLVE_BUFFERED_FRAMES,
                     )
 
-                # Two bad options here, and the third one is what this does.
-                #
-                # Give up and fall back to abort + chat.send: the ONLY thing
-                # that floods this window is a run already streaming, which
-                # means the gateway already accepted the answer. Aborting and
-                # re-sending the same text then runs the user's answer TWICE —
-                # once as the accepted resolve whose side effects are already
-                # partly done, once as a fresh prompt. Duplicate spreadsheets,
-                # duplicate writes, and no way for the user to know.
-                #
-                # Keep reading and discarding everything: the run's terminal
-                # chat event goes with it, so the turn waits for a final that
-                # already passed and stalls to its full deadline.
-                #
-                # So: drop the narration, never the chat channel. It carries
-                # the state transitions (final/error/aborted) and is a handful
-                # of frames, not a stream. Worst case is a reply missing its
-                # middle — visibly truncated, logged, and honest — rather than
-                # a silent double-execution or a stall.
+                # Drop the narration, never the chat channel — it carries the
+                # run's terminal state (final/error/aborted). Both alternatives
+                # are worse and both were tried: giving up here re-sends the
+                # answer to a run the gateway already accepted (double
+                # execution), and discarding everything loses the final event
+                # (stalls to the full deadline). See the commit message.
                 is_chat_frame = (
                     reply.get("type") == "event" and reply.get("event") == "chat"
                 )

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1418,6 +1418,7 @@ class OpenClawAdapter(HarnessAdapter):
         # already destroyed — and would resolve a stale id on the NEXT turn.
         buffered: list = []
         overflowed = False
+        terminal_overflowed = False
         resolve_id = str(uuid.uuid4())
         try:
             ws.send(json.dumps({
@@ -1490,10 +1491,26 @@ class OpenClawAdapter(HarnessAdapter):
                 is_chat_frame = (
                     reply.get("type") == "event" and reply.get("event") == "chat"
                 )
-                if is_chat_frame and len(buffered) < (
+                if not is_chat_frame:
+                    continue
+                if len(buffered) < (
                     MAX_RESOLVE_BUFFERED_FRAMES + MAX_RESOLVE_TERMINAL_FRAMES
                 ):
                     buffered.append(raw)
+                elif not terminal_overflowed:
+                    # The narration cap is a truncated reply. THIS one can cost
+                    # the run's final event, and a turn that loses its final
+                    # sits until the outer deadline and answers "the agent
+                    # stalled". The narration cap already warns; without this
+                    # the worse failure was the silent one, diagnosable only by
+                    # noticing a stall with no cause in the log.
+                    terminal_overflowed = True
+                    logger.warning(
+                        "question.resolve terminal-frame allowance (%d) "
+                        "exhausted before the ack; a chat state transition may "
+                        "be lost and this turn may run to its deadline",
+                        MAX_RESOLVE_TERMINAL_FRAMES,
+                    )
 
             # No ack inside the window. That is NOT the same as "refused" —
             # the ack may simply be slow, and the caller's fallback aborts and

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -344,6 +344,23 @@ MAX_RESOLVE_TERMINAL_FRAMES = 16
 RESOLVE_ACK_WAIT_S = 10
 
 
+def _frames_from_run(frames, run_id) -> bool:
+    """True when any buffered frame belongs to `run_id`.
+
+    Used as proof that a run has resumed. This socket carries every run in the
+    container, so "some frames arrived" proves nothing on its own — the run id
+    is what makes it evidence rather than a guess.
+    """
+    for raw in frames:
+        try:
+            payload = (json.loads(raw) or {}).get("payload") or {}
+        except (json.JSONDecodeError, ValueError, AttributeError):
+            continue
+        if payload.get("runId") == run_id:
+            return True
+    return False
+
+
 def _classify_chat_error(error_message: str) -> str:
     """Name the chat-error class from OpenClaw's message.
 
@@ -1307,7 +1324,14 @@ class OpenClawAdapter(HarnessAdapter):
         while len(self._pending_questions) > MAX_PENDING_QUESTIONS:
             evicted, _ = next(iter(self._pending_questions.items()))
             self._pending_questions.pop(evicted, None)
-            logger.info("evicted pending question for an idle session")
+            # Warning, not info: the cap sits far above any plausible number
+            # of concurrent askers, so an eviction firing at all means a leak
+            # or an abuse pattern, not routine churn. At info it would be lost
+            # in normal log volume.
+            logger.warning(
+                "evicted pending question for an idle session; %d sessions "
+                "were holding one", MAX_PENDING_QUESTIONS,
+            )
 
     def _resolve_pending_question(self, ws, websocket, message, session_id):
         """Answer the question the gateway is still holding, if there is one.
@@ -1452,6 +1476,26 @@ class OpenClawAdapter(HarnessAdapter):
                     MAX_RESOLVE_BUFFERED_FRAMES + MAX_RESOLVE_TERMINAL_FRAMES
                 ):
                     buffered.append(raw)
+
+            # No ack inside the window. That is NOT the same as "refused" —
+            # the ack may simply be slow, and the caller's fallback aborts and
+            # re-sends the identical text, running the user's answer twice.
+            #
+            # There is direct evidence available, so use it instead of
+            # guessing: a run blocked on a question emits nothing. If frames
+            # from the ASKING run arrived during this wait, that run resumed,
+            # which it only does once the gateway accepts the answer. Treat it
+            # as accepted and listen, rather than aborting work already in
+            # flight.
+            asking_run = pending.get("run_id")
+            if asking_run and _frames_from_run(buffered, asking_run):
+                logger.warning(
+                    "question.resolve ack not seen in %ss, but run %s is "
+                    "already streaming — treating the answer as accepted "
+                    "rather than sending it a second time",
+                    RESOLVE_ACK_WAIT_S, str(asking_run)[:12],
+                )
+                return True, buffered, asking_run
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "question.resolve failed (falling back to chat.send): %s",
@@ -1648,6 +1692,9 @@ class OpenClawAdapter(HarnessAdapter):
                 # Answer the gateway's pending question BEFORE anything can
                 # cancel it. The pre-send abort below is exactly what used to
                 # kill it, so the two are mutually exclusive by construction.
+                # Before the resolve, so a resumed turn's latency includes
+                # the ack wait the user actually waited through.
+                resolve_started_at = time.time()
                 (
                     answered_pending,
                     resumed_frames,
@@ -1720,7 +1767,13 @@ class OpenClawAdapter(HarnessAdapter):
                 # Latency clock starts the instant we hand the message to
                 # the gateway. final_state event stops it. Captured before
                 # ws.send so we don't count our own serialization.
-                chat_send_at = time.time()
+                #
+                # On a resumed turn the message was handed over at
+                # question.resolve, and the ack wait already elapsed. Starting
+                # the clock here instead would report resumed turns as faster
+                # than the user experienced them — and those are precisely the
+                # turns whose latency we most need to be able to trust.
+                chat_send_at = resolve_started_at if answered_pending else time.time()
                 if answered_pending:
                     # No chat.send: listen for the resumed run. The loop below
                     # ends on the chat `final` event, which that run still

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1312,9 +1312,13 @@ class OpenClawAdapter(HarnessAdapter):
         compare against — see _process_once.
 
         Access is unsynchronized: agentcore_wrapper serializes the whole
-        entrypoint behind `_invocation_lock`, so no two turns are ever inside
-        _process_once at once. That invariant lives in another file; if the
-        lock is ever narrowed or removed, this dict needs its own.
+        entrypoint behind `_invocation_lock` (grep that name — the definition
+        carries the other half of this note), so no two turns are ever inside
+        _process_once at once. That invariant lives in another file and is
+        enforced by nothing but these two comments; if the lock is narrowed or
+        the container ever runs multiple workers, this dict needs its own
+        synchronization. No test would catch it — the interleaving tests
+        interleave sequentially, which is all a single-threaded replay can do.
         """
         self._pending_questions.pop(session_id, None)
         self._pending_questions[session_id] = {

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -618,6 +618,10 @@ class OpenClawAdapter(HarnessAdapter):
         # --token` (launcher) and reused in the connect envelope (client), so the
         # two always agree within this process.
         self._gateway_token: str = secrets.token_urlsafe(32)
+        # The question the agent asked on the PREVIOUS turn, still pending on
+        # the gateway. The user's next message is its answer, not a new
+        # request — see _resolve_pending_question.
+        self._pending_question: Optional[dict] = None
 
     def configure(self, config: dict) -> None:
         """Configure the OpenClaw adapter. Idempotent — safe to call multiple times."""
@@ -1240,6 +1244,77 @@ class OpenClawAdapter(HarnessAdapter):
             return False
         return result.latency_ms <= UPSTREAM_RETRY_MAX_LATENCY_MS
 
+
+    def _resolve_pending_question(self, ws, websocket, message, session_id):
+        """Answer the question the gateway is still holding, if there is one.
+
+        The agent's ask leaves a question in `pending` on the gateway, waiting
+        for `question.resolve`. This adapter used to walk away from it and let
+        the next turn's pre-send `chat.abort` cancel it — the bundle's ask-user
+        tool registers an abort listener that fires
+        `cancelPendingQuestion("run-abort")` — after which the model correctly
+        reported that its question had been aborted. Users read that as the
+        agent inventing an abort they never performed. They were right that
+        they never aborted anything; we did, on every turn.
+
+        Params are exactly QuestionResolveParamsSchema:
+            { id, answers: { answers: { <questionId>: [<text>] } }, resolvedBy }
+        which is the same shape OpenClaw's own plain-text claim path sends.
+
+        Returns True when the gateway accepted the answer, meaning the ORIGINAL
+        run resumes and this turn must listen to it rather than starting a new
+        one. Returns False for anything else — expired, cancelled, unknown id,
+        transport error — so the caller falls back to a normal chat.send. A
+        question we cannot answer must never block the user's message.
+        """
+        pending = self._pending_question
+        self._pending_question = None
+        if not pending or pending.get("session_id") != session_id:
+            return False
+
+        question_ids = pending.get("question_ids") or []
+        if not question_ids:
+            return False
+        answers = {qid: [message] for qid in question_ids}
+
+        resolve_id = str(uuid.uuid4())
+        try:
+            ws.send(json.dumps({
+                "type": "req",
+                "id": resolve_id,
+                "method": "question.resolve",
+                "params": {
+                    "id": pending["id"],
+                    "answers": {"answers": answers},
+                    "resolvedBy": "plain-text",
+                },
+            }))
+            ws.settimeout(10)
+            deadline = time.time() + 10
+            while time.time() < deadline:
+                try:
+                    raw = ws.recv()
+                except websocket.WebSocketTimeoutException:
+                    break
+                try:
+                    reply = json.loads(raw)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if reply.get("type") == "res" and reply.get("id") == resolve_id:
+                    ok = bool(reply.get("ok"))
+                    status = (reply.get("payload") or {}).get("status")
+                    logger.info(
+                        "question.resolve ok=%s status=%s id=%s",
+                        ok, status, str(pending["id"])[:12],
+                    )
+                    return ok and status == "answered"
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "question.resolve failed (falling back to chat.send): %s",
+                str(exc)[:200],
+            )
+        return False
+
     def _process_once(
         self,
         message: str,
@@ -1426,7 +1501,21 @@ class OpenClawAdapter(HarnessAdapter):
                 # protocol (sessions.reset would additionally wipe stored
                 # conversation state, so we deliberately do NOT use it here).
                 # Kill switch: OPENCLAW_PRESEND_ABORT=0.
-                if os.environ.get("OPENCLAW_PRESEND_ABORT", "1") != "0":
+                # Answer the gateway's pending question BEFORE anything can
+                # cancel it. The pre-send abort below is exactly what used to
+                # kill it, so the two are mutually exclusive by construction.
+                answered_pending = self._resolve_pending_question(
+                    ws, websocket, message, session_id
+                )
+                if answered_pending:
+                    logger.info(
+                        "pending question answered; resuming the original run "
+                        "instead of starting a new one"
+                    )
+
+                if not answered_pending and os.environ.get(
+                    "OPENCLAW_PRESEND_ABORT", "1"
+                ) != "0":
                     try:
                         abort_id = str(uuid.uuid4())
                         ws.send(json.dumps({
@@ -1474,21 +1563,32 @@ class OpenClawAdapter(HarnessAdapter):
                 # multi-user case) other users' history entirely. The
                 # AgentCore runtime gives us a stable per-user session_id;
                 # use it directly.
+                # When the answer was accepted the ORIGINAL run resumes and
+                # streams its continuation on this same socket. Sending a new
+                # chat.send here would run the user's answer a second time as a
+                # fresh prompt — OpenClaw's own claim path returns without
+                # queueing for the same reason.
                 chat_id = str(uuid.uuid4())
                 # Latency clock starts the instant we hand the message to
                 # the gateway. final_state event stops it. Captured before
                 # ws.send so we don't count our own serialization.
                 chat_send_at = time.time()
-                ws.send(json.dumps({
-                    "type": "req",
-                    "id": chat_id,
-                    "method": "chat.send",
-                    "params": {
-                        "sessionKey": session_id or "default",
-                        "message": message,
-                        "idempotencyKey": chat_id,
-                    },
-                }))
+                if answered_pending:
+                    # No chat.send: listen for the resumed run. The loop below
+                    # ends on the chat `final` event, which that run still
+                    # emits, rather than on a chat.send response id.
+                    pass
+                else:
+                    ws.send(json.dumps({
+                        "type": "req",
+                        "id": chat_id,
+                        "method": "chat.send",
+                        "params": {
+                            "sessionKey": session_id or "default",
+                            "message": message,
+                            "idempotencyKey": chat_id,
+                        },
+                    }))
 
                 # Step 4: Collect response events until final.
                 # Instrumented to log every event type we see so we can
@@ -2080,6 +2180,24 @@ class OpenClawAdapter(HarnessAdapter):
                             max(0, int(time.time() - chat_send_at)),
                             bool(prefix),
                         )
+                        # Remember it so the NEXT turn answers it instead of
+                        # cancelling it. The gateway holds this question open
+                        # (status pending, with expiresAtMs) waiting for
+                        # question.resolve; walking away is what left it to be
+                        # killed by the next turn's pre-send abort.
+                        pending_id = q_payload.get("id")
+                        if isinstance(pending_id, str) and pending_id:
+                            question_ids = [
+                                entry.get("id")
+                                for entry in (q_payload.get("questions") or [])
+                                if isinstance(entry, dict)
+                                and isinstance(entry.get("id"), str)
+                            ]
+                            self._pending_question = {
+                                "id": pending_id,
+                                "question_ids": question_ids,
+                                "session_id": session_id,
+                            }
                         got_final = True
                         break
 

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -332,6 +332,11 @@ MAX_PENDING_QUESTIONS = 256
 # anything beyond this is a gateway misbehaving, not a run to reassemble.
 MAX_RESOLVE_BUFFERED_FRAMES = 200
 
+# How long to wait for the question.resolve ack before giving up and falling
+# back to a normal chat.send. Small on purpose: this sits in front of the
+# user's turn, and every path out of it is safe.
+RESOLVE_ACK_WAIT_S = 10
+
 
 def _classify_chat_error(error_message: str) -> str:
     """Name the chat-error class from OpenClaw's message.
@@ -1320,12 +1325,21 @@ class OpenClawAdapter(HarnessAdapter):
         if not pending:
             return False, []
 
+        # Kill switch, matching OPENCLAW_PRESEND_ABORT on the path this one
+        # replaces. Disabling it restores the previous behaviour exactly —
+        # the question is abandoned and the abort below cancels it — so an
+        # operator can back this out without shipping an image.
+        if os.environ.get("OPENCLAW_QUESTION_RESOLVE", "1") == "0":
+            logger.info("question.resolve disabled by OPENCLAW_QUESTION_RESOLVE=0")
+            return False, []
+
         question_ids = pending.get("question_ids") or []
         if not question_ids:
             return False, []
         answers = {qid: [message] for qid in question_ids}
 
         buffered: list = []
+        overflowed = False
         resolve_id = str(uuid.uuid4())
         try:
             ws.send(json.dumps({
@@ -1338,9 +1352,17 @@ class OpenClawAdapter(HarnessAdapter):
                     "resolvedBy": "plain-text",
                 },
             }))
-            ws.settimeout(10)
-            deadline = time.time() + 10
-            while time.time() < deadline:
+            deadline = time.time() + RESOLVE_ACK_WAIT_S
+            while True:
+                # The socket timeout is what actually bounds this, so it has to
+                # shrink with the deadline. A single settimeout() up front only
+                # bounds each recv() individually: a frame at the 9s mark would
+                # re-enter recv() with a fresh 10s budget, so the real ceiling
+                # was double the one the comment claimed.
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    break
+                ws.settimeout(remaining)
                 try:
                     raw = ws.recv()
                 except websocket.WebSocketTimeoutException:
@@ -1363,9 +1385,19 @@ class OpenClawAdapter(HarnessAdapter):
                     return answered, (buffered if answered else [])
                 # Not the ack — the resumed run's own output, arriving ahead of
                 # or interleaved with it. Bounded so a chatty gateway cannot
-                # grow this without limit inside a 10-second window.
+                # grow this without limit inside the ack window.
                 if len(buffered) < MAX_RESOLVE_BUFFERED_FRAMES:
                     buffered.append(raw)
+                elif not overflowed:
+                    # Said once, loudly. Silently truncating here would surface
+                    # later as a reply missing its middle, with nothing in the
+                    # logs to connect it to this cap.
+                    overflowed = True
+                    logger.warning(
+                        "question.resolve buffer full at %d frames; further "
+                        "resumed-run output before the ack is being dropped",
+                        MAX_RESOLVE_BUFFERED_FRAMES,
+                    )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "question.resolve failed (falling back to chat.send): %s",

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -320,6 +320,18 @@ UPSTREAM_RETRY_MAX_LATENCY_MS = 30_000
 # silently rounded back UP into an overshoot.
 UPSTREAM_RETRY_MIN_REMAINING_S = 60
 
+# One entry per session that asked a question and has not been answered yet.
+# This is a singleton adapter shared by every user in the container, so the
+# map is per-session; the cap keeps a session that never answers from pinning
+# an entry for the container's lifetime. Far above any real concurrent-asker
+# count — it is a leak stop, not a throttle.
+MAX_PENDING_QUESTIONS = 256
+
+# Frames buffered while waiting for the question.resolve ack, in case the
+# resumed run streams ahead of it. Bounded because the wait is only ~10s and
+# anything beyond this is a gateway misbehaving, not a run to reassemble.
+MAX_RESOLVE_BUFFERED_FRAMES = 200
+
 
 def _classify_chat_error(error_message: str) -> str:
     """Name the chat-error class from OpenClaw's message.
@@ -618,10 +630,20 @@ class OpenClawAdapter(HarnessAdapter):
         # --token` (launcher) and reused in the connect envelope (client), so the
         # two always agree within this process.
         self._gateway_token: str = secrets.token_urlsafe(32)
-        # The question the agent asked on the PREVIOUS turn, still pending on
-        # the gateway. The user's next message is its answer, not a new
+        # Questions the agent asked on a PREVIOUS turn, still pending on the
+        # gateway. The asking user's next message is the answer, not a new
         # request — see _resolve_pending_question.
-        self._pending_question: Optional[dict] = None
+        #
+        # KEYED BY SESSION, deliberately. This is a module-level singleton
+        # adapter (agentcore_wrapper.py) serving every user in the container,
+        # and turns from different sessions interleave freely — the run-id
+        # fence in _process_once exists for exactly that reason. A single
+        # scalar here would let ANY other user's turn clear the entry between
+        # the ask and the answer, dropping the pending question back onto the
+        # pre-send abort path this whole mechanism exists to avoid. The bug
+        # would be intermittent and multi-user only, which is the worst kind
+        # to find in production.
+        self._pending_questions: dict = {}
 
     def configure(self, config: dict) -> None:
         """Configure the OpenClaw adapter. Idempotent — safe to call multiple times."""
@@ -1245,6 +1267,24 @@ class OpenClawAdapter(HarnessAdapter):
         return result.latency_ms <= UPSTREAM_RETRY_MAX_LATENCY_MS
 
 
+    def _remember_pending_question(self, session_id, pending_id, question_ids):
+        """Hold one pending question per session, oldest evicted first.
+
+        Bounded because a session that asks and never answers would otherwise
+        leave its entry here for the life of the container. Eviction is safe:
+        the gateway expires questions on its own, and a dropped entry only
+        costs us the resolve, falling back to a normal chat.send.
+        """
+        self._pending_questions.pop(session_id, None)
+        self._pending_questions[session_id] = {
+            "id": pending_id,
+            "question_ids": question_ids,
+        }
+        while len(self._pending_questions) > MAX_PENDING_QUESTIONS:
+            evicted, _ = next(iter(self._pending_questions.items()))
+            self._pending_questions.pop(evicted, None)
+            logger.info("evicted pending question for an idle session")
+
     def _resolve_pending_question(self, ws, websocket, message, session_id):
         """Answer the question the gateway is still holding, if there is one.
 
@@ -1261,22 +1301,31 @@ class OpenClawAdapter(HarnessAdapter):
             { id, answers: { answers: { <questionId>: [<text>] } }, resolvedBy }
         which is the same shape OpenClaw's own plain-text claim path sends.
 
-        Returns True when the gateway accepted the answer, meaning the ORIGINAL
-        run resumes and this turn must listen to it rather than starting a new
-        one. Returns False for anything else — expired, cancelled, unknown id,
-        transport error — so the caller falls back to a normal chat.send. A
-        question we cannot answer must never block the user's message.
+        Returns `(answered, frames)`. `answered` is True when the gateway
+        accepted the answer, meaning the ORIGINAL run resumes and this turn
+        must listen to it rather than starting a new one; False for anything
+        else — expired, cancelled, unknown id, transport error — so the caller
+        falls back to a normal chat.send. A question we cannot answer must
+        never block the user's message.
+
+        `frames` are raw messages that arrived while waiting for the resolve
+        ack. The resumed run streams onto this same socket, so those frames
+        can be its continuation; they are handed back for the event loop to
+        consume rather than dropped. (The pre-send abort drain below discards
+        its frames on purpose — those belong to a run being torn down. This
+        one does not.)
         """
-        pending = self._pending_question
-        self._pending_question = None
-        if not pending or pending.get("session_id") != session_id:
-            return False
+        # Only this session's question, and only ever consumed once.
+        pending = self._pending_questions.pop(session_id, None)
+        if not pending:
+            return False, []
 
         question_ids = pending.get("question_ids") or []
         if not question_ids:
-            return False
+            return False, []
         answers = {qid: [message] for qid in question_ids}
 
+        buffered: list = []
         resolve_id = str(uuid.uuid4())
         try:
             ws.send(json.dumps({
@@ -1303,17 +1352,26 @@ class OpenClawAdapter(HarnessAdapter):
                 if reply.get("type") == "res" and reply.get("id") == resolve_id:
                     ok = bool(reply.get("ok"))
                     status = (reply.get("payload") or {}).get("status")
+                    answered = ok and status == "answered"
                     logger.info(
-                        "question.resolve ok=%s status=%s id=%s",
-                        ok, status, str(pending["id"])[:12],
+                        "question.resolve ok=%s status=%s id=%s buffered=%d",
+                        ok, status, str(pending["id"])[:12], len(buffered),
                     )
-                    return ok and status == "answered"
+                    # Frames only matter when the run actually resumes. On any
+                    # other outcome the caller aborts and re-sends, so keeping
+                    # them would replay a dead run's events into a new turn.
+                    return answered, (buffered if answered else [])
+                # Not the ack — the resumed run's own output, arriving ahead of
+                # or interleaved with it. Bounded so a chatty gateway cannot
+                # grow this without limit inside a 10-second window.
+                if len(buffered) < MAX_RESOLVE_BUFFERED_FRAMES:
+                    buffered.append(raw)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "question.resolve failed (falling back to chat.send): %s",
                 str(exc)[:200],
             )
-        return False
+        return False, []
 
     def _process_once(
         self,
@@ -1504,7 +1562,7 @@ class OpenClawAdapter(HarnessAdapter):
                 # Answer the gateway's pending question BEFORE anything can
                 # cancel it. The pre-send abort below is exactly what used to
                 # kill it, so the two are mutually exclusive by construction.
-                answered_pending = self._resolve_pending_question(
+                answered_pending, resumed_frames = self._resolve_pending_question(
                     ws, websocket, message, session_id
                 )
                 if answered_pending:
@@ -1680,13 +1738,20 @@ class OpenClawAdapter(HarnessAdapter):
                 # with the scratchpad as the final reply.
                 ws.settimeout(60)
                 while time.time() < deadline:
-                    try:
-                        raw = ws.recv()
-                    except websocket.WebSocketTimeoutException:
-                        # Idle gap, not a failure — outer deadline still
-                        # governs. Fall through and let the while loop
-                        # re-check time.time().
-                        continue
+                    if resumed_frames:
+                        # The resumed run's output that arrived while we were
+                        # waiting for the question.resolve ack. Drained first
+                        # and in order, so the continuation this turn returns
+                        # is not missing its opening events.
+                        raw = resumed_frames.pop(0)
+                    else:
+                        try:
+                            raw = ws.recv()
+                        except websocket.WebSocketTimeoutException:
+                            # Idle gap, not a failure — outer deadline still
+                            # governs. Fall through and let the while loop
+                            # re-check time.time().
+                            continue
                     msg = json.loads(raw)
                     mtype = msg.get("type")
                     mevent = msg.get("event") if mtype == "event" else None
@@ -2193,11 +2258,9 @@ class OpenClawAdapter(HarnessAdapter):
                                 if isinstance(entry, dict)
                                 and isinstance(entry.get("id"), str)
                             ]
-                            self._pending_question = {
-                                "id": pending_id,
-                                "question_ids": question_ids,
-                                "session_id": session_id,
-                            }
+                            self._remember_pending_question(
+                                session_id, pending_id, question_ids
+                            )
                         got_final = True
                         break
 

--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -29,6 +29,15 @@ as a "summary" row or a note next to a number.
 
 1. Resolve the school. Confirm back which school and year you are running.
 2. Discover the roster: `GR0x` homeroom sections + lead teachers + counts.
+   **The roster defines the grade span — never state one you did not query.**
+   On 2026-08-15 the agent announced "Minter Creek is a K-2 school (it's PSD's
+   K-2 primary)", invented the justification, and scoped an entire report to
+   it. Minter Creek is K-5. The roster query answers this; asserting it from
+   apparent knowledge is a Rule 3 fabrication in a document a principal reads
+   as fact.
+   **Keep the section -> teacher map from this step** and pass it to
+   `build_tab.py --teachers`; the classroom columns are headed by teacher
+   name, not section id.
 3. Per grade, **extract → aggregate → build** (see `references/sql.md`):
    - run the extraction query — raw matched pairs, no `NTILE`, no norms join,
      no `GROUPING SETS`

--- a/infra/agent-image/skills/quartile-growth-report/references/sql.md
+++ b/infra/agent-image/skills/quartile-growth-report/references/sql.md
@@ -88,6 +88,13 @@ SELECT m.meas, m.studentid::text, m.b::text, m.e::text,
 Skipping them cost roughly ten round trips of trial and error per run on
 2026-08-15 — the agent rediscovered this the hard way, one column at a time.
 
+### Step 1b — carry the teacher map
+
+The roster query already returns lead teacher per section. Keep it as a
+`{sectionid: "Last, First"}` map and pass it to `build_tab.py --teachers`.
+Without it the classroom columns are headed by raw section ids, which is what
+shipped on 2026-08-15 and had to be relabelled by hand afterwards.
+
 ### Step 2 — aggregate
 
 **Feed the exported CSV straight in. Do not write a converter.** `aggregate.py`

--- a/infra/agent-image/skills/quartile-growth-report/scripts/build_tab.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/build_tab.py
@@ -48,7 +48,27 @@ def cell(record):
     return "/".join(part for part in parts if part != "")
 
 
-def build(records, school, grade, year, window, sections=None):
+def column_label(section_id, teachers):
+    """The header for a classroom column: the teacher, not a section number.
+
+    layout.md specifies `Teacher1 | … | School | District`. This emitted the
+    raw sectionid instead, so a principal opening the workbook saw column
+    headers like `274893` and had to be told which teacher that was. The agent
+    papered over it by hand-writing relabeling scripts after the fact — the one
+    thing this script exists to make unnecessary.
+
+    The id is kept alongside the name because two teachers can share a name and
+    section ids are what every downstream query keys on.
+    """
+    name = (teachers or {}).get(str(section_id))
+    if not name:
+        # A section with no Lead Teacher in PowerSchool. Named explicitly so it
+        # cannot be mistaken for a lookup that silently failed.
+        return f"(Not on file) ({section_id})"
+    return f"{name} ({section_id})"
+
+
+def build(records, school, grade, year, window, sections=None, teachers=None):
     """One tab's grid: a block per measure, quartile rows, then subgroups."""
     by_measure = defaultdict(lambda: defaultdict(dict))
     subgroups = defaultdict(list)
@@ -77,7 +97,11 @@ def build(records, school, grade, year, window, sections=None):
     for meas in sorted(by_measure):
         scopes = by_measure[meas]
         values.append([f"{meas} ({window})"])
-        values.append(["Quartile"] + [str(s) for s in section_ids] + ["School", "District"])
+        values.append(
+            ["Quartile"]
+            + [column_label(s, teachers) for s in section_ids]
+            + ["School", "District"]
+        )
         for label, key in QUARTILE_ROWS:
             row = [label]
             for section in section_ids:
@@ -117,6 +141,11 @@ def main() -> int:
         "Fall→Spring is a wrong report, not a cosmetic slip",
     )
     parser.add_argument(
+        "--teachers",
+        help='JSON map of sectionid -> teacher name, e.g. \'{"274893":"Hansen, Jane"}\'. '
+        "Sections without an entry render as (Not on file).",
+    )
+    parser.add_argument(
         "--emit",
         choices=("grid", "values", "addsheet"),
         default="values",
@@ -148,7 +177,10 @@ def main() -> int:
         if args.rows:
             handle.close()
 
-    tab = build(records, args.school, args.grade, args.year, args.window)
+    teachers = json.loads(args.teachers) if args.teachers else None
+    tab = build(
+        records, args.school, args.grade, args.year, args.window, teachers=teachers
+    )
 
     if args.emit == "grid":
         print(json.dumps(tab, indent=1))

--- a/infra/agent-image/skills/quartile-growth-report/scripts/build_tab.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/build_tab.py
@@ -177,7 +177,23 @@ def main() -> int:
         if args.rows:
             handle.close()
 
-    teachers = json.loads(args.teachers) if args.teachers else None
+    teachers = None
+    if args.teachers:
+        # A raw JSONDecodeError here reads as a script bug and costs the agent
+        # a debugging round trip — the exact tax this skill's docs exist to
+        # avoid. Name what was wrong and what the argument should look like.
+        try:
+            teachers = json.loads(args.teachers)
+        except (json.JSONDecodeError, ValueError) as exc:
+            parser.error(
+                f"--teachers is not valid JSON ({exc}). Expected a map of "
+                'sectionid to teacher name, e.g. \'{"274893": "Hansen, Jane"}\''
+            )
+        if not isinstance(teachers, dict):
+            parser.error(
+                "--teachers must be a JSON object mapping sectionid to teacher "
+                f"name, got {type(teachers).__name__}"
+            )
     tab = build(
         records, args.school, args.grade, args.year, args.window, teachers=teachers
     )

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_build_tab.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_build_tab.py
@@ -60,10 +60,12 @@ class Layout(unittest.TestCase):
 
     def test_classroom_columns_appear(self):
         # The per-teacher breakdown is the point of the report; aggregate.py
-        # emits sectionid so these columns can exist at all.
+        # emits sectionid so these columns can exist at all. Headers carry the
+        # teacher per layout.md — this originally asserted the raw section id,
+        # i.e. it pinned the bug instead of the spec.
         header = next(r for r in self.grid()["values"] if r and r[0] == "Quartile")
-        self.assertIn("S1", header)
-        self.assertIn("S2", header)
+        self.assertTrue(any("S1" in str(c) for c in header))
+        self.assertTrue(any("S2" in str(c) for c in header))
         self.assertEqual(header[-2:], ["School", "District"])
 
     def test_section_columns_are_ordered_deterministically(self):
@@ -127,3 +129,48 @@ class Payloads(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ClassroomColumnsAreHeadedByTeacher(unittest.TestCase):
+    """layout.md says `Teacher1 | … | School | District`.
+
+    build_tab emitted raw section ids, so a principal saw headers like `274893`
+    and the agent hand-wrote relabeling scripts after the fact — the exact glue
+    this script exists to remove. The spec was in the same directory the whole
+    time; the tests asserted the implementation instead of it.
+    """
+
+    RECORDS = [
+        rec("class", "All", section="274893"),
+        rec("class", "All", section="274894"),
+        rec("school", "All"),
+        rec("district", "All"),
+    ]
+    TEACHERS = {"274893": "Hansen, Jane"}
+
+    def header(self, teachers):
+        grid = build_tab.build(
+            self.RECORDS, "Purdy", "3", "2025-26", "Fall→Spring", teachers=teachers
+        )
+        return next(r for r in grid["values"] if r and r[0] == "Quartile")
+
+    def test_the_teacher_name_is_the_column_header(self):
+        self.assertIn("Hansen, Jane (274893)", self.header(self.TEACHERS))
+
+    def test_a_section_with_no_teacher_says_so_explicitly(self):
+        # "(Not on file)" must not be mistaken for a lookup that failed.
+        self.assertIn("(Not on file) (274894)", self.header(self.TEACHERS))
+
+    def test_the_section_id_is_retained_alongside_the_name(self):
+        # Two teachers can share a name, and every downstream query keys on id.
+        header = self.header(self.TEACHERS)
+        self.assertTrue(any("274893" in str(c) for c in header))
+
+    def test_school_and_district_stay_the_last_two_columns(self):
+        self.assertEqual(self.header(self.TEACHERS)[-2:], ["School", "District"])
+
+    def test_no_map_still_renders_a_usable_header(self):
+        # Degrades to (Not on file) rather than crashing or emitting a bare id.
+        header = self.header(None)
+        self.assertNotIn("274893", header)
+        self.assertIn("(Not on file) (274893)", header)

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -114,8 +114,13 @@ class FakeGateway:
     """
 
     def __init__(self, agent_events, resume_events=None, question_expired=False,
-                 resume_before_ack=False):
+                 resume_before_ack=False, withhold_ack=False):
         self._agent_events = agent_events
+        # The gateway accepts the resolve and the run resumes, but the ack
+        # itself never lands inside our wait window. Nothing in the protocol
+        # orders those two, and this is the case where guessing "refused"
+        # costs the user a duplicate execution.
+        self._withhold_ack = withhold_ack
         # Whether the resumed run's output lands BEFORE the question.resolve
         # ack. The gateway is async; nothing guarantees the ack wins that race,
         # and frames dropped during the resolve wait are gone for good.
@@ -177,7 +182,10 @@ class FakeGateway:
                         })
                     )
 
-                if self._resume_before_ack:
+                if self._withhold_ack:
+                    # Accepted server-side; the ack is lost or slow.
+                    stream_the_resumed_run()
+                elif self._resume_before_ack:
                     stream_the_resumed_run()
                     self._reply(request_id, {"status": "answered"})
                 else:
@@ -588,7 +596,8 @@ def turn_runner():
 
 
 def two_turn_replay(first_events, answer_text, resume_events, question_expired=False,
-                    resume_before_ack=False, interleaved_session=None, env=None):
+                    resume_before_ack=False, interleaved_session=None, env=None,
+                    withhold_ack=False):
     """Turn 1 asks a question; turn 2 is the user's answer, on ONE adapter.
 
     The adapter instance is shared deliberately — the pending question is
@@ -617,7 +626,8 @@ def two_turn_replay(first_events, answer_text, resume_events, question_expired=F
     # The gateway is now holding that question open, as it does in production.
     g2 = FakeGateway([], resume_events=resume_events,
                      question_expired=question_expired,
-                     resume_before_ack=resume_before_ack).hold_question()
+                     resume_before_ack=resume_before_ack,
+                     withhold_ack=withhold_ack).hold_question()
     second = run(g2, answer_text)
     return first.text, second.text, g2
 
@@ -775,6 +785,48 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
             [ASK], "Keep going", [says("Sheet shared.")]
         )
         self.assertIn("Sheet shared", second)
+
+    def test_a_lost_ack_with_the_run_streaming_is_not_treated_as_a_refusal(self):
+        # The ack and the resumed run's output are unordered. If the ack is
+        # slow or lost, "no ack" is NOT "refused" — and the fallback aborts
+        # the accepted run and re-sends the same text, running the user's
+        # answer twice against side effects already underway.
+        #
+        # A run blocked on a question emits nothing, so frames carrying the
+        # ASKING run's id are proof it resumed, which only happens once the
+        # gateway accepts. Evidence, not a heuristic — the socket carries
+        # every run in the container, so the run id is what makes it evidence.
+        _, second, g2 = two_turn_replay(
+            [ASK], "Keep going", [says("Sheet shared: the link.")],
+            withhold_ack=True,
+        )
+        sends = [m for m in g2.sent if m.get("method") == "chat.send"]
+        self.assertEqual(sends, [], "a lost ack must not re-run the answer")
+        aborts = [m for m in g2.sent if m.get("method") == "chat.abort"]
+        self.assertEqual(aborts, [], "the accepted run must not be aborted")
+        self.assertIn("Sheet shared", second)
+
+    def test_a_lost_ack_with_nothing_streaming_still_falls_back(self):
+        # The converse. No ack AND no sign of the run means we have no reason
+        # to believe it was accepted, and the user's message must still be
+        # delivered rather than silently swallowed.
+        _, _, g2 = two_turn_replay(
+            [ASK], "Keep going", [], withhold_ack=True,
+        )
+        sends = [m for m in g2.sent if m.get("method") == "chat.send"]
+        self.assertEqual(len(sends), 1, "a message we cannot resolve must still send")
+
+    def test_another_runs_frames_are_not_mistaken_for_ours_resuming(self):
+        # Frames arriving during the wait prove nothing on their own — this
+        # socket carries every run in the container. Only the asking run's id
+        # counts, or an unrelated busy run would suppress the fallback and
+        # strand the user's message.
+        _, _, g2 = two_turn_replay(
+            [ASK], "Keep going", [foreign_says("Someone else's run.")],
+            withhold_ack=True,
+        )
+        sends = [m for m in g2.sent if m.get("method") == "chat.send"]
+        self.assertEqual(len(sends), 1, "foreign traffic must not look like our resume")
 
     def test_a_flood_before_the_ack_truncates_but_never_double_sends(self):
         # Only a run already streaming can flood this window — which means the

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -890,6 +890,44 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         self.assertNotIn("stalled", second)
         self.assertIn("chunk0", second)
 
+    def test_exhausting_the_terminal_allowance_says_so(self):
+        # The narration cap warns; this one did not. It is the worse of the
+        # two — losing a chat state transition can cost the run's final event,
+        # and the turn then sits to its outer deadline answering "the agent
+        # stalled" with nothing in the log pointing here.
+        #
+        # Driven directly rather than through a replay: a turn that really
+        # loses its final event runs for the full 550s deadline, which is the
+        # bug, not something to pay for on every test run.
+        chat_frame = json.dumps({"type": "event", "event": "chat",
+                                 "payload": {"state": "running"}})
+        frames = [json.dumps(says("narration"))] + [chat_frame] * 4
+
+        adapter = OpenClawAdapter()
+        adapter._remember_pending_question("s", "q-abc", ["only"], TURN_RUN_ID)
+
+        ws = mock.Mock()
+        ws.recv.side_effect = frames + [_FakeTimeout()]
+        websocket_module = mock.Mock()
+        websocket_module.WebSocketTimeoutException = _FakeTimeout
+
+        with mock.patch.object(harness_adapter, "MAX_RESOLVE_BUFFERED_FRAMES", 1), \
+             mock.patch.object(harness_adapter, "MAX_RESOLVE_TERMINAL_FRAMES", 1), \
+             mock.patch.object(harness_adapter.logger, "warning") as warned:
+            answered, buffered, _ = adapter._resolve_pending_question(
+                ws, websocket_module, "Keep going", "s")
+
+        messages = [call.args[0] for call in warned.call_args_list]
+        self.assertTrue(
+            any("terminal-frame allowance" in m for m in messages),
+            f"exhausting the terminal cap must be logged; got {messages}",
+        )
+        # Capped at narration(1) + terminal(1), not the four that arrived.
+        self.assertEqual(len(buffered), 2)
+        # No ack came, and the asking run WAS streaming, so this is the
+        # accept-on-evidence path rather than a re-send.
+        self.assertTrue(answered)
+
     def test_pending_questions_are_capped_and_evict_oldest_first(self):
         adapter = OpenClawAdapter()
         with mock.patch.object(harness_adapter, "MAX_PENDING_QUESTIONS", 3):

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -113,8 +113,18 @@ class FakeGateway:
     is what a real idle socket does and what the bounded drain loops expect.
     """
 
-    def __init__(self, agent_events):
+    def __init__(self, agent_events, resume_events=None, question_expired=False):
         self._agent_events = agent_events
+        # What the ORIGINAL run streams once its question is answered. Modelled
+        # because that is what really happens: question.resolve unblocks the
+        # run that asked, and it continues on this same socket.
+        self._resume_events = resume_events or []
+        self._question_expired = question_expired
+        # Gateway-side question state, mirroring QuestionStatusSchema:
+        # pending | answered | cancelled | expired.
+        self.question_status = None
+        self.question_answers = None
+        self.aborted_a_pending_question = False
         self._outbox = collections.deque()
         self.sent = []
         self.closed = False
@@ -139,7 +149,34 @@ class FakeGateway:
             self._reply(request_id, {"protocol": 4})
         elif method == "tools.catalog":
             self._reply(request_id, {"tools": ["exec", "read"]})
+        elif method == "question.resolve":
+            params = message.get("params") or {}
+            if self._question_expired or self.question_status != "pending":
+                # Terminal states are refused, exactly as the manager does.
+                self._reply(request_id, {"status": "cancelled"}, ok=False)
+            elif params.get("cancel"):
+                self.question_status = "cancelled"
+                self._reply(request_id, {"status": "cancelled"})
+            else:
+                self.question_status = "answered"
+                self.question_answers = params.get("answers")
+                self._reply(request_id, {"status": "answered"})
+                # The run that asked resumes and streams its continuation.
+                for event in self._resume_events:
+                    self._outbox.append(json.dumps(event))
+                self._outbox.append(
+                    json.dumps({
+                        "type": "event", "event": "chat",
+                        "payload": {"state": "final"},
+                    })
+                )
         elif method == "chat.abort":
+            # The bundle's ask-user tool registers an abort listener that fires
+            # cancelPendingQuestion("run-abort"). This models that: aborting
+            # while a question is pending destroys it.
+            if self.question_status == "pending":
+                self.question_status = "cancelled"
+                self.aborted_a_pending_question = True
             self._reply(request_id, {})
         elif method == "chat.send":
             # The gateway names this turn's run before streaming anything —
@@ -157,10 +194,16 @@ class FakeGateway:
         return self._outbox.popleft()
 
     # -- helpers ------------------------------------------------------------
-    def _reply(self, request_id, payload):
+    def _reply(self, request_id, payload, ok=True):
         self._outbox.append(
-            json.dumps({"type": "res", "id": request_id, "ok": True, "payload": payload})
+            json.dumps({"type": "res", "id": request_id, "ok": ok, "payload": payload})
         )
+
+    def hold_question(self, question_id="q1", ids=("continue_report",)):
+        """Put the gateway into the state it is in after the agent asks."""
+        self.question_status = "pending"
+        self._pending_ids = list(ids)
+        self._pending_id = question_id
 
 
 def aborts(stop_reason="cancelled"):
@@ -499,3 +542,128 @@ class StructuredQuestionsReachTheUser(unittest.TestCase):
         # is now the last resort, not the common path.
         text = replay([asks_question({"questions": []})])
         self.assertIn("I need a bit more information", text)
+
+
+def two_turn_replay(first_events, answer_text, resume_events, question_expired=False):
+    """Turn 1 asks a question; turn 2 is the user's answer, on ONE adapter.
+
+    The adapter instance is shared deliberately — the pending question is
+    carried on it between turns, which is the whole mechanism under test.
+    Returns (first_reply, second_reply, gateway_of_turn_2).
+    """
+    adapter = OpenClawAdapter()
+    adapter._ready = True
+    zero_usage = {"model_calls": 0, "input": 0, "output": 0,
+                  "cache_read": 0, "cache_write": 0}
+
+    def run(gateway, text):
+        fake_websocket = mock.Mock()
+        fake_websocket.create_connection.return_value = gateway
+        fake_websocket.WebSocketTimeoutException = _FakeTimeout
+        with mock.patch.dict(sys.modules, {"websocket": fake_websocket}), \
+             mock.patch.object(OpenClawAdapter, "_read_turn_usage",
+                               return_value=zero_usage), \
+             mock.patch.object(harness_adapter, "record_failure"):
+            return adapter._process_once(text, "session-replay")
+
+    g1 = FakeGateway(first_events)
+    first = run(g1, "Give me a quartile growth report")
+    # The gateway is now holding that question open, as it does in production.
+    g2 = FakeGateway([], resume_events=resume_events,
+                     question_expired=question_expired)
+    g2.question_status = "pending"
+    second = run(g2, answer_text)
+    return first.text, second.text, g2
+
+
+ASK = {
+    "type": "event",
+    "event": "question.requested",
+    "payload": {
+        "id": "q-abc",
+        "runId": TURN_RUN_ID,
+        "sessionKey": "agent:main:replay",
+        "status": "pending",
+        "questions": [{
+            "id": "continue_report",
+            "question": "Want me to finish and post the link now?",
+            "options": [{"label": "Keep going to completion (Recommended)"},
+                        {"label": "Stop here"}],
+        }],
+    },
+}
+
+
+class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
+    """The user's answer must RESOLVE the pending question, not cancel it.
+
+    The gateway holds an asked question in `pending` awaiting question.resolve.
+    This adapter walked away from it, and the next turn's pre-send chat.abort
+    hit the ask-user tool's abort listener — cancelPendingQuestion("run-abort")
+    in the bundle — destroying it. The model then correctly reported that its
+    question had been aborted, and users read that as a fabricated abort they
+    never performed. They never did. We did, every turn.
+    """
+
+    def test_the_pending_question_is_answered_not_cancelled(self):
+        _, _, g2 = two_turn_replay(
+            [ASK], "Keep going", [says("Done — here is the link.")]
+        )
+        self.assertEqual(g2.question_status, "answered")
+        self.assertFalse(
+            g2.aborted_a_pending_question,
+            "the pre-send abort cancelled the question the user was answering",
+        )
+
+    def test_the_answer_carries_the_users_text_in_the_schema_shape(self):
+        # QuestionResolveParamsSchema: answers is {answers: {qid: [str]}}
+        _, _, g2 = two_turn_replay(
+            [ASK], "Keep going", [says("Done.")]
+        )
+        self.assertEqual(g2.question_answers, {"answers": {"continue_report": ["Keep going"]}})
+
+    def test_no_second_chat_send_is_issued(self):
+        # OpenClaw's own claim path returns without queueing; running the
+        # answer again as a fresh prompt would double-execute the turn.
+        _, _, g2 = two_turn_replay([ASK], "Keep going", [says("Done.")])
+        sends = [m for m in g2.sent if m.get("method") == "chat.send"]
+        self.assertEqual(sends, [])
+
+    def test_the_resumed_run_reply_reaches_the_user(self):
+        _, second, _ = two_turn_replay(
+            [ASK], "Keep going", [says("Grades 3-5 written. Sheet shared.")]
+        )
+        self.assertIn("Grades 3-5 written", second)
+
+    def test_the_question_still_reaches_the_user_on_turn_one(self):
+        first, _, _ = two_turn_replay([ASK], "Keep going", [says("Done.")])
+        self.assertIn("Want me to finish and post the link now?", first)
+        self.assertIn("Keep going to completion", first)
+
+    def test_an_expired_question_falls_back_to_a_normal_turn(self):
+        # A question we cannot answer must never block the user's message.
+        _, _, g2 = two_turn_replay(
+            [ASK], "Keep going", [], question_expired=True
+        )
+        sends = [m for m in g2.sent if m.get("method") == "chat.send"]
+        self.assertEqual(len(sends), 1, "expired question must fall back to chat.send")
+
+    def test_a_turn_with_no_pending_question_is_unchanged(self):
+        # The ordinary path must not grow a question.resolve call.
+        adapter = OpenClawAdapter()
+        adapter._ready = True
+        g = FakeGateway([says("Plain answer.")])
+        fake_websocket = mock.Mock()
+        fake_websocket.create_connection.return_value = g
+        fake_websocket.WebSocketTimeoutException = _FakeTimeout
+        with mock.patch.dict(sys.modules, {"websocket": fake_websocket}), \
+             mock.patch.object(OpenClawAdapter, "_read_turn_usage",
+                               return_value={"model_calls": 0, "input": 0,
+                                             "output": 0, "cache_read": 0,
+                                             "cache_write": 0}), \
+             mock.patch.object(harness_adapter, "record_failure"):
+            result = adapter._process_once("hello", "session-replay")
+        self.assertIn("Plain answer.", result.text)
+        self.assertEqual(
+            [m for m in g.sent if m.get("method") == "question.resolve"], []
+        )

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -113,8 +113,13 @@ class FakeGateway:
     is what a real idle socket does and what the bounded drain loops expect.
     """
 
-    def __init__(self, agent_events, resume_events=None, question_expired=False):
+    def __init__(self, agent_events, resume_events=None, question_expired=False,
+                 resume_before_ack=False):
         self._agent_events = agent_events
+        # Whether the resumed run's output lands BEFORE the question.resolve
+        # ack. The gateway is async; nothing guarantees the ack wins that race,
+        # and frames dropped during the resolve wait are gone for good.
+        self._resume_before_ack = resume_before_ack
         # What the ORIGINAL run streams once its question is answered. Modelled
         # because that is what really happens: question.resolve unblocks the
         # run that asked, and it continues on this same socket.
@@ -160,16 +165,24 @@ class FakeGateway:
             else:
                 self.question_status = "answered"
                 self.question_answers = params.get("answers")
-                self._reply(request_id, {"status": "answered"})
-                # The run that asked resumes and streams its continuation.
-                for event in self._resume_events:
-                    self._outbox.append(json.dumps(event))
-                self._outbox.append(
-                    json.dumps({
-                        "type": "event", "event": "chat",
-                        "payload": {"state": "final"},
-                    })
-                )
+
+                def stream_the_resumed_run():
+                    # The run that asked resumes and streams its continuation.
+                    for event in self._resume_events:
+                        self._outbox.append(json.dumps(event))
+                    self._outbox.append(
+                        json.dumps({
+                            "type": "event", "event": "chat",
+                            "payload": {"state": "final"},
+                        })
+                    )
+
+                if self._resume_before_ack:
+                    stream_the_resumed_run()
+                    self._reply(request_id, {"status": "answered"})
+                else:
+                    self._reply(request_id, {"status": "answered"})
+                    stream_the_resumed_run()
         elif method == "chat.abort":
             # The bundle's ask-user tool registers an abort listener that fires
             # cancelPendingQuestion("run-abort"). This models that: aborting
@@ -199,11 +212,13 @@ class FakeGateway:
             json.dumps({"type": "res", "id": request_id, "ok": ok, "payload": payload})
         )
 
-    def hold_question(self, question_id="q1", ids=("continue_report",)):
-        """Put the gateway into the state it is in after the agent asks."""
+    def hold_question(self):
+        """Put the gateway into the state it is in after the agent asks.
+
+        Returns self so it can be chained at construction.
+        """
         self.question_status = "pending"
-        self._pending_ids = list(ids)
-        self._pending_id = question_id
+        return self
 
 
 def aborts(stop_reason="cancelled"):
@@ -544,11 +559,18 @@ class StructuredQuestionsReachTheUser(unittest.TestCase):
         self.assertIn("I need a bit more information", text)
 
 
-def two_turn_replay(first_events, answer_text, resume_events, question_expired=False):
+def two_turn_replay(first_events, answer_text, resume_events, question_expired=False,
+                    resume_before_ack=False, interleaved_session=None):
     """Turn 1 asks a question; turn 2 is the user's answer, on ONE adapter.
 
     The adapter instance is shared deliberately — the pending question is
     carried on it between turns, which is the whole mechanism under test.
+
+    `interleaved_session` runs an unrelated session's turn BETWEEN the two, on
+    the same adapter. That is the production shape: agentcore_wrapper holds one
+    module-level adapter for every user in the container, and turns from
+    different sessions interleave freely.
+
     Returns (first_reply, second_reply, gateway_of_turn_2).
     """
     adapter = OpenClawAdapter()
@@ -556,7 +578,7 @@ def two_turn_replay(first_events, answer_text, resume_events, question_expired=F
     zero_usage = {"model_calls": 0, "input": 0, "output": 0,
                   "cache_read": 0, "cache_write": 0}
 
-    def run(gateway, text):
+    def run(gateway, text, session="session-replay"):
         fake_websocket = mock.Mock()
         fake_websocket.create_connection.return_value = gateway
         fake_websocket.WebSocketTimeoutException = _FakeTimeout
@@ -564,14 +586,20 @@ def two_turn_replay(first_events, answer_text, resume_events, question_expired=F
              mock.patch.object(OpenClawAdapter, "_read_turn_usage",
                                return_value=zero_usage), \
              mock.patch.object(harness_adapter, "record_failure"):
-            return adapter._process_once(text, "session-replay")
+            return adapter._process_once(text, session)
 
     g1 = FakeGateway(first_events)
     first = run(g1, "Give me a quartile growth report")
+
+    if interleaved_session:
+        # Someone else's turn, start to finish, while our question waits.
+        run(FakeGateway([says("Unrelated answer.")]),
+            "What's the weather", interleaved_session)
+
     # The gateway is now holding that question open, as it does in production.
     g2 = FakeGateway([], resume_events=resume_events,
-                     question_expired=question_expired)
-    g2.question_status = "pending"
+                     question_expired=question_expired,
+                     resume_before_ack=resume_before_ack).hold_question()
     second = run(g2, answer_text)
     return first.text, second.text, g2
 
@@ -647,6 +675,49 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         )
         sends = [m for m in g2.sent if m.get("method") == "chat.send"]
         self.assertEqual(len(sends), 1, "expired question must fall back to chat.send")
+
+    def test_another_users_turn_in_between_does_not_drop_the_question(self):
+        # agentcore_wrapper holds ONE module-level adapter for every user in
+        # the container, so turns from different sessions interleave. Holding
+        # the pending question in a single scalar let any unrelated session's
+        # turn clear it, dropping this user straight back onto the abort path
+        # — the original bug, now intermittent and multi-user only.
+        _, second, g2 = two_turn_replay(
+            [ASK], "Keep going", [says("Grades 3-5 written.")],
+            interleaved_session="someone-else",
+        )
+        self.assertEqual(g2.question_status, "answered")
+        self.assertFalse(
+            g2.aborted_a_pending_question,
+            "another session's turn let the pre-send abort kill this question",
+        )
+        self.assertIn("Grades 3-5 written", second)
+
+    def test_the_other_session_does_not_answer_our_question(self):
+        # The converse: an unrelated turn must never resolve a question it did
+        # not ask, which is what a global scalar would have allowed.
+        adapter_sends = []
+
+        _, _, g2 = two_turn_replay(
+            [ASK], "Keep going", [says("Done.")],
+            interleaved_session="someone-else",
+        )
+        adapter_sends.extend(g2.sent)
+        resolves = [m for m in adapter_sends if m.get("method") == "question.resolve"]
+        self.assertEqual(len(resolves), 1)
+        self.assertEqual(resolves[0]["params"]["id"], "q-abc")
+
+    def test_resumed_output_arriving_before_the_ack_is_not_lost(self):
+        # question.resolve is a req/res, but the resumed run streams onto the
+        # SAME socket and nothing orders it after the ack. Frames read during
+        # the resolve wait used to be discarded, so a run that answered fast
+        # lost its opening events — or its whole reply.
+        _, second, g2 = two_turn_replay(
+            [ASK], "Keep going", [says("Sheet shared: the link.")],
+            resume_before_ack=True,
+        )
+        self.assertEqual(g2.question_status, "answered")
+        self.assertIn("Sheet shared", second)
 
     def test_a_turn_with_no_pending_question_is_unchanged(self):
         # The ordinary path must not grow a question.resolve call.

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -787,6 +787,22 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         )
         self.assertIn("Sheet shared", second)
 
+    def test_a_multi_question_ask_answers_every_sub_question(self):
+        # One reply, several sub-questions. Answering only the first leaves the
+        # rest unanswered, and a partial resolve the gateway refuses lands us
+        # back on the abort path. Redundant beats refused.
+        multi = dict(ASK)
+        multi["payload"] = dict(ASK["payload"], questions=[
+            {"id": "grades", "question": "Which grades?"},
+            {"id": "year", "question": "Which year?"},
+        ])
+        _, _, g2 = two_turn_replay([multi], "K-5, 2025-26", [says("Done.")])
+        self.assertEqual(
+            g2.question_answers,
+            {"answers": {"grades": ["K-5, 2025-26"], "year": ["K-5, 2025-26"]}},
+        )
+        self.assertEqual(g2.question_status, "answered")
+
     def test_a_failed_resolve_still_counts_toward_reported_latency(self):
         # A resolve that times out and falls back has already burned the ack
         # wait and the abort drain — time the user spent waiting. Restarting
@@ -937,4 +953,44 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         self.assertIn("Plain answer.", result.text)
         self.assertEqual(
             [m for m in g.sent if m.get("method") == "question.resolve"], []
+        )
+
+
+class FramesFromRunIsEvidenceNotAGuess(unittest.TestCase):
+    """Direct contract for the sole evidence source behind "lost ack = accepted".
+
+    Exercised through the replay tests too, but this is the check that decides
+    whether a user's answer gets executed a second time, so it is pinned on its
+    own rather than only inside a larger scenario.
+    """
+
+    def test_a_frame_from_that_run_counts(self):
+        self.assertTrue(
+            harness_adapter._frames_from_run(
+                [json.dumps(says("hi"))], TURN_RUN_ID)
+        )
+
+    def test_a_frame_from_another_run_does_not(self):
+        self.assertFalse(
+            harness_adapter._frames_from_run(
+                [json.dumps(foreign_says("hi"))], TURN_RUN_ID)
+        )
+
+    def test_no_frames_is_no_evidence(self):
+        self.assertFalse(harness_adapter._frames_from_run([], TURN_RUN_ID))
+
+    def test_malformed_frames_are_skipped_not_raised(self):
+        # A frame we cannot parse is not evidence, and must not take the turn
+        # down either — this runs on the path that decides whether to re-send.
+        frames = ["{not json", json.dumps(["a", "list"]), json.dumps({}),
+                  json.dumps({"payload": None}), json.dumps(says("hi"))]
+        self.assertTrue(harness_adapter._frames_from_run(frames, TURN_RUN_ID))
+        self.assertFalse(
+            harness_adapter._frames_from_run(frames[:-1], TURN_RUN_ID))
+
+    def test_a_null_run_id_never_matches_a_payload_without_one(self):
+        # Guards the caller's `if asking_run and ...`: two unknowns must not
+        # compare equal into a false "it resumed".
+        self.assertFalse(
+            harness_adapter._frames_from_run([json.dumps({"payload": {}})], None)
         )

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -708,6 +708,63 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         self.assertEqual(len(resolves), 1)
         self.assertEqual(resolves[0]["params"]["id"], "q-abc")
 
+    def test_a_foreign_run_cannot_contribute_to_the_resumed_reply(self):
+        # turn_run_id is normally learned from the chat.send `started` res, and
+        # BOTH fences are gated on it being truthy. A resumed-question turn
+        # sends no chat.send — so without seeding it from the asking run, the
+        # fence was off for exactly the turns that listen longest to a socket
+        # carrying other runs. That is the 2026-08-14 incident's setup.
+        _, second, _ = two_turn_replay(
+            [ASK], "Keep going",
+            [foreign_says("STOLEN: someone else's answer."),
+             says("Grades 3-5 written.")],
+        )
+        self.assertNotIn("STOLEN", second)
+        self.assertIn("Grades 3-5 written", second)
+
+    def test_the_asking_runs_own_output_is_not_fenced_out(self):
+        # The converse, and the way a fence like this usually breaks: seeding
+        # the wrong id would silence the run we are actually waiting for.
+        _, second, _ = two_turn_replay(
+            [ASK], "Keep going", [says("Sheet shared.")]
+        )
+        self.assertIn("Sheet shared", second)
+
+    def test_a_flood_before_the_ack_falls_back_instead_of_hanging(self):
+        # The cap must not silently truncate. Discarding frames past it takes
+        # the final event with them and hangs the turn to its full deadline —
+        # the exact failure the buffer exists to prevent. Falling back to
+        # abort + chat.send costs the in-flight work but answers the user.
+        with mock.patch.object(harness_adapter, "MAX_RESOLVE_BUFFERED_FRAMES", 2):
+            _, second, g2 = two_turn_replay(
+                [ASK], "Keep going",
+                [says(f"chunk {i} ") for i in range(6)],
+                resume_before_ack=True,
+            )
+        sends = [m for m in g2.sent if m.get("method") == "chat.send"]
+        self.assertEqual(len(sends), 1, "overflow must fall back, not hang")
+        self.assertNotIn("stalled", second)
+
+    def test_pending_questions_are_capped_and_evict_oldest_first(self):
+        adapter = OpenClawAdapter()
+        with mock.patch.object(harness_adapter, "MAX_PENDING_QUESTIONS", 3):
+            for n in range(5):
+                adapter._remember_pending_question(
+                    f"session-{n}", f"q-{n}", ["only"], f"run-{n}"
+                )
+        self.assertEqual(len(adapter._pending_questions), 3)
+        # Oldest gone, newest kept — a session that asked and walked away must
+        # not pin an entry for the container's life.
+        self.assertNotIn("session-0", adapter._pending_questions)
+        self.assertIn("session-4", adapter._pending_questions)
+
+    def test_re_asking_in_one_session_replaces_rather_than_accumulates(self):
+        adapter = OpenClawAdapter()
+        adapter._remember_pending_question("s", "q-first", ["a"], "run-1")
+        adapter._remember_pending_question("s", "q-second", ["b"], "run-2")
+        self.assertEqual(len(adapter._pending_questions), 1)
+        self.assertEqual(adapter._pending_questions["s"]["id"], "q-second")
+
     def test_the_kill_switch_restores_the_old_behaviour_exactly(self):
         # OPENCLAW_QUESTION_RESOLVE=0 must back this out to what shipped
         # before — abandon the question, abort, re-send — without an image

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -35,6 +35,7 @@ import collections
 import json
 import os
 import sys
+import time
 import unittest
 from unittest import mock
 
@@ -785,6 +786,27 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
             [ASK], "Keep going", [says("Sheet shared.")]
         )
         self.assertIn("Sheet shared", second)
+
+    def test_a_failed_resolve_still_counts_toward_reported_latency(self):
+        # A resolve that times out and falls back has already burned the ack
+        # wait and the abort drain — time the user spent waiting. Restarting
+        # the clock afterwards reports the SLOWEST turns as the fastest, which
+        # is worse than not measuring them at all.
+        original = OpenClawAdapter._resolve_pending_question
+
+        def slow(adapter_self, *args, **kwargs):
+            time.sleep(0.15)
+            return original(adapter_self, *args, **kwargs)
+
+        adapter, run = turn_runner()
+        run(FakeGateway([ASK]), "Quartile growth report")
+        # Expired: the resolve is refused, so this turn takes the fallback.
+        g2 = FakeGateway([says("Done.")], question_expired=True).hold_question()
+        with mock.patch.object(OpenClawAdapter, "_resolve_pending_question", slow):
+            result = run(g2, "Keep going")
+        sends = [m for m in g2.sent if m.get("method") == "chat.send"]
+        self.assertEqual(len(sends), 1, "this test must exercise the fallback")
+        self.assertGreaterEqual(result.latency_ms, 150)
 
     def test_a_lost_ack_with_the_run_streaming_is_not_treated_as_a_refusal(self):
         # The ack and the resumed run's output are unordered. If the ack is

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -776,20 +776,29 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         )
         self.assertIn("Sheet shared", second)
 
-    def test_a_flood_before_the_ack_falls_back_instead_of_hanging(self):
-        # The cap must not silently truncate. Discarding frames past it takes
-        # the final event with them and hangs the turn to its full deadline —
-        # the exact failure the buffer exists to prevent. Falling back to
-        # abort + chat.send costs the in-flight work but answers the user.
+    def test_a_flood_before_the_ack_truncates_but_never_double_sends(self):
+        # Only a run already streaming can flood this window — which means the
+        # gateway already accepted the answer. Falling back to abort +
+        # chat.send would then run the user's answer a SECOND time, with the
+        # first run's side effects already partly done. Dropping everything
+        # instead loses the terminal chat event and stalls the turn.
+        #
+        # So the narration is dropped and the chat channel is not: a visibly
+        # truncated reply, rather than a silent double-execution or a stall.
         with mock.patch.object(harness_adapter, "MAX_RESOLVE_BUFFERED_FRAMES", 2):
             _, second, g2 = two_turn_replay(
                 [ASK], "Keep going",
-                [says(f"chunk {i} ") for i in range(6)],
+                [says(f"chunk{i} ") for i in range(6)],
                 resume_before_ack=True,
             )
         sends = [m for m in g2.sent if m.get("method") == "chat.send"]
-        self.assertEqual(len(sends), 1, "overflow must fall back, not hang")
+        self.assertEqual(sends, [], "the answer must never be sent twice")
+        aborts = [m for m in g2.sent if m.get("method") == "chat.abort"]
+        self.assertEqual(aborts, [], "the accepted run must not be aborted")
+        self.assertEqual(g2.question_status, "answered")
+        # Completed rather than stalled, and what survived is real text.
         self.assertNotIn("stalled", second)
+        self.assertIn("chunk0", second)
 
     def test_pending_questions_are_capped_and_evict_oldest_first(self):
         adapter = OpenClawAdapter()

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -559,6 +559,34 @@ class StructuredQuestionsReachTheUser(unittest.TestCase):
         self.assertIn("I need a bit more information", text)
 
 
+def turn_runner():
+    """One adapter, many turns — the production shape.
+
+    agentcore_wrapper holds a single module-level OpenClawAdapter for the life
+    of the container, so state carried between turns (the pending question) is
+    carried on THIS object. Sharing it is the point, not a shortcut.
+
+    Returns (adapter, run) where run(gateway, text, session, env) -> TurnResult.
+    """
+    adapter = OpenClawAdapter()
+    adapter._ready = True
+    zero_usage = {"model_calls": 0, "input": 0, "output": 0,
+                  "cache_read": 0, "cache_write": 0}
+
+    def run(gateway, text, session="session-replay", env=None):
+        fake_websocket = mock.Mock()
+        fake_websocket.create_connection.return_value = gateway
+        fake_websocket.WebSocketTimeoutException = _FakeTimeout
+        with mock.patch.dict(sys.modules, {"websocket": fake_websocket}), \
+             mock.patch.dict(os.environ, env or {}), \
+             mock.patch.object(OpenClawAdapter, "_read_turn_usage",
+                               return_value=zero_usage), \
+             mock.patch.object(harness_adapter, "record_failure"):
+            return adapter._process_once(text, session)
+
+    return adapter, run
+
+
 def two_turn_replay(first_events, answer_text, resume_events, question_expired=False,
                     resume_before_ack=False, interleaved_session=None, env=None):
     """Turn 1 asks a question; turn 2 is the user's answer, on ONE adapter.
@@ -573,21 +601,10 @@ def two_turn_replay(first_events, answer_text, resume_events, question_expired=F
 
     Returns (first_reply, second_reply, gateway_of_turn_2).
     """
-    adapter = OpenClawAdapter()
-    adapter._ready = True
-    zero_usage = {"model_calls": 0, "input": 0, "output": 0,
-                  "cache_read": 0, "cache_write": 0}
+    adapter, run_on = turn_runner()
 
     def run(gateway, text, session="session-replay"):
-        fake_websocket = mock.Mock()
-        fake_websocket.create_connection.return_value = gateway
-        fake_websocket.WebSocketTimeoutException = _FakeTimeout
-        with mock.patch.dict(sys.modules, {"websocket": fake_websocket}), \
-             mock.patch.dict(os.environ, env or {}), \
-             mock.patch.object(OpenClawAdapter, "_read_turn_usage",
-                               return_value=zero_usage), \
-             mock.patch.object(harness_adapter, "record_failure"):
-            return adapter._process_once(text, session)
+        return run_on(gateway, text, session, env)
 
     g1 = FakeGateway(first_events)
     first = run(g1, "Give me a quartile growth report")
@@ -707,6 +724,35 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         resolves = [m for m in adapter_sends if m.get("method") == "question.resolve"]
         self.assertEqual(len(resolves), 1)
         self.assertEqual(resolves[0]["params"]["id"], "q-abc")
+
+    def test_a_second_question_asked_inside_the_resumed_run_also_resolves(self):
+        # The agent asks, is answered, and asks AGAIN from the resumed run —
+        # a clarify-then-clarify-again exchange. The second ask arrives on the
+        # resumed listen path rather than after a chat.send, so it has to be
+        # remembered the same way or turn 3 falls back onto the abort that
+        # started this whole bug.
+        adapter, run = turn_runner()
+
+        second_ask = dict(ASK)
+        second_ask["payload"] = dict(ASK["payload"], id="q-def")
+
+        run(FakeGateway([ASK]), "Quartile growth report for Purdy")
+
+        # Turn 2: answers q-abc, and the resumed run immediately asks q-def.
+        g2 = FakeGateway([], resume_events=[second_ask]).hold_question()
+        second = run(g2, "Keep going")
+        self.assertEqual(g2.question_status, "answered")
+        self.assertIn("Want me to finish", second.text)
+        self.assertEqual(adapter._pending_questions["session-replay"]["id"], "q-def")
+
+        # Turn 3: the follow-up answer must resolve q-def, not abort it.
+        g3 = FakeGateway([], resume_events=[says("Sheet shared.")]).hold_question()
+        third = run(g3, "Yes, all grades")
+        self.assertEqual(g3.question_status, "answered")
+        self.assertFalse(g3.aborted_a_pending_question)
+        resolves = [m for m in g3.sent if m.get("method") == "question.resolve"]
+        self.assertEqual(resolves[0]["params"]["id"], "q-def")
+        self.assertIn("Sheet shared", third.text)
 
     def test_a_foreign_run_cannot_contribute_to_the_resumed_reply(self):
         # turn_run_id is normally learned from the chat.send `started` res, and

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -560,7 +560,7 @@ class StructuredQuestionsReachTheUser(unittest.TestCase):
 
 
 def two_turn_replay(first_events, answer_text, resume_events, question_expired=False,
-                    resume_before_ack=False, interleaved_session=None):
+                    resume_before_ack=False, interleaved_session=None, env=None):
     """Turn 1 asks a question; turn 2 is the user's answer, on ONE adapter.
 
     The adapter instance is shared deliberately — the pending question is
@@ -583,6 +583,7 @@ def two_turn_replay(first_events, answer_text, resume_events, question_expired=F
         fake_websocket.create_connection.return_value = gateway
         fake_websocket.WebSocketTimeoutException = _FakeTimeout
         with mock.patch.dict(sys.modules, {"websocket": fake_websocket}), \
+             mock.patch.dict(os.environ, env or {}), \
              mock.patch.object(OpenClawAdapter, "_read_turn_usage",
                                return_value=zero_usage), \
              mock.patch.object(harness_adapter, "record_failure"):
@@ -706,6 +707,19 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         resolves = [m for m in adapter_sends if m.get("method") == "question.resolve"]
         self.assertEqual(len(resolves), 1)
         self.assertEqual(resolves[0]["params"]["id"], "q-abc")
+
+    def test_the_kill_switch_restores_the_old_behaviour_exactly(self):
+        # OPENCLAW_QUESTION_RESOLVE=0 must back this out to what shipped
+        # before — abandon the question, abort, re-send — without an image
+        # build. An escape hatch that half-works is worse than none.
+        _, _, g2 = two_turn_replay(
+            [ASK], "Keep going", [says("Done.")],
+            env={"OPENCLAW_QUESTION_RESOLVE": "0"},
+        )
+        resolves = [m for m in g2.sent if m.get("method") == "question.resolve"]
+        self.assertEqual(resolves, [])
+        sends = [m for m in g2.sent if m.get("method") == "chat.send"]
+        self.assertEqual(len(sends), 1, "disabled path must still deliver the message")
 
     def test_resumed_output_arriving_before_the_ack_is_not_lost(self):
         # question.resolve is a req/res, but the resumed run streams onto the


### PR DESCRIPTION
**"You never abort anything" was correct.** This adapter did, on every turn.

## The loop, all four links evidenced

1. The agent asks → the gateway holds a question in `pending` with `expiresAtMs`, waiting for `question.resolve`
2. This adapter treated the event as **terminal** and walked away. Its own comment said why: *"there is no channel to answer a question"*
3. The user's reply opened a new turn, whose **pre-send `chat.abort`** fired
4. The bundle's ask-user tool registers an abort listener calling `cancelPendingQuestion("run-abort")` — destroying the question

The model then reported that its question had been aborted — **accurately**. Five rounds of prompt rules told it to stop saying a true thing, which is why none worked.

## There is a channel

From the pinned bundle:

```js
QuestionResolveParamsSchema = Union(
  { id, answers: { answers: Record<questionId, string[]> }, resolvedBy? },
  { id, cancel: true, resolvedBy? })
```

OpenClaw's own plain-text path sends `question.resolve {id, answers, resolvedBy: "plain-text"}`. **Our adapter called it zero times.**

## The fix

The pending question id is carried on the adapter between turns. On the next turn we resolve it with the user's text **before** anything can cancel it, and skip the pre-send abort — the two are mutually exclusive by construction. When the gateway answers, the **original run resumes** on the same socket and we listen to it rather than issuing a second `chat.send` (OpenClaw's claim path returns without queueing for the same reason).

**Fails open:** expired, cancelled, unknown id, or any transport error falls back to a normal `chat.send`. A question we cannot answer must never block a message.

## Proven, not asserted

`FakeGateway` now models the real lifecycle — `pending`/`answered`/`cancelled`, and `chat.abort` cancelling a pending question the way the abort listener does. A two-turn replay on one adapter reproduces production exactly.

**Reverting the fix fails four tests with the production symptom:**

```
'cancelled' != 'answered'
None != {'answers': {'continue_report': ['Keep going']}}
chat.send issued when it must not be
the resumed run's reply never reaches the user
```

## Also in this commit

- **`build_tab.py` heads classroom columns with the teacher**, per `layout.md` (`Teacher1 | … | School | District`). It emitted raw section ids, so a principal saw `274893` and the agent hand-wrote relabeling scripts — the exact glue `build_tab` exists to remove. The spec was in the same directory; my test asserted my implementation instead of it, and now asserts the spec.
- Sections with no Lead Teacher render `(Not on file) (id)` so it can't be mistaken for a failed lookup. The id is retained because names collide.
- **The roster defines the grade span.** The agent announced *"Minter Creek is a K-2 school (it's PSD's K-2 primary)"*, invented the justification, and scoped a whole report to it. It's K-5. `SKILL.md` now forbids stating a span it didn't query.

111 tests across the skill's scripts and replay harness; 258 across the image suites; bootstrap budget clean.
