### PR TITLE
fix(agent): read questionId, not id — #1660 shipped as a no-op

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -367,6 +367,11 @@ RESOLVE_ACK_WAIT_S = 10
 # NOTE the per-question key is `questionId`, NOT `id`, and QuestionSchema is a
 # closedObject so `id` is not merely absent, it is rejected.
 
+# Upstream's regex, character class included: `-` is a valid separator, so it
+# is also excluded from the key. A hyphenated header ("Multi-Select: yes")
+# therefore parses as key "multi" and falls through to positional matching.
+# That is upstream's behaviour and this is a port — diverging here would mean
+# our keyed form accepts headers the gateway's own plain-text path does not.
 _KEYED_ANSWER_RE = re.compile(r"^\s*([^:=-]+?)\s*[:=-]\s*(.+?)\s*$")
 _DIGITS_RE = re.compile(r"\d+")
 
@@ -427,6 +432,8 @@ def _build_question_answers(questions: list, text: str) -> dict:
     answers: dict = {}
     if len(questions) == 1:
         question = questions[0]
+        if not question.get("questionId"):
+            return answers
         normalized = _normalize_question_answer(text, question)
         answers[question["questionId"]] = [normalized] if normalized else []
         return answers
@@ -434,6 +441,10 @@ def _build_question_answers(questions: list, text: str) -> dict:
     keyed = _parse_keyed_answers(text)
     lines = [line.strip() for line in re.split(r"\r?\n", text or "")]
     for index, question in enumerate(questions):
+        # `index` still advances for a slot we cannot answer — that is the
+        # whole point of holding it.
+        if not question.get("questionId"):
+            continue
         answer = (
             keyed.get(str(question.get("questionId") or "").lower())
             or keyed.get(str(question.get("header") or "").lower())
@@ -1507,6 +1518,14 @@ class OpenClawAdapter(HarnessAdapter):
             return False, [], None
         # Upstream's own mapping, ported — see _build_question_answers.
         answers = _build_question_answers(questions, message)
+        if not answers:
+            # Every question was unusable. Sending an empty answers map would
+            # mark the question answered with nothing in it; fall back and let
+            # the user's message run as its own turn.
+            logger.warning(
+                "pending question had no answerable questions; falling back"
+            )
+            return False, [], None
 
         # Popped before every failure branch below, including a transport
         # error, and never restored. That is deliberate rather than an
@@ -2563,20 +2582,41 @@ class OpenClawAdapter(HarnessAdapter):
                             # `id` is still accepted as a fallback so a future
                             # rename degrades instead of silently reverting to
                             # that same no-op.
+                            #
+                            # POSITION IS PRESERVED, including for entries we
+                            # cannot use. The multi-question fallback answers
+                            # question N with line N, so dropping a malformed
+                            # entry here would silently shift every later
+                            # question's answer by one. An unusable entry
+                            # keeps its slot with questionId None and is
+                            # skipped when the answers are built.
                             pending_questions = []
                             for entry in (q_payload.get("questions") or []):
                                 if not isinstance(entry, dict):
+                                    pending_questions.append({"questionId": None})
                                     continue
                                 qid = entry.get("questionId") or entry.get("id")
-                                if not (isinstance(qid, str) and qid):
-                                    continue
                                 pending_questions.append({
-                                    "questionId": qid,
+                                    "questionId": (
+                                        qid if isinstance(qid, str) and qid
+                                        else None
+                                    ),
                                     "header": entry.get("header"),
                                     "question": entry.get("question"),
                                     "options": entry.get("options") or [],
                                     "isOther": entry.get("isOther"),
                                 })
+                            unusable = sum(
+                                1 for q in pending_questions
+                                if not q.get("questionId")
+                            )
+                            if unusable:
+                                logger.warning(
+                                    "question event carried %d question(s) with "
+                                    "no usable id; their slots are held so the "
+                                    "others still line up",
+                                    unusable,
+                                )
                             # The run that asked is the run that resumes. Prefer
                             # what the event says; fall back to this turn's own
                             # run, which is the same run by construction — the

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -345,6 +345,109 @@ MAX_RESOLVE_TERMINAL_FRAMES = 16
 RESOLVE_ACK_WAIT_S = 10
 
 
+# --- question answering -------------------------------------------------
+#
+# Ported from the pinned OpenClaw bundle (2026.7.2-beta.5,
+# app/dist/openclaw-tools-Be4wAI1K.js: buildAgentHarnessUserInputAnswers,
+# normalizeAgentHarnessUserInputAnswer, parseKeyedAnswers). Deliberately a
+# port and not an interpretation — this decides what the model reads back as
+# the user's answer, and inventing a third dialect here means the agent's own
+# ask_user tool is answered in a language it does not speak.
+#
+# Wire shape, from the gateway protocol schemas in the same image
+# (packages/gateway-protocol/src/schema/questions.ts):
+#
+#   question.requested payload = QuestionRecordSchema
+#     { id, questions: [QuestionSchema], runId?, sessionKey?, status,
+#       createdAtMs, expiresAtMs, ... }
+#   QuestionSchema = { questionId, header, question, options: [{label,
+#                      description?}], multiSelect?, isOther?, isSecret? }
+#   question.resolve = { id, answers: { answers: { <questionId>: [str] } } }
+#
+# NOTE the per-question key is `questionId`, NOT `id`, and QuestionSchema is a
+# closedObject so `id` is not merely absent, it is rejected.
+
+_KEYED_ANSWER_RE = re.compile(r"^\s*([^:=-]+?)\s*[:=-]\s*(.+?)\s*$")
+_DIGITS_RE = re.compile(r"\d+")
+
+
+def _parse_keyed_answers(text: str) -> dict:
+    """`header: value` lines -> {key: value}, keys lowercased."""
+    answers: dict = {}
+    for line in re.split(r"\r?\n", text or ""):
+        match = _KEYED_ANSWER_RE.match(line)
+        if not match:
+            continue
+        key = (match.group(1) or "").strip().lower()
+        value = (match.group(2) or "").strip()
+        if key and value:
+            answers[key] = value
+    return answers
+
+
+def _normalize_question_answer(answer: str, question: dict):
+    """One reply -> the option label it names, or the raw text, or None.
+
+    None means "no answer" and the tool renders it to the model literally as
+    `(no answer)`. That is only reachable for a fixed-choice question, and
+    ask_user hardcodes isOther=true on every question it builds, so in
+    practice free text always survives. Kept anyway: the gateway accepts
+    questions from sources other than ask_user.
+    """
+    trimmed = (answer or "").strip()
+    options = [o for o in (question.get("options") or []) if isinstance(o, dict)]
+
+    if _DIGITS_RE.fullmatch(trimmed):
+        index = int(trimmed) - 1
+        if 0 <= index < len(options):
+            # Matches upstream: an in-range index wins outright and does not
+            # fall through to the label comparison below.
+            label = options[index].get("label")
+            return label if isinstance(label, str) and label else None
+
+    for option in options:
+        label = option.get("label")
+        if isinstance(label, str) and label.lower() == trimmed.lower():
+            return label
+
+    if options and not question.get("isOther"):
+        return None
+    return trimmed or None
+
+
+def _build_question_answers(questions: list, text: str) -> dict:
+    """{questionId: [answer]} for the whole ask, upstream's mapping.
+
+    One question: the reply IS the answer. Several: match by question id,
+    header, question text or 1-based position (`header: value` lines), then
+    fall back to the Nth line. Broadcasting the same text to every question —
+    what this adapter did before — is not one of the options; it answers
+    "which grades?" and "which year?" identically.
+    """
+    answers: dict = {}
+    if len(questions) == 1:
+        question = questions[0]
+        normalized = _normalize_question_answer(text, question)
+        answers[question["questionId"]] = [normalized] if normalized else []
+        return answers
+
+    keyed = _parse_keyed_answers(text)
+    lines = [line.strip() for line in re.split(r"\r?\n", text or "")]
+    for index, question in enumerate(questions):
+        answer = (
+            keyed.get(str(question.get("questionId") or "").lower())
+            or keyed.get(str(question.get("header") or "").lower())
+            or keyed.get(str(question.get("question") or "").lower())
+            or keyed.get(str(index + 1))
+            or (lines[index] if index < len(lines) else "")
+        )
+        normalized = (
+            _normalize_question_answer(answer, question) if answer else None
+        )
+        answers[question["questionId"]] = [normalized] if normalized else []
+    return answers
+
+
 def _frames_from_run(frames, run_id) -> bool:
     """True when any buffered frame belongs to `run_id`.
 
@@ -1306,7 +1409,7 @@ class OpenClawAdapter(HarnessAdapter):
 
 
     def _remember_pending_question(
-        self, session_id, pending_id, question_ids, run_id
+        self, session_id, pending_id, questions, run_id
     ):
         """Hold one pending question per session, oldest evicted first.
 
@@ -1332,7 +1435,10 @@ class OpenClawAdapter(HarnessAdapter):
         self._pending_questions.pop(session_id, None)
         self._pending_questions[session_id] = {
             "id": pending_id,
-            "question_ids": question_ids,
+            # Whole questions, not just ids: answering correctly needs each
+            # question's options and isOther flag — see
+            # _normalize_question_answer.
+            "questions": questions,
             "run_id": run_id,
         }
         while len(self._pending_questions) > MAX_PENDING_QUESTIONS:
@@ -1396,19 +1502,11 @@ class OpenClawAdapter(HarnessAdapter):
             logger.info("question.resolve disabled by OPENCLAW_QUESTION_RESOLVE=0")
             return False, [], None
 
-        question_ids = pending.get("question_ids") or []
-        if not question_ids:
+        questions = pending.get("questions") or []
+        if not questions:
             return False, [], None
-        # One free-text reply, N sub-questions: every id gets the same text.
-        #
-        # OUR CHOICE, not a verified mirror of upstream's plain-text path —
-        # the pinned bundle was not available to check when this was written,
-        # and it is recorded that way rather than implied to be authoritative.
-        # The reasoning: answering only the first id leaves the rest unanswered,
-        # and a partial resolve the gateway refuses puts us straight back on
-        # the abort-and-cancel path this whole mechanism removes. A redundant
-        # answer the agent can parse beats a refused one.
-        answers = {qid: [message] for qid in question_ids}
+        # Upstream's own mapping, ported — see _build_question_answers.
+        answers = _build_question_answers(questions, message)
 
         # Popped before every failure branch below, including a transport
         # error, and never restored. That is deliberate rather than an
@@ -2455,12 +2553,30 @@ class OpenClawAdapter(HarnessAdapter):
                         # killed by the next turn's pre-send abort.
                         pending_id = q_payload.get("id")
                         if isinstance(pending_id, str) and pending_id:
-                            question_ids = [
-                                entry.get("id")
-                                for entry in (q_payload.get("questions") or [])
-                                if isinstance(entry, dict)
-                                and isinstance(entry.get("id"), str)
-                            ]
+                            # `questionId`, per QuestionSchema. This read
+                            # `id`, which that closedObject does not even
+                            # permit — so every question yielded None, the
+                            # id list came back empty, and the resolve was
+                            # skipped for a fallback to the abort that started
+                            # all of this. The fix shipped as a no-op.
+                            #
+                            # `id` is still accepted as a fallback so a future
+                            # rename degrades instead of silently reverting to
+                            # that same no-op.
+                            pending_questions = []
+                            for entry in (q_payload.get("questions") or []):
+                                if not isinstance(entry, dict):
+                                    continue
+                                qid = entry.get("questionId") or entry.get("id")
+                                if not (isinstance(qid, str) and qid):
+                                    continue
+                                pending_questions.append({
+                                    "questionId": qid,
+                                    "header": entry.get("header"),
+                                    "question": entry.get("question"),
+                                    "options": entry.get("options") or [],
+                                    "isOther": entry.get("isOther"),
+                                })
                             # The run that asked is the run that resumes. Prefer
                             # what the event says; fall back to this turn's own
                             # run, which is the same run by construction — the
@@ -2469,7 +2585,8 @@ class OpenClawAdapter(HarnessAdapter):
                             if not (isinstance(asked_by, str) and asked_by):
                                 asked_by = turn_run_id
                             self._remember_pending_question(
-                                session_id, pending_id, question_ids, asked_by
+                                session_id, pending_id, pending_questions,
+                                asked_by
                             )
                         got_final = True
                         break

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -633,6 +633,17 @@ def two_turn_replay(first_events, answer_text, resume_events, question_expired=F
     return first.text, second.text, g2
 
 
+# QuestionRecordSchema, read from the pinned bundle's gateway-protocol
+# schemas (2026.7.2-beta.5, packages/gateway-protocol/src/schema/questions.ts)
+# rather than authored to match the adapter. The per-question key is
+# `questionId`; QuestionSchema is a closedObject, so `id` is not just absent
+# from real traffic, it is rejected by it. The previous fixture used `id`,
+# which is precisely how the adapter's `entry.get("id")` bug stayed green
+# through eleven rounds of review — the warning in this module's docstring,
+# earned.
+#
+# ask_user hardcodes isOther=true on every question it builds
+# (normalizeAskUserParams), so it is set here too.
 ASK = {
     "type": "event",
     "event": "question.requested",
@@ -641,11 +652,15 @@ ASK = {
         "runId": TURN_RUN_ID,
         "sessionKey": "agent:main:replay",
         "status": "pending",
+        "createdAtMs": 0,
+        "expiresAtMs": 600000,
         "questions": [{
-            "id": "continue_report",
+            "questionId": "continue_report",
+            "header": "Continue",
             "question": "Want me to finish and post the link now?",
             "options": [{"label": "Keep going to completion (Recommended)"},
                         {"label": "Stop here"}],
+            "isOther": True,
         }],
     },
 }
@@ -793,13 +808,17 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         # back on the abort path. Redundant beats refused.
         multi = dict(ASK)
         multi["payload"] = dict(ASK["payload"], questions=[
-            {"id": "grades", "question": "Which grades?"},
-            {"id": "year", "question": "Which year?"},
+            {"questionId": "grades", "header": "Grades",
+             "question": "Which grades?", "options": [], "isOther": True},
+            {"questionId": "year", "header": "Year",
+             "question": "Which year?", "options": [], "isOther": True},
         ])
-        _, _, g2 = two_turn_replay([multi], "K-5, 2025-26", [says("Done.")])
+        # `header: value` lines, upstream's keyed form.
+        _, _, g2 = two_turn_replay(
+            [multi], "Grades: K-5\nYear: 2025-26", [says("Done.")])
         self.assertEqual(
             g2.question_answers,
-            {"answers": {"grades": ["K-5, 2025-26"], "year": ["K-5, 2025-26"]}},
+            {"answers": {"grades": ["K-5"], "year": ["2025-26"]}},
         )
         self.assertEqual(g2.question_status, "answered")
 
@@ -904,7 +923,10 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         frames = [json.dumps(says("narration"))] + [chat_frame] * 4
 
         adapter = OpenClawAdapter()
-        adapter._remember_pending_question("s", "q-abc", ["only"], TURN_RUN_ID)
+        adapter._remember_pending_question(
+            "s", "q-abc",
+            [{"questionId": "only", "options": [], "isOther": True}],
+            TURN_RUN_ID)
 
         ws = mock.Mock()
         ws.recv.side_effect = frames + [_FakeTimeout()]
@@ -933,7 +955,8 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
         with mock.patch.object(harness_adapter, "MAX_PENDING_QUESTIONS", 3):
             for n in range(5):
                 adapter._remember_pending_question(
-                    f"session-{n}", f"q-{n}", ["only"], f"run-{n}"
+                    f"session-{n}", f"q-{n}",
+                    [{"questionId": "only", "options": []}], f"run-{n}"
                 )
         self.assertEqual(len(adapter._pending_questions), 3)
         # Oldest gone, newest kept — a session that asked and walked away must
@@ -943,8 +966,10 @@ class AnsweringAQuestionDoesNotAbortIt(unittest.TestCase):
 
     def test_re_asking_in_one_session_replaces_rather_than_accumulates(self):
         adapter = OpenClawAdapter()
-        adapter._remember_pending_question("s", "q-first", ["a"], "run-1")
-        adapter._remember_pending_question("s", "q-second", ["b"], "run-2")
+        adapter._remember_pending_question(
+            "s", "q-first", [{"questionId": "a", "options": []}], "run-1")
+        adapter._remember_pending_question(
+            "s", "q-second", [{"questionId": "b", "options": []}], "run-2")
         self.assertEqual(len(adapter._pending_questions), 1)
         self.assertEqual(adapter._pending_questions["s"]["id"], "q-second")
 
@@ -1032,3 +1057,105 @@ class FramesFromRunIsEvidenceNotAGuess(unittest.TestCase):
         self.assertFalse(
             harness_adapter._frames_from_run([json.dumps({"payload": {}})], None)
         )
+
+
+class AnswerMappingMatchesTheGateway(unittest.TestCase):
+    """Ported from the pinned bundle; these pin the port, not my reading of it.
+
+    Source: 2026.7.2-beta.5, app/dist/openclaw-tools-Be4wAI1K.js —
+    buildAgentHarnessUserInputAnswers / normalizeAgentHarnessUserInputAnswer /
+    parseKeyedAnswers. The adapter previously broadcast the raw reply to every
+    question id, which answers "which grades?" and "which year?" identically
+    and sends "1" where the gateway expects an option label.
+    """
+
+    CHOICE = {
+        "questionId": "continue_report",
+        "header": "Continue",
+        "question": "Finish and post the link?",
+        "options": [{"label": "Keep going to completion (Recommended)"},
+                    {"label": "Stop here"}],
+        "isOther": True,
+    }
+
+    def test_a_number_selects_that_option_by_label(self):
+        answers = harness_adapter._build_question_answers([self.CHOICE], "1")
+        self.assertEqual(
+            answers,
+            {"continue_report": ["Keep going to completion (Recommended)"]},
+        )
+
+    def test_the_second_number_selects_the_second_option(self):
+        answers = harness_adapter._build_question_answers([self.CHOICE], "2")
+        self.assertEqual(answers, {"continue_report": ["Stop here"]})
+
+    def test_an_out_of_range_number_is_not_an_option(self):
+        # Falls through to the label comparison, then to free text because
+        # ask_user sets isOther.
+        answers = harness_adapter._build_question_answers([self.CHOICE], "9")
+        self.assertEqual(answers, {"continue_report": ["9"]})
+
+    def test_an_exact_option_label_is_matched_case_insensitively(self):
+        answers = harness_adapter._build_question_answers(
+            [self.CHOICE], "stop HERE")
+        self.assertEqual(answers, {"continue_report": ["Stop here"]})
+
+    def test_free_text_survives_because_ask_user_sets_isOther(self):
+        # The case Hagel actually hit. normalizeAskUserParams hardcodes
+        # isOther=true, so an off-menu reply is kept rather than discarded.
+        answers = harness_adapter._build_question_answers(
+            [self.CHOICE], "Keep going")
+        self.assertEqual(answers, {"continue_report": ["Keep going"]})
+
+    def test_a_fixed_choice_question_discards_an_off_menu_reply(self):
+        # Not reachable through ask_user, but the gateway takes questions from
+        # elsewhere. Upstream returns no answer, which the tool renders to the
+        # model as "(no answer)".
+        fixed = dict(self.CHOICE, isOther=False)
+        answers = harness_adapter._build_question_answers([fixed], "maybe")
+        self.assertEqual(answers, {"continue_report": []})
+
+    def test_several_questions_are_matched_by_header(self):
+        questions = [
+            {"questionId": "grades", "header": "Grades",
+             "question": "Which grades?", "options": [], "isOther": True},
+            {"questionId": "year", "header": "Year",
+             "question": "Which year?", "options": [], "isOther": True},
+        ]
+        answers = harness_adapter._build_question_answers(
+            questions, "Grades: K-5\nYear: 2025-26")
+        self.assertEqual(answers, {"grades": ["K-5"], "year": ["2025-26"]})
+
+    def test_several_questions_fall_back_to_one_line_each(self):
+        questions = [
+            {"questionId": "grades", "header": "Grades",
+             "question": "Which grades?", "options": [], "isOther": True},
+            {"questionId": "year", "header": "Year",
+             "question": "Which year?", "options": [], "isOther": True},
+        ]
+        answers = harness_adapter._build_question_answers(
+            questions, "K-5\n2025-26")
+        self.assertEqual(answers, {"grades": ["K-5"], "year": ["2025-26"]})
+
+    def test_a_missing_line_leaves_that_question_unanswered(self):
+        questions = [
+            {"questionId": "grades", "header": "Grades",
+             "question": "Which grades?", "options": [], "isOther": True},
+            {"questionId": "year", "header": "Year",
+             "question": "Which year?", "options": [], "isOther": True},
+        ]
+        answers = harness_adapter._build_question_answers(questions, "K-5")
+        self.assertEqual(answers, {"grades": ["K-5"], "year": []})
+
+    def test_one_reply_is_never_broadcast_to_every_question(self):
+        # The behaviour this replaces. Named so a future "simplification"
+        # back to a dict comprehension trips something.
+        questions = [
+            {"questionId": "grades", "header": "Grades",
+             "question": "Which grades?", "options": [], "isOther": True},
+            {"questionId": "year", "header": "Year",
+             "question": "Which year?", "options": [], "isOther": True},
+        ]
+        answers = harness_adapter._build_question_answers(
+            questions, "K-5, 2025-26")
+        self.assertNotEqual(answers["grades"], answers["year"])

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -1159,3 +1159,27 @@ class AnswerMappingMatchesTheGateway(unittest.TestCase):
         answers = harness_adapter._build_question_answers(
             questions, "K-5, 2025-26")
         self.assertNotEqual(answers["grades"], answers["year"])
+
+    def test_an_unusable_question_holds_its_slot(self):
+        # Dropping it would answer question 3 with line 2. This whole PR
+        # exists because a should-not-happen shape did happen, so the
+        # malformed case gets the same treatment as the happy one.
+        questions = [
+            {"questionId": "grades", "header": "Grades",
+             "question": "Which grades?", "options": [], "isOther": True},
+            {"questionId": None},
+            {"questionId": "year", "header": "Year",
+             "question": "Which year?", "options": [], "isOther": True},
+        ]
+        answers = harness_adapter._build_question_answers(
+            questions, "K-5\nignored\n2025-26")
+        self.assertEqual(answers, {"grades": ["K-5"], "year": ["2025-26"]})
+
+    def test_all_questions_unusable_yields_nothing_to_send(self):
+        # The caller turns this into a fallback rather than resolving a
+        # question with an empty answer map.
+        self.assertEqual(
+            harness_adapter._build_question_answers(
+                [{"questionId": None}], "anything"),
+            {},
+        )


### PR DESCRIPTION
Reading the pinned bundle to settle one "unverified" comment turned up that **the fix in #1660 could not have worked at all.**

## The bug

`question.requested`'s payload is `QuestionRecordSchema`, and each entry in its `questions` array is `QuestionSchema`:

```ts
{ questionId, header, question, options, multiSelect?, isOther?, isSecret? }
```

The adapter read `entry.get("id")`. **`QuestionSchema` is a `closedObject`** — `id` isn't merely absent from real traffic, it's rejected by it. So every question yielded `None`, the id list came back empty, and `_resolve_pending_question` returned `False` before sending anything. Every turn fell through to the pre-send `chat.abort`. The whole mechanism was inert.

It survived eleven rounds of review and every mutation I ran because **the `ASK` fixture was authored to match my code instead of captured from the gateway.** This module's own docstring warns about exactly this: *"If OpenClaw changes either shape, these tests keep passing while production breaks."* It wasn't a change — it was never right — and the warning applied anyway.

Fixtures now carry the schema as written in `packages/gateway-protocol/src/schema/questions.ts`. Restoring the `id` read fails three tests; before, it failed none. `id` stays as a fallback so a future rename degrades instead of silently reverting to the same no-op.

## The answer mapping was also wrong

#1660 broadcast the raw reply to every question id and labelled it *"OUR CHOICE, not a verified mirror of upstream"*. Now verified — wrong three ways:

| Reply | Upstream | #1660 |
|---|---|---|
| `"2"` on a question with options | that option's **label** | literal `"2"` |
| several questions | keyed by id/header/question/position (`Grades: K-5`), else the Nth line | same text to every id |
| off-menu text, `isOther` false | **no answer** | the raw text |

Ported rather than reinterpreted — this decides what the model reads back as the user's answer.

## The regression I checked for before porting

The off-menu-discard branch renders to the model as literally `(no answer)` (`answeredResult`), which would have regressed plain replies like "Keep going". It doesn't: `normalizeAskUserParams` hardcodes `isOther: true` on every `ask_user` question, so free text always survives. Pinned by `test_free_text_survives_because_ask_user_sets_isOther`.

## Evidence

Mutations: broadcasting fails 1 test, dropping the numeric-option lookup fails 2, restoring the `id` read fails 3.

807 image tests, bootstrap budget and config consistency clean.
