### PR TITLE
fix(agent-image): the cutover guard could not read a tag-pinned runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           infra/agent-image/test_iteration_telemetry.py \
           infra/agent-image/test_mantle_proxy.py \
           infra/agent-image/test_mantle_proxy_logging.py \
+          infra/agent-image/test_cutover_guard.py \
           infra/agent-image/test_check_bootstrap_budget.py \
           infra/agent-image/test_check_config_consistency.py \
           infra/agent-image/test_candidate_matrix.py \

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -724,22 +724,37 @@ CUTOVER_PATHS=(
 )
 
 deployed_commit() {
-  # Deployed image -> digest -> its commit- tag. Older images predate that tag
-  # but follow a <name>-<sha12> convention, so fall back to the trailing field.
-  local runtime_id digest tags t sha
+  # Deployed image -> its commit- tag. Older images predate that tag but follow
+  # a <name>-<sha12> convention, so fall back to the trailing field.
+  local runtime_id uri ref tags t sha
   runtime_id="$(aws cloudformation describe-stacks \
     --region "${REGION}" --stack-name "${STACK_NAME}" \
     --query 'Stacks[0].Outputs[?OutputKey==`AgentCoreRuntimeId`].OutputValue | [0]' \
     --output text 2>/dev/null)" || return 1
   [ -n "${runtime_id}" ] && [ "${runtime_id}" != "None" ] || return 1
-  digest="$(aws bedrock-agentcore-control get-agent-runtime \
+  uri="$(aws bedrock-agentcore-control get-agent-runtime \
     --region "${REGION}" --agent-runtime-id "${runtime_id}" \
     --query 'agentRuntimeArtifact.containerConfiguration.containerUri' \
     --output text 2>/dev/null)" || return 1
-  digest="${digest##*@}"
-  [ -n "${digest}" ] && [ "${digest}" != "None" ] || return 1
+  [ -n "${uri}" ] && [ "${uri}" != "None" ] || return 1
+  # A runtime is pinned EITHER by digest (repo@sha256:...) or by tag
+  # (repo:2026-08-14-run-fence), depending on whether the deploy passed
+  # agentImageDigest. This only handled the digest form: for a tag-pinned
+  # runtime `${uri##*@}` is a no-op, so the whole URI was passed as an
+  # imageDigest, the lookup failed, and the guard fell to "cannot determine"
+  # and demanded a drain. prod has been tag-pinned the entire time, so every
+  # prod build since 2026-08-03 raised a cutover that was never real.
+  #
+  # Crying wolf on every prod build is not a safe default. It is how a guard
+  # gets ignored on the one build where it matters — the exact failure the
+  # comment above says this rewrite existed to fix.
+  case "${uri}" in
+    *@*) ref="imageDigest=${uri##*@}" ;;
+    *:*) ref="imageTag=${uri##*:}" ;;
+    *)   return 1 ;;
+  esac
   tags="$(aws ecr describe-images --region "${REGION}" \
-    --repository-name "${ECR_URI##*/}" --image-ids "imageDigest=${digest}" \
+    --repository-name "${ECR_URI##*/}" --image-ids "${ref}" \
     --query 'imageDetails[0].imageTags' --output text 2>/dev/null)" || return 1
   for t in ${tags}; do
     case "${t}" in

--- a/infra/agent-image/test_cutover_guard.py
+++ b/infra/agent-image/test_cutover_guard.py
@@ -1,0 +1,120 @@
+"""The workspace-cutover guard must resolve BOTH ways a runtime can be pinned.
+
+An AgentCore runtime carries either a digest reference
+(`repo@sha256:...`) or a tag reference (`repo:2026-08-14-run-fence`),
+depending on whether the deploy passed `agentImageDigest`. `deployed_commit`
+in build-and-push.sh only handled the digest form: on a tag-pinned runtime the
+`${uri##*@}` strip is a no-op, the whole URI went out as an `imageDigest`, the
+ECR lookup failed, and the guard fell through to "could not determine the
+deployed image's commit" and demanded a workspace drain.
+
+dev is digest-pinned and prod is tag-pinned, so from 2026-08-03 every single
+prod build raised a cutover that was not real, while dev never did. A guard
+that cries wolf on every build of one environment is worse than no guard —
+that is precisely the failure the commit which introduced this function set
+out to fix ("it stopped being read").
+
+The function is exercised directly, with `aws` and `git` stubbed on PATH, so
+these tests pin the shell that actually ships rather than a transcription of
+it.
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+SCRIPT = pathlib.Path(__file__).with_name("build-and-push.sh")
+
+DIGEST = "sha256:5deea07c297d674a57e2eed10894574f7aa7a1e482e114557b281c696665d78f"
+REPO = "390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-prod"
+
+
+def _extract_function() -> str:
+    """The real deployed_commit(), lifted verbatim from the shipped script."""
+    lines = SCRIPT.read_text().splitlines()
+    start = next(
+        i for i, line in enumerate(lines) if line.startswith("deployed_commit() {")
+    )
+    end = next(i for i in range(start, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+class DeployedCommitResolvesEitherPinning(unittest.TestCase):
+    def _run(self, container_uri, tags="commit-9c271a21bbfb 2026-08-14-run-fence"):
+        """Run deployed_commit() against a stubbed AWS/git, return (rc, stdout)."""
+        work = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, work)
+        binaries = pathlib.Path(work, "bin")
+        binaries.mkdir()
+
+        # `aws` answers the three calls the function makes, and — critically —
+        # FAILS on an image-id it does not recognize, the way the real API does
+        # when handed a whole URI as a digest.
+        (binaries / "aws").write_text(textwrap.dedent(f"""\
+            #!/usr/bin/env bash
+            case "$*" in
+              *describe-stacks*) echo "psd_agent-ABC123" ;;
+              *get-agent-runtime*) echo "{container_uri}" ;;
+              *describe-images*)
+                case "$*" in
+                  *"imageDigest={DIGEST}"*|*"imageTag=2026-08-14-run-fence"*)
+                    echo "{tags}" ;;
+                  *) echo "An error occurred: InvalidParameterException" >&2; exit 254 ;;
+                esac ;;
+              *) exit 1 ;;
+            esac
+        """))
+        # `git cat-file -e` validates the sha exists locally; accept it.
+        (binaries / "git").write_text("#!/usr/bin/env bash\nexit 0\n")
+        for stub in ("aws", "git"):
+            (binaries / stub).chmod(0o755)
+
+        script = "\n".join([
+            "set -uo pipefail",
+            'REGION=us-east-1',
+            'REPO_ROOT=/tmp',
+            'STACK_NAME=AIStudio-AgentPlatformStack-Prod',
+            f'ECR_URI="{REPO}"',
+            _extract_function(),
+            "deployed_commit",
+        ])
+        env = dict(os.environ, PATH=f"{binaries}:{os.environ['PATH']}")
+        done = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, env=env
+        )
+        return done.returncode, done.stdout.strip()
+
+    def test_a_digest_pinned_runtime_resolves(self):
+        rc, sha = self._run(f"{REPO}@{DIGEST}")
+        self.assertEqual(rc, 0)
+        self.assertEqual(sha, "9c271a21bbfb")
+
+    def test_a_tag_pinned_runtime_resolves(self):
+        # The prod case. This returned non-zero for thirteen days, which the
+        # guard reported as "cutover required".
+        rc, sha = self._run(f"{REPO}:2026-08-14-run-fence")
+        self.assertEqual(rc, 0, "a tag-pinned runtime must not read as unknown")
+        self.assertEqual(sha, "9c271a21bbfb")
+
+    def test_an_unparseable_reference_still_fails_closed(self):
+        # Failing closed is right when we genuinely cannot tell; the bug was
+        # reaching that branch for a reference we could have read.
+        rc, _ = self._run("psd-agent-base-prod")
+        self.assertNotEqual(rc, 0)
+
+    def test_an_image_with_no_commit_tag_falls_back_to_the_trailing_sha(self):
+        rc, sha = self._run(f"{REPO}:2026-08-14-run-fence", tags="2026-08-14-9c271a21bbfb")
+        self.assertEqual(rc, 0)
+        self.assertEqual(sha, "9c271a21bbfb")
+
+    def test_an_image_with_no_usable_tag_fails_closed(self):
+        rc, _ = self._run(f"{REPO}:2026-08-14-run-fence", tags="latest")
+        self.assertNotEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every prod build since 2026-08-03 demanded a workspace drain that was not real. Not a flaky heuristic — a one-line bug, unchanged since the day the guard was written.

## The bug

An AgentCore runtime is pinned **either** by digest (`repo@sha256:...`) **or** by tag (`repo:2026-08-14-run-fence`), depending on whether the deploy passed `agentImageDigest`. `deployed_commit` did:

```bash
digest="${digest##*@}"
```

On a tag-pinned runtime there is no `@`, so that strip is a no-op and the **entire URI** went out as an `imageDigest`. The ECR lookup failed, the function returned non-zero, and the guard fell to its *"could not determine the deployed image's commit … failing closed"* branch.

**dev is digest-pinned. prod is tag-pinned.** So dev's guard has always worked and prod's has never worked — which is exactly why it reads as arbitrary.

## Verified, not reasoned about

The fixed resolver against both live runtimes:

```
dev:  586095ccbbdd  fix(quartile): include the partition in the cell key
prod: 9c271a21bbfb  Merge pull request #1647
```

And prod's contract diff (`storage-broker.ts`, `workspace_sync.py`, `schema/171*`) across `9c271a21bbfb..9c341646a` is **empty** — today's build was an ordinary deploy the whole time.

## Why this is the opposite of safe

The commit that introduced this function said it plainly: the warning used to print unconditionally, and *"that made the one build where it mattered indistinguishable from the twenty where it did not, so it stopped being read."* Firing on every prod build rebuilt that same failure in a narrower place.

Failing closed is right when we genuinely cannot tell. It is not right when we could have read the reference and didn't.

## Tested, and wired somewhere it runs

`test_cutover_guard.py` lifts the real `deployed_commit()` out of the shipped script and runs it with `aws`/`git` stubbed, so it pins the shell that ships rather than a transcription of it. Both pinnings resolve; an unparseable reference and an image with no usable tag still fail closed.

```
restoring the digest-only strip -> AssertionError: 1 != 0 :
                                   a tag-pinned runtime must not read as unknown
```

Added to the unittest list in `ci.yml` deliberately: `infra/agent-image` already contains `bin/gh-wrapper.test.sh`, which nothing invokes — a test that runs nowhere is the same silent failure in a different costume.

814 image tests, bootstrap budget clean.
