### PR TITLE
fix(agent): end an assistant segment at ANY model activity, not a known list

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -246,18 +246,24 @@ _STRUCTURAL_MARK_FIELDS = (
     "kind",
     "status",
     "state",
-    # `event:task` frames are shaped {"action": str, "task": dict} and carry no
-    # runId, so neither the run fence nor the boundary logic can see them. They
-    # are also the difference between a turn that fuses assistant segments and
-    # one that does not: a Docs turn with 43 of them fused twice
-    # ("ownership.Now", "Kris.Done") while a calendar turn with none stayed
-    # clean, both with ordinary stream=item tool events present.
+    # `event:task` frames are shaped {"action": str, "task": dict}. This note
+    # used to say they carry no runId and that neither the run fence nor the
+    # boundary logic could see them. BOTH claims are now false: the id is
+    # nested at payload.task.runId (which is why it read as absent), the task
+    # branch fences on it, and task frames end an assistant segment.
     #
-    # `action` is the discriminator that decides whether a frame marks work
-    # starting/finishing (a real segment boundary) or is a progress update
-    # inside one segment. Treating all 43 as boundaries would drop the earlier
-    # part of any segment they interleave with — trading fusion for truncated
-    # answers — so capture the vocabulary before changing behaviour.
+    # The correlation this note recorded held up. A Docs turn with 43 of them
+    # fused twice ("ownership.Now", "Kris.Done") while a calendar turn with
+    # none stayed clean; on 2026-08-16 a quartile turn fused four fragments
+    # into 515 chars with `thinking` and task frames between them.
+    #
+    # It also warned that treating all 43 as boundaries would trade fusion for
+    # truncated answers. That was the right worry and it is handled, but not by
+    # inspecting `action`: segment splitting and answer suppression are now two
+    # flags (assistant_boundary_pending, tool_activity_since_text), so a task
+    # frame can end a segment without condemning a finished answer as
+    # scratchpad. `action` stays sampled — it is still the vocabulary a future
+    # reader needs.
     "action",
 )
 
@@ -2310,7 +2316,8 @@ class OpenClawAdapter(HarnessAdapter):
                                 and (agent_assistant_accum or response_text)
                             ):
                                 assistant_boundary_pending = True
-                                tool_activity_since_text = True
+                                if not agent_payload.get("isHeartbeat"):
+                                    tool_activity_since_text = True
                                 response_text = ""
                             # Native-tool mode (#1138 r12+) reports tool
                             # execution ONLY here — record it so telemetry's
@@ -2325,7 +2332,8 @@ class OpenClawAdapter(HarnessAdapter):
                             # Same boundary rule for protocol-v3 tool events.
                             if agent_assistant_accum or response_text:
                                 assistant_boundary_pending = True
-                                tool_activity_since_text = True
+                                if not agent_payload.get("isHeartbeat"):
+                                    tool_activity_since_text = True
                                 response_text = ""
                             tool_id = (
                                 data.get("id")
@@ -2341,7 +2349,8 @@ class OpenClawAdapter(HarnessAdapter):
                         elif stream == "tool_result" and isinstance(data, dict):
                             if agent_assistant_accum or response_text:
                                 assistant_boundary_pending = True
-                                tool_activity_since_text = True
+                                if not agent_payload.get("isHeartbeat"):
+                                    tool_activity_since_text = True
                                 response_text = ""
                             tool_id = (
                                 data.get("id")

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -2393,6 +2393,32 @@ class OpenClawAdapter(HarnessAdapter):
                         # timers, not the model doing something, and a
                         # heartbeat landing mid-stream must never split a
                         # message that is still being written.
+                        # Fenced like every other stream that mutates turn
+                        # state. This socket is operator-scoped, so a
+                        # concurrent subagent's long-running exec emits task
+                        # frames here too — and an unfenced one would mark THIS
+                        # turn's finished answer as scratchpad and blank
+                        # response_text, on the strength of somebody else's
+                        # tool call. That is the 2026-08-14 incident's shape,
+                        # which is why the agent and chat streams are fenced;
+                        # this branch was added without it.
+                        #
+                        # The id sits one level deeper than on the other
+                        # streams (payload.task.runId, not payload.runId).
+                        task_payload = msg.get("payload") or {}
+                        task_detail = task_payload.get("task")
+                        task_run_id = (
+                            task_detail.get("runId")
+                            if isinstance(task_detail, dict) else None
+                        )
+                        if (
+                            isinstance(task_run_id, str)
+                            and task_run_id
+                            and turn_run_id
+                            and task_run_id != turn_run_id
+                        ):
+                            foreign_run_events += 1
+                            continue
                         if agent_assistant_accum or response_text:
                             assistant_boundary_pending = True
                             tool_activity_since_text = True

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -2007,6 +2007,26 @@ class OpenClawAdapter(HarnessAdapter):
                 # final-event handler suppresses ("Here's how far I got: Now
                 # run the batchUpdate."). Covered by test_reply_replay.py.
                 assistant_boundary_pending: bool = False
+                # SEPARATE from the flag above, and the distinction matters.
+                #
+                # `assistant_boundary_pending` answers "does the next delta
+                # start a NEW message?" — set by any model activity, so
+                # segments never fuse.
+                #
+                # This one answers "is the accumulated text scratchpad?" — set
+                # ONLY by genuine tool work. Text followed by a tool call is
+                # something the model said on its way to doing something else;
+                # text followed by a reasoning or commentary item is still its
+                # answer.
+                #
+                # Review caught these being one flag: any `item` frame then
+                # suppressed a COMPLETE answer that happened to be followed by
+                # a non-tool progress item — the exact case
+                # _is_tool_activity_stream's carve-out exists for, reintroduced
+                # while fixing fusion. itemKind() in the pinned bundle emits
+                # `analysis` for reasoning and context compaction, so those
+                # frames are real, not hypothetical.
+                tool_activity_since_text: bool = False
                 # The run THIS turn started, learned from the chat.send res
                 # (`{"runId": ..., "status": "started"}`). Everything the reply
                 # is built from must belong to it.
@@ -2035,6 +2055,8 @@ class OpenClawAdapter(HarnessAdapter):
                 # socket carrying other runs. Seed it from the run that asked;
                 # that is the run resuming, and it is the only run whose output
                 # belongs in this reply.
+                # Why the run stopped, as the chat channel reported it.
+                final_stop_reason: Optional[str] = None
                 turn_run_id: Optional[str] = (
                     resumed_run_id if answered_pending else None
                 )
@@ -2269,9 +2291,11 @@ class OpenClawAdapter(HarnessAdapter):
                                     assistant_boundary_pending,
                                 )
                                 assistant_boundary_pending = False
+                                tool_activity_since_text = False
                             elif isinstance(cumulative, str) and cumulative:
                                 agent_assistant_accum = cumulative
                                 assistant_boundary_pending = False
+                                tool_activity_since_text = False
                         elif stream in ("item", "command_output"):
                             # Newer OpenClaw builds report tool activity as
                             # `item`/`command_output` streams. Tool activity
@@ -2286,6 +2310,7 @@ class OpenClawAdapter(HarnessAdapter):
                                 and (agent_assistant_accum or response_text)
                             ):
                                 assistant_boundary_pending = True
+                                tool_activity_since_text = True
                                 response_text = ""
                             # Native-tool mode (#1138 r12+) reports tool
                             # execution ONLY here — record it so telemetry's
@@ -2300,6 +2325,7 @@ class OpenClawAdapter(HarnessAdapter):
                             # Same boundary rule for protocol-v3 tool events.
                             if agent_assistant_accum or response_text:
                                 assistant_boundary_pending = True
+                                tool_activity_since_text = True
                                 response_text = ""
                             tool_id = (
                                 data.get("id")
@@ -2315,6 +2341,7 @@ class OpenClawAdapter(HarnessAdapter):
                         elif stream == "tool_result" and isinstance(data, dict):
                             if agent_assistant_accum or response_text:
                                 assistant_boundary_pending = True
+                                tool_activity_since_text = True
                                 response_text = ""
                             tool_id = (
                                 data.get("id")
@@ -2368,6 +2395,8 @@ class OpenClawAdapter(HarnessAdapter):
                         # message that is still being written.
                         if agent_assistant_accum or response_text:
                             assistant_boundary_pending = True
+                            tool_activity_since_text = True
+                            response_text = ""
 
                     elif mtype == "event" and mevent == "chat":
                         payload = msg.get("payload", {})
@@ -2396,6 +2425,16 @@ class OpenClawAdapter(HarnessAdapter):
                             continue
                         state = payload.get("state")
                         last_state = state
+                        # Kept for every state, not just aborts. The Artondale
+                        # turn ended at `final` while the model's last message
+                        # was still stopReason=toolUse — i.e. the run stopped
+                        # mid-loop and the report was never built — and there
+                        # was no way to tell that from the logs without pulling
+                        # the workspace transcript out of S3. One field here
+                        # answers it next time.
+                        final_stop_reason = (
+                            payload.get("stopReason") or final_stop_reason
+                        )
                         event_message = payload.get("message")
                         content = event_message.get("content") if isinstance(event_message, dict) else None
                         text = self._extract_text(content) or self._extract_text(event_message)
@@ -2417,7 +2456,7 @@ class OpenClawAdapter(HarnessAdapter):
                             if (
                                 not response_text
                                 and agent_assistant_accum
-                                and not assistant_boundary_pending
+                                and not tool_activity_since_text
                             ):
                                 response_text = agent_assistant_accum
                             got_final = True
@@ -2743,7 +2782,7 @@ class OpenClawAdapter(HarnessAdapter):
                             if (
                                 not response_text
                                 and agent_assistant_accum
-                                and not assistant_boundary_pending
+                                and not tool_activity_since_text
                             ):
                                 response_text = agent_assistant_accum
                             got_final = True
@@ -2827,7 +2866,7 @@ class OpenClawAdapter(HarnessAdapter):
             if (
                 not response_text
                 and agent_assistant_accum
-                and not assistant_boundary_pending
+                and not tool_activity_since_text
             ):
                 response_text = agent_assistant_accum
             error_message = (
@@ -2881,7 +2920,7 @@ class OpenClawAdapter(HarnessAdapter):
             if (
                 not response_text
                 and agent_assistant_accum
-                and not assistant_boundary_pending
+                and not tool_activity_since_text
             ):
                 response_text = agent_assistant_accum
             logger.error(
@@ -2955,12 +2994,13 @@ class OpenClawAdapter(HarnessAdapter):
             )
 
         logger.info(
-            "chat turn ok: resp_len=%d last_state=%s run_id=%s "
-            "foreign_run_events=%d event_counts=%s "
+            "chat turn ok: resp_len=%d last_state=%s stop_reason=%s "
+            "run_id=%s foreign_run_events=%d event_counts=%s "
             "model=%s tokens_in=%d tokens_out=%d cache_read=%d cache_write=%d "
             "latency_ms=%d tool_calls=%d transcript_model_calls=%d",
             len(response_text),
             last_state,
+            final_stop_reason or "none",
             turn_run_id or "unknown",
             foreign_run_events,
             json.dumps(event_counts),

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -2311,13 +2311,21 @@ class OpenClawAdapter(HarnessAdapter):
                                 stream,
                                 data,
                             )
+                            # Segment splitting is NOT set here: the general
+                            # rule above already did it for every non-assistant
+                            # stream, heartbeat-guarded. Setting it again here
+                            # skipped that guard, so a heartbeat tagged as
+                            # item/command_output would have split a live
+                            # message and blanked response_text — the
+                            # mirror-image bug this rule exists to avoid.
+                            # This branch now decides ONE thing: whether the
+                            # accumulated text is scratchpad.
                             if (
                                 is_tool_activity
+                                and not agent_payload.get("isHeartbeat")
                                 and (agent_assistant_accum or response_text)
                             ):
-                                assistant_boundary_pending = True
-                                if not agent_payload.get("isHeartbeat"):
-                                    tool_activity_since_text = True
+                                tool_activity_since_text = True
                                 response_text = ""
                             # Native-tool mode (#1138 r12+) reports tool
                             # execution ONLY here — record it so telemetry's
@@ -2331,10 +2339,9 @@ class OpenClawAdapter(HarnessAdapter):
                         elif stream == "tool_call" and isinstance(data, dict):
                             # Same boundary rule for protocol-v3 tool events.
                             if agent_assistant_accum or response_text:
-                                assistant_boundary_pending = True
                                 if not agent_payload.get("isHeartbeat"):
                                     tool_activity_since_text = True
-                                response_text = ""
+                                    response_text = ""
                             tool_id = (
                                 data.get("id")
                                 or data.get("toolCallId")
@@ -2348,10 +2355,9 @@ class OpenClawAdapter(HarnessAdapter):
                             }
                         elif stream == "tool_result" and isinstance(data, dict):
                             if agent_assistant_accum or response_text:
-                                assistant_boundary_pending = True
                                 if not agent_payload.get("isHeartbeat"):
                                     tool_activity_since_text = True
-                                response_text = ""
+                                    response_text = ""
                             tool_id = (
                                 data.get("id")
                                 or data.get("toolCallId")
@@ -2428,6 +2434,24 @@ class OpenClawAdapter(HarnessAdapter):
                         ):
                             foreign_run_events += 1
                             continue
+                        # Every task frame counts as work, with no `kind`
+                        # check — unlike the item lane, deliberately.
+                        #
+                        # `item` is a SHARED progress lane: it carries tool
+                        # work and also reasoning/commentary, which is why it
+                        # has to discriminate. A task frame is not shared —
+                        # it exists because the runtime is executing something
+                        # on the model's behalf. Only kind="exec" has been
+                        # observed, so a future non-exec kind is unproven
+                        # either way; the reason not to guess at an allowlist
+                        # is that this file has now been wrong twice about
+                        # which kinds matter.
+                        #
+                        # If that turns out wrong, the cost is a finished
+                        # answer suppressed as scratchpad. Pinned by
+                        # test_a_non_exec_task_frame_is_still_treated_as_work
+                        # so the decision is visible rather than implied, and
+                        # changing it trips a test.
                         if agent_assistant_accum or response_text:
                             assistant_boundary_pending = True
                             tool_activity_since_text = True

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -2193,6 +2193,45 @@ class OpenClawAdapter(HarnessAdapter):
                                     tokens_in = max(tokens_in, ti)
                                 if isinstance(to, int):
                                     tokens_out = max(tokens_out, to)
+                        # SEGMENT BOUNDARY — inverted rule, deliberately.
+                        #
+                        # One assistant message's deltas arrive back-to-back.
+                        # So anything that is NOT more assistant content ended
+                        # that message, and the next delta starts a new one.
+                        #
+                        # This used to name the events that count as a
+                        # boundary (item/command_output/tool_call with a
+                        # tool-ish `kind`). That list was incomplete twice, and
+                        # the second time shipped: on 2026-08-16 a quartile
+                        # report answered with four fused narration fragments —
+                        # 244+131+76+64 = 515 chars, exactly the resp_len in
+                        # the turn log. Between those fragments were 22
+                        # `thinking` events and `event:task` frames carrying
+                        # kind=exec, neither of which was on the list, so the
+                        # accumulator never reset and every fragment the model
+                        # wrote across six minutes was concatenated into one
+                        # reply.
+                        #
+                        # An allowlist fails toward FUSING (a wrong answer
+                        # built from scratchpad). This fails toward SPLITTING
+                        # (at worst the last part of an answer), and an unknown
+                        # future stream defaults to the safe side.
+                        # `lifecycle` and `run_status` are excluded because they
+                        # describe the RUN, not the model: a lifecycle error
+                        # means the run is dying, and a run_status phase is
+                        # workspace plumbing. Neither means the model started a
+                        # new message, and treating them as boundaries throws
+                        # away the partial text a failed turn is supposed to
+                        # show (issue #1461, pinned by
+                        # test_context_overflow_abort_is_not_recorded_as_deadline).
+                        # Everything else — known or not — is model activity
+                        # and ends the segment.
+                        if (
+                            stream not in ("assistant", "lifecycle", "run_status")
+                            and not agent_payload.get("isHeartbeat")
+                            and (agent_assistant_accum or response_text)
+                        ):
+                            assistant_boundary_pending = True
                         if stream == "lifecycle" and isinstance(data, dict):
                             phase = data.get("phase")
                             lifecycle_error = data.get("error")
@@ -2315,6 +2354,20 @@ class OpenClawAdapter(HarnessAdapter):
                                 ).isoformat(),
                             }
                             tool_calls.append(entry)
+
+                    elif mtype == "event" and mevent == "task":
+                        # Long-running tool execution reports here, not on the
+                        # agent stream: the sampled frame carries
+                        # marks={"action": "upserted", "kind": "exec",
+                        # "status": "running"}. It is model activity between
+                        # assistant messages, so it ends a segment for the same
+                        # reason the agent-stream rule above does. `event:tick`
+                        # and `event:health` are NOT included — they are
+                        # timers, not the model doing something, and a
+                        # heartbeat landing mid-stream must never split a
+                        # message that is still being written.
+                        if agent_assistant_accum or response_text:
+                            assistant_boundary_pending = True
 
                     elif mtype == "event" and mevent == "chat":
                         payload = msg.get("payload", {})

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -1295,6 +1295,26 @@ class SegmentsEndAtAnyModelActivity(unittest.TestCase):
         text = replay([says("The "), says("report "), says("is ready.")])
         self.assertEqual(text.strip(), "The report is ready.")
 
+    def test_a_non_exec_task_frame_is_still_treated_as_work(self):
+        # Documents a decision rather than an observation: only kind="exec"
+        # has ever been seen on a task frame. Unlike `item` — a shared lane
+        # carrying commentary as well as tool work — a task frame exists
+        # because the runtime is executing something, so it is not
+        # discriminated by kind. If that is ever wrong, this test is what
+        # changes, deliberately.
+        text = replay([says("The report is ready."),
+                       runs_task(kind="planning")])
+        self.assertNotIn("report is ready", text)
+
+    def test_a_heartbeat_on_the_item_stream_never_splits_a_live_message(self):
+        # The general boundary rule guards heartbeats; the tool branches used
+        # to set the boundary again without that guard, so a heartbeat tagged
+        # as item would have split a live message and blanked response_text.
+        beat = calls_tool("exec", "start")
+        beat["payload"]["isHeartbeat"] = True
+        text = replay([says("one "), beat, says("two")])
+        self.assertEqual(text.strip(), "one two")
+
     def test_a_foreign_task_frame_cannot_suppress_this_turns_answer(self):
         # The operator socket carries every run in the container, so another
         # session's long-running exec emits task frames here. Unfenced, one

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -129,6 +129,20 @@ def runs_task(kind="exec", status="running"):
                  "progressSummary": "p", "runtime": "r", "sourceId": "s"}}}
 
 
+
+def reasons(title="considering the roster"):
+    """A non-tool `item` frame.
+
+    itemKind() in the pinned bundle maps `reasoning` and `contextCompaction`
+    to kind="analysis", so item frames that are NOT tool work genuinely occur.
+    _is_tool_activity_stream carves them out on purpose: one arriving right
+    before the final chat event must not discard a finished answer.
+    """
+    return agent_event("item", {"itemId": "analysis:1", "phase": "start",
+                                "kind": "analysis", "title": title,
+                                "status": "running"})
+
+
 def beats():
     """A heartbeat on the agent stream. Must never split a live message."""
     event = agent_event("thinking", {"text": "", "delta": ""})
@@ -1280,6 +1294,25 @@ class SegmentsEndAtAnyModelActivity(unittest.TestCase):
     def test_deltas_of_one_message_still_concatenate(self):
         text = replay([says("The "), says("report "), says("is ready.")])
         self.assertEqual(text.strip(), "The report is ready.")
+
+    def test_a_non_tool_item_before_final_does_not_discard_the_answer(self):
+        # The carve-out _is_tool_activity_stream was written for. Fixing
+        # fusion by treating every item as tool activity would silently
+        # reintroduce it — review caught exactly that.
+        text = replay([says("The report is ready: https://example.test/s"),
+                       reasons()])
+        self.assertIn("The report is ready", text)
+
+    def test_a_non_tool_item_still_ends_the_segment(self):
+        # It is not tool work, but it IS activity: a message that resumes
+        # after it is a new message, not a continuation.
+        text = replay([says("scratchpad. "), reasons(), says("answer.")])
+        self.assertEqual(text.strip(), "answer.")
+
+    def test_a_real_tool_before_final_still_suppresses_narration(self):
+        # The other half. Text followed by actual tool work is scratchpad.
+        text = replay([says("Now let me run the query."), *uses_tool("exec")])
+        self.assertNotIn("run the query", text)
 
     def test_narration_followed_by_a_task_is_not_offered_as_the_answer(self):
         # The turn's other symptom: it ended right after a tool call, with

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -101,6 +101,41 @@ def uses_tool(name="exec"):
     return [calls_tool(name, "start"), calls_tool(name, "end")]
 
 
+
+def thinks(text):
+    """A `thinking` delta — reasoning, dropped from the reply but real activity.
+
+    Shape from the live dev runtime (openclaw_event_sample stream=thinking,
+    2026-08-16). 22 of these sat between the assistant fragments of the fused
+    Artondale turn.
+    """
+    return agent_event("thinking", {"text": text, "delta": text})
+
+
+def runs_task(kind="exec", status="running"):
+    """An `event:task` frame — long-running tool execution.
+
+    Shape from the live runtime's own openclaw_kind_shape diagnostic:
+    marks={"action": "upserted", "kind": "exec", "status": "running"}.
+    This is NOT an event:agent frame, which is exactly why the old
+    boundary rule never saw it.
+    """
+    return {"type": "event", "event": "task", "payload": {
+        "action": "upserted",
+        "task": {"agentId": "main", "id": "t1", "taskId": "t1", "kind": kind,
+                 "status": status, "runId": TURN_RUN_ID, "title": kind,
+                 "sessionKey": "agent:main:replay", "createdAt": 1,
+                 "updatedAt": 2, "startedAt": 1, "ownerKey": "o",
+                 "progressSummary": "p", "runtime": "r", "sourceId": "s"}}}
+
+
+def beats():
+    """A heartbeat on the agent stream. Must never split a live message."""
+    event = agent_event("thinking", {"text": "", "delta": ""})
+    event["payload"]["isHeartbeat"] = True
+    return event
+
+
 class FakeGateway:
     """In-process stand-in for the OpenClaw gateway WebSocket.
 
@@ -1183,3 +1218,72 @@ class AnswerMappingMatchesTheGateway(unittest.TestCase):
                 [{"questionId": None}], "anything"),
             {},
         )
+
+class SegmentsEndAtAnyModelActivity(unittest.TestCase):
+    """The Artondale fusion, 2026-08-16 — reproduced, then fixed.
+
+    A quartile-growth request answered with four narration fragments the model
+    wrote across six minutes, concatenated into one reply. The transcript
+    (agents/main/agent/openclaw-agent.sqlite) stored them as four separate
+    assistant messages at seq 45/50/117/119, lengths 244+131+76+64 = 515 —
+    exactly the resp_len the turn logged. Between them: 22 `thinking` events
+    and `event:task` frames carrying kind=exec, plus 33 tool calls.
+
+    The old rule named which events count as a boundary (item/command_output/
+    tool_call with a tool-ish kind). `thinking` and `event:task` were not on
+    that list, so the accumulator never reset. An allowlist fails toward
+    FUSING; the rule now fails toward splitting.
+    """
+
+    FRAGMENTS = [
+        "Good — Fall+Spring data present across DIBELS, i-Ready, and SBA. ",
+        "Good, dibels_scores has grade_level directly. ",
+        "Only the load_csv line is broken. Fix that single line directly.",
+    ]
+
+    def _production_sequence(self):
+        events = [says(self.FRAGMENTS[0]), thinks("check tables"), runs_task()]
+        events += [says(self.FRAGMENTS[1]), thinks("repair it"), runs_task()]
+        events += [says(self.FRAGMENTS[2])]
+        return events
+
+    def test_the_production_sequence_returns_only_the_last_fragment(self):
+        text = replay(self._production_sequence())
+        self.assertEqual(text.strip(), self.FRAGMENTS[2].strip())
+
+    def test_no_earlier_fragment_survives_into_the_reply(self):
+        text = replay(self._production_sequence())
+        for stale in self.FRAGMENTS[:2]:
+            self.assertNotIn(stale.strip()[:24], text)
+
+    def test_thinking_alone_ends_a_segment(self):
+        text = replay([says("scratchpad. "), thinks("hmm"), says("answer.")])
+        self.assertEqual(text.strip(), "answer.")
+
+    def test_an_event_task_alone_ends_a_segment(self):
+        text = replay([says("scratchpad. "), runs_task(), says("answer.")])
+        self.assertEqual(text.strip(), "answer.")
+
+    def test_an_unknown_future_stream_ends_a_segment(self):
+        # The point of inverting the rule: a stream nobody has seen yet must
+        # fail toward splitting, not toward fusing.
+        unknown = agent_event("some_new_stream_2027", {"whatever": True})
+        text = replay([says("scratchpad. "), unknown, says("answer.")])
+        self.assertEqual(text.strip(), "answer.")
+
+    def test_a_heartbeat_never_splits_a_live_message(self):
+        # The mirror-image risk. Heartbeats arrive on a timer and can land
+        # mid-stream; splitting there would truncate a real answer.
+        text = replay([says("one "), beats(), says("two "), beats(), says("three")])
+        self.assertEqual(text.strip(), "one two three")
+
+    def test_deltas_of_one_message_still_concatenate(self):
+        text = replay([says("The "), says("report "), says("is ready.")])
+        self.assertEqual(text.strip(), "The report is ready.")
+
+    def test_narration_followed_by_a_task_is_not_offered_as_the_answer(self):
+        # The turn's other symptom: it ended right after a tool call, with
+        # narration as the last text. That is not an answer, and promoting it
+        # is how the user got "Fix that single line directly." as a reply.
+        text = replay([says("Only the load_csv line is broken."), runs_task()])
+        self.assertNotIn("load_csv", text)

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -1309,9 +1309,13 @@ class SegmentsEndAtAnyModelActivity(unittest.TestCase):
                        says("two")])
         self.assertEqual(text.strip(), "one two")
 
-    def test_our_own_task_frame_still_ends_the_segment(self):
-        # The fence must not defeat the fix it is protecting.
-        text = replay([says("scratchpad. "), runs_task(), says("answer.")])
+    def test_the_fence_passes_a_same_run_task_frame(self):
+        # The fence must not defeat the fix it is protecting: an EXPLICIT
+        # this-turn run id still ends the segment. Stated explicitly rather
+        # than relying on the fixture default, which is what hid the foreign
+        # case in the first place.
+        text = replay([says("scratchpad. "),
+                       runs_task(run_id=TURN_RUN_ID), says("answer.")])
         self.assertEqual(text.strip(), "answer.")
 
     def test_a_non_tool_item_before_final_does_not_discard_the_answer(self):

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -112,7 +112,7 @@ def thinks(text):
     return agent_event("thinking", {"text": text, "delta": text})
 
 
-def runs_task(kind="exec", status="running"):
+def runs_task(kind="exec", status="running", run_id=TURN_RUN_ID):
     """An `event:task` frame — long-running tool execution.
 
     Shape from the live runtime's own openclaw_kind_shape diagnostic:
@@ -123,7 +123,7 @@ def runs_task(kind="exec", status="running"):
     return {"type": "event", "event": "task", "payload": {
         "action": "upserted",
         "task": {"agentId": "main", "id": "t1", "taskId": "t1", "kind": kind,
-                 "status": status, "runId": TURN_RUN_ID, "title": kind,
+                 "status": status, "runId": run_id, "title": kind,
                  "sessionKey": "agent:main:replay", "createdAt": 1,
                  "updatedAt": 2, "startedAt": 1, "ownerKey": "o",
                  "progressSummary": "p", "runtime": "r", "sourceId": "s"}}}
@@ -1294,6 +1294,25 @@ class SegmentsEndAtAnyModelActivity(unittest.TestCase):
     def test_deltas_of_one_message_still_concatenate(self):
         text = replay([says("The "), says("report "), says("is ready.")])
         self.assertEqual(text.strip(), "The report is ready.")
+
+    def test_a_foreign_task_frame_cannot_suppress_this_turns_answer(self):
+        # The operator socket carries every run in the container, so another
+        # session's long-running exec emits task frames here. Unfenced, one
+        # would mark THIS turn's finished answer as scratchpad on the strength
+        # of somebody else's tool call.
+        text = replay([says("The report is ready: https://example.test/s"),
+                       runs_task(run_id="run-somebody-else")])
+        self.assertIn("The report is ready", text)
+
+    def test_a_foreign_task_frame_cannot_split_this_turns_answer(self):
+        text = replay([says("one "), runs_task(run_id="run-somebody-else"),
+                       says("two")])
+        self.assertEqual(text.strip(), "one two")
+
+    def test_our_own_task_frame_still_ends_the_segment(self):
+        # The fence must not defeat the fix it is protecting.
+        text = replay([says("scratchpad. "), runs_task(), says("answer.")])
+        self.assertEqual(text.strip(), "answer.")
 
     def test_a_non_tool_item_before_final_does_not_discard_the_answer(self):
         # The carve-out _is_tool_activity_stream was written for. Fixing


### PR DESCRIPTION
A quartile-growth request came back as four narration fragments the model wrote across six minutes, concatenated into one reply — *"…per grade.Good, dibels_scores…"*, *"…for Artondale.Confirmed the literal \n bug…"*.

## Proven from the turn, not inferred

The agent's own transcript (`agents/main/agent/openclaw-agent.sqlite`, pushed by that turn) stores them as four **separate** assistant messages:

| seq | len | text |
|---|---|---|
| 45 | 244 | `Good — Fall+Spring data present across DIBELS…` |
| 50 | 131 | `Good, dibels_scores has grade_level directly…` |
| 117 | 76 | `Confirmed the literal \n bug per Rule 9a…` |
| 119 | 64 | `Only the load_csv line is broken…` |
| | **515** | and the turn logged **`resp_len=515`** |

Exact. Two earlier theories died on evidence first: the turn did not hit its deadline (`last_state=final`, `elapsed_s=484` against 550) and nothing was fenced (`foreign_run_events=0`).

## Root cause

Between those fragments the transcript holds 22 `thinking` blocks and 33 tool calls, and the runtime's own diagnostic shows long-running execution arriving as **`event:task`** with `marks={"action":"upserted","kind":"exec","status":"running"}` — not as an `event:agent` item.

The boundary rule named which events count: `item`/`command_output`/`tool_call` carrying a tool-ish `kind`. `thinking` wasn't on it. `event:task` isn't even an agent frame. So the accumulator never reset.

Replaying the real shapes reproduces it exactly:

```
'Good — Fall+Spring data present. Good, dibels_scores has grade_level
 directly.Only the load_csv line is broken.'
```

## The fix, and why it's inverted

One message's deltas arrive back-to-back. So anything that is *not more assistant content* ended that message. The rule now says exactly that.

**An allowlist fails toward fusing** — a wrong answer assembled from scratchpad. **This fails toward splitting** — at worst the tail of one answer. The list has been incomplete twice and the second time shipped, so the default matters more than the list.

Excluded, each for a reason:
- `lifecycle` / `run_status` describe the **run**, not the model. A lifecycle error means the run is dying, not that a new message began; treating it as a boundary discards the partial text a failed turn exists to show. The #1461 regression test caught that and it stands.
- **Heartbeats** arrive on a timer and can land mid-stream. Splitting there would truncate a live answer — the mirror-image bug, pinned by its own test.

## It also fixes the second symptom

That reply was scratchpad, not an answer: the run ended right after a tool call (last message `stopReason=toolUse`, then a toolResult, then nothing). The existing guard already refuses to promote the accumulator when tool activity followed it — it just never fired, for the same reason. One root cause, both symptoms.

Reverting the rule fails **6 tests**, including the production sequence.

822 image tests, bootstrap budget clean.
