### PR TITLE
fix(agent-image): a no-op file mutation must not end the whole run

### DIFF
--- a/infra/agent-image/openclaw_runtime_patch.mjs
+++ b/infra/agent-image/openclaw_runtime_patch.mjs
@@ -253,12 +253,93 @@ selection.source = replaceOnce(
   "detach ingress user before orphan repair",
 );
 
+// A no-op file mutation must not END THE RUN.
+//
+// On 2026-08-16 a quartile-growth report died 484 seconds in, 53 model calls
+// deep, with the whole report still to build. The last thing the agent did was
+// repair a script and issue an `edit` whose replacement happened to match what
+// was already there. That returns `terminate: true`, and agent-core does:
+//
+//     hasMoreToolCalls = !executedToolBatch.terminate;
+//     shouldTerminateToolBatch = calls.length > 0 && calls.every(c => c.terminate)
+//
+// The batch held that one call, so the loop exited while the model's own
+// stopReason was still `toolUse` — it was asking to continue. The gateway then
+// broadcast `final` and the user got a half-finished narration instead of a
+// spreadsheet.
+//
+// The trap is worst exactly where it is most likely: repairing a file (the
+// literal-\n bug, psd-rules Rule 9a) means writing content that may already be
+// correct, so the recovery action and the kill switch are the same keystroke.
+// Same for `write` when the file is already right, and `patch` when the hunk
+// is already applied.
+//
+// Upstream presumably wants to stop a model looping on no-op edits forever.
+// That trade is wrong here: our turns are already bounded by the chat deadline
+// and the two-hour job budget, so the worst case without this is a few wasted
+// iterations, while the worst case with it is a destroyed multi-minute run.
+//
+// The client-delegated `terminate: true` in the tool-definition adapter
+// ("Tool execution delegated to client") is NOT touched — that one is a real
+// pause, not a no-op.
+const fileTools = findUniqueBundle(files, "file mutation no-op terminate", [
+  "The replacement text is identical to the original.",
+  "The file already has identical content.",
+]);
+
+fileTools.source = replaceOnce(
+  fileTools.source,
+  [
+    "\t\t\t\t\t\t...textResult(`No changes made to ${path}. The replacement text is identical to the original.`, { changed: false }),",
+    "\t\t\t\t\t\tterminate: true",
+  ].join("\n"),
+  "\t\t\t\t\t\t...textResult(`No changes made to ${path}. The replacement text is identical to the original.`, { changed: false })",
+  "edit no-op must not terminate the run",
+);
+
+fileTools.source = replaceOnce(
+  fileTools.source,
+  [
+    "\t\t\t\t\t\t...textResult(`No changes made to ${path}. The replacement produced identical content.`, { changed: false }),",
+    "\t\t\t\t\t\tterminate: true",
+  ].join("\n"),
+  "\t\t\t\t\t\t...textResult(`No changes made to ${path}. The replacement produced identical content.`, { changed: false })",
+  "edit identical-content must not terminate the run",
+);
+
+fileTools.source = replaceOnce(
+  fileTools.source,
+  [
+    "\t\t\t\t\t...textResult(`No changes made to ${path}. The file already has identical content.`, { changed: false }),",
+    "\t\t\t\t\tterminate: true",
+  ].join("\n"),
+  "\t\t\t\t\t...textResult(`No changes made to ${path}. The file already has identical content.`, { changed: false })",
+  "write no-op must not terminate the run",
+);
+
+const patchTool = findUniqueBundle(files, "patch tool no-op terminate", [
+  "\t\t\t\t...result.noOp ? { terminate: true } : {}",
+  "Provide a patch input.",
+]);
+
+patchTool.source = replaceOnce(
+  patchTool.source,
+  [
+    "\t\t\t\tdetails: { summary: result.summary },",
+    "\t\t\t\t...result.noOp ? { terminate: true } : {}",
+  ].join("\n"),
+  "\t\t\t\tdetails: { summary: result.summary }",
+  "patch no-op must not terminate the run",
+);
+
 for (const file of [
   embeddedAgent,
   agentCommand,
   sessionManager,
   guardWrapper,
   selection,
+  fileTools,
+  patchTool,
 ]) {
   // filePath is confined to the enumerated, version-checked dist directory.
   // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -267,7 +348,15 @@ for (const file of [
 
 process.stdout.write(
   `Patched OpenClaw ${EXPECTED_OPENCLAW_VERSION}: ` +
-    [embeddedAgent, agentCommand, sessionManager, guardWrapper, selection]
+    [
+      embeddedAgent,
+      agentCommand,
+      sessionManager,
+      guardWrapper,
+      selection,
+      fileTools,
+      patchTool,
+    ]
       .map((file) => file.name)
       .join(", ") +
     "\n",

--- a/tests/unit/agent-image-openclaw-runtime-patch.test.ts
+++ b/tests/unit/agent-image-openclaw-runtime-patch.test.ts
@@ -43,6 +43,31 @@ describe("pinned OpenClaw runtime backports", () => {
     expect(runtimePatch).toContain("expected anchor occurred more than once")
   })
 
+  it("stops a no-op file mutation from ending the whole run", () => {
+    // A quartile report died 484s in, 53 model calls deep, because the agent
+    // issued an `edit` whose replacement matched what was already there.
+    // That returns `terminate: true`, and agent-core ends the run when every
+    // call in the batch terminated — while the model's own stopReason was
+    // still `toolUse`. Worst exactly where it is most likely: repairing a file
+    // means writing content that may already be correct.
+    expect(runtimePatch).toContain("edit no-op must not terminate the run")
+    expect(runtimePatch).toContain(
+      "edit identical-content must not terminate the run",
+    )
+    expect(runtimePatch).toContain("write no-op must not terminate the run")
+    expect(runtimePatch).toContain("patch no-op must not terminate the run")
+  })
+
+  it("leaves the client-delegated terminate alone", () => {
+    // "Tool execution delegated to client" is a real pause, not a no-op, and
+    // must keep terminating. Named here so a future sweep for `terminate:
+    // true` does not take it out with the others.
+    expect(runtimePatch).toContain("Tool execution delegated to client")
+    expect(runtimePatch).not.toContain(
+      "delegated to client must not terminate",
+    )
+  })
+
   it("contains every transcript-ownership fix required by the backport", () => {
     expect(runtimePatch).toContain("reuse ingress transcript recorder")
     expect(runtimePatch).toContain("detach ingress user before orphan repair")


### PR DESCRIPTION
**This is why the quartile report never gets built.**

## What happens

A run died 484 seconds in, 53 model calls deep, with the entire report still to build. The last thing it did was repair a script and issue an `edit` whose replacement matched what was already there:

```
seq 119  assistant [text, edit]        stopReason: toolUse
seq 120  toolResult "No changes made to /tmp/qgr/merge.py. The replacement
                     text is identical to the original."  {changed: false}
seq 121  (nothing — run over)
```

`sessions-DUkbYyLt.js:6110`
```js
if (realEdits.length === 0) return {
  ...textResult(`No changes made to ${path}. …`, { changed: false }),
  terminate: true
};
```

`agent-core-DiXDJ1Ly.js:322-325`
```js
if (message.stopReason === "toolUse" && toolCalls.length > 0) {
  const executedToolBatch = await executeToolCalls(…);
  hasMoreToolCalls = !executedToolBatch.terminate;
}
```
with `shouldTerminateToolBatch = calls.length > 0 && calls.every(c => c.terminate)`.

That message carried **one** tool call, so `every` was trivially satisfied. The loop exited while the model's own `stopReason` was still `toolUse` — it was asking to continue — and the gateway broadcast `final`.

## Why it keeps happening

The trap is worst exactly where it's most likely. Repairing a file — the literal `\n` bug, psd-rules Rule 9a — means writing content that may already be correct, so **the recovery action and the kill switch are the same keystroke.** Four siblings do this:

| tool | condition | site |
|---|---|---|
| `edit` | replacement identical to original | sessions:6110 |
| `edit` | replacement produced identical content | sessions:6151 |
| `write` | file already has identical content | sessions:7981 |
| `patch` | hunk already applied | agent-tools:384 |

All four patched. `write` is the nastiest — writing a file that is already correct is not an error in any sense, and it killed runs silently.

## What is *not* patched

`agent-tool-definition-adapter:370` — *"Tool execution delegated to client"* — keeps its terminate. That's a real pause, not a no-op. Pinned by a test so a future sweep for `terminate: true` doesn't take it out with the others.

## The trade, stated

Upstream presumably wants to stop a model looping on no-op edits forever. That trade is wrong here: our turns are already bounded by the chat deadline and the two-hour job budget, so the worst case without this is a few wasted iterations, and the worst case with it is a destroyed multi-minute run.

## Verified against the real bundle

Extracted the pinned image (openclaw 2026.7.2-beta.5), ran the patch against it, confirmed: all four anchors unique, all four applied, both touched bundles still parse under `node --check`, zero `terminate: true` left in them, and a second run still fails closed on the missing anchors.

## How this was found

Four theories died on evidence first — deadline (elapsed 484 of 550), step cap (none in config or bundle), context limit (per-call output 132–1595 tokens), run fencing (`foreign_run_events=0`). The `stopReason` diagnostic added in #1663 would have answered nothing either: `broadcastChatFinal` omits `stopReason` from the payload entirely.
