### PR TITLE
fix(agent): a promoted job must not abort the run it exists to finish

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -327,6 +327,12 @@ UPSTREAM_RETRY_MAX_LATENCY_MS = 30_000
 # silently rounded back UP into an overshoot.
 UPSTREAM_RETRY_MIN_REMAINING_S = 60
 
+# Above this, a payload deadline can only be the async-job runner's explicit
+# override — interactive turns are clamped to 550 and send no override at all.
+# Mirrors agentcore_wrapper.LONG_JOB_DEADLINE_THRESHOLD_SECONDS; the two must
+# agree, because that module uses the same number to pick the long drain.
+LONG_JOB_DEADLINE_THRESHOLD_S = 600
+
 # One entry per session that asked a question and has not been answered yet.
 # This is a singleton adapter shared by every user in the container, so the
 # map is per-session; the cap keeps a session that never answers from pinning
@@ -1877,9 +1883,47 @@ class OpenClawAdapter(HarnessAdapter):
                         "instead of starting a new one"
                     )
 
-                if not answered_pending and os.environ.get(
-                    "OPENCLAW_PRESEND_ABORT", "1"
-                ) != "0":
+                # A PROMOTED JOB MUST NOT ABORT THE RUN IT EXISTS TO FINISH.
+                #
+                # The comment above is right about interactive turns and wrong
+                # about this one. Promotion happens precisely BECAUSE the
+                # OpenClaw run is still going when our deadline hits — we stop
+                # listening, the run keeps working, and a background job picks
+                # it up. That job runs on ECS, outside the router's per-session
+                # lock, so "no legitimate work is active here" is false for it.
+                #
+                # Measured on dev 2026-08-16, an Artondale quartile report:
+                #     15:06:44  deadline expired -> promoted
+                #     15:07:22  ECS job starts
+                #     15:07:53  pre-send chat.abort  ok=True
+                #     15:08:12  job posts "nothing written to the sheet yet"
+                #     15:08:47  job stops, 85s, no data extracted
+                # The job's first act killed the run it was promoted to
+                # continue, so it began from nothing and had 85 seconds. The
+                # model then told the user they had interrupted it — true, and
+                # not the user.
+                #
+                # A long-job deadline is the marker: only the job runner sends
+                # deadline_s, and it is clamped above the interactive ceiling
+                # (agentcore_wrapper.LONG_JOB_DEADLINE_THRESHOLD_SECONDS).
+                # Interactive turns send nothing and keep the abort, which is
+                # what clears a wedged reply session.
+                is_promoted_job = (
+                    deadline_s is not None
+                    and int(deadline_s) > LONG_JOB_DEADLINE_THRESHOLD_S
+                )
+                if is_promoted_job:
+                    logger.info(
+                        "promoted job turn: skipping the pre-send abort so the "
+                        "run this job continues is not killed (deadline_s=%s)",
+                        deadline_s,
+                    )
+
+                if (
+                    not answered_pending
+                    and not is_promoted_job
+                    and os.environ.get("OPENCLAW_PRESEND_ABORT", "1") != "0"
+                ):
                     try:
                         abort_id = str(uuid.uuid4())
                         ws.send(json.dumps({

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -34,6 +34,7 @@ Run:
 import collections
 import json
 import os
+import pathlib
 import sys
 import time
 import unittest
@@ -1363,3 +1364,65 @@ class SegmentsEndAtAnyModelActivity(unittest.TestCase):
         # is how the user got "Fix that single line directly." as a reply.
         text = replay([says("Only the load_csv line is broken."), runs_task()])
         self.assertNotIn("load_csv", text)
+
+
+class PromotedJobDoesNotAbortTheRunItContinues(unittest.TestCase):
+    """Measured on dev 2026-08-16 (Artondale quartile report):
+
+        15:06:44  deadline expired -> promoted to a background job
+        15:07:22  ECS job starts
+        15:07:53  pre-send chat.abort  ok=True
+        15:08:12  job posts "nothing written to the sheet yet"
+        15:08:47  job stops — 85 seconds, no data extracted
+
+    Promotion happens BECAUSE the OpenClaw run is still going when our
+    deadline hits. The job's first act was to abort it, so it started from
+    nothing. The model then told the user they had interrupted it — true, and
+    not the user.
+
+    Only the job runner sends deadline_s, clamped above the interactive
+    ceiling, so that is the marker.
+    """
+
+    LONG = harness_adapter.LONG_JOB_DEADLINE_THRESHOLD_S + 1
+
+    def _run(self, deadline_s):
+        gateway = FakeGateway([says("done.")])
+        fake_websocket = mock.Mock()
+        fake_websocket.create_connection.return_value = gateway
+        fake_websocket.WebSocketTimeoutException = _FakeTimeout
+        adapter = OpenClawAdapter()
+        adapter._ready = True
+        zero = {"model_calls": 0, "input": 0, "output": 0,
+                "cache_read": 0, "cache_write": 0}
+        with mock.patch.dict(sys.modules, {"websocket": fake_websocket}), \
+             mock.patch.object(OpenClawAdapter, "_read_turn_usage", return_value=zero), \
+             mock.patch.object(harness_adapter, "record_failure"):
+            adapter._process_once("go", "s1", deadline_s=deadline_s)
+        return [m.get("method") for m in gateway.sent]
+
+    def test_a_promoted_job_turn_sends_no_pre_send_abort(self):
+        self.assertNotIn("chat.abort", self._run(self.LONG))
+
+    def test_a_promoted_job_turn_still_sends_the_message(self):
+        self.assertIn("chat.send", self._run(self.LONG))
+
+    def test_an_interactive_turn_keeps_the_abort(self):
+        # The abort still clears a wedged reply session on the path it was
+        # written for (2026-07-01, "I encountered an error" on every follow-up).
+        self.assertIn("chat.abort", self._run(None))
+
+    def test_a_short_explicit_deadline_is_not_a_promoted_job(self):
+        # Cron sends its own bounded deadline; only the long-job override
+        # clears the threshold.
+        self.assertIn("chat.abort", self._run(120))
+
+    def test_the_threshold_matches_the_wrapper(self):
+        # Two modules keying off one number. If the wrapper's threshold moves,
+        # a promoted job silently starts aborting itself again.
+        wrapper = pathlib.Path(__file__).with_name("agentcore_wrapper.py").read_text()
+        self.assertIn(
+            f"LONG_JOB_DEADLINE_THRESHOLD_SECONDS = "
+            f"{harness_adapter.LONG_JOB_DEADLINE_THRESHOLD_S}",
+            wrapper,
+        )


### PR DESCRIPTION
Measured on dev, an Artondale quartile report:

```
15:06:44  deadline expired -> promoted to a background job
15:07:22  ECS job starts
15:07:53  pre-send chat.abort  ok=True
15:08:12  job posts "nothing has been written to the sheet yet"
15:08:47  job stops — 85 seconds, no data extracted
```

**The job's first act was to kill the run it was promoted to continue.**

Promotion exists precisely because the OpenClaw run is still going when our 550s deadline hits — we stop listening, the run keeps working, a background job picks it up. The pre-send abort's own comment says it is safe because *"the router already serializes turns per session (a DynamoDB session lock), so no legitimate work for this sessionKey is active here."* That holds for interactive turns. It is false for a promoted job, which runs on ECS **outside** that lock — the one case where live work is guaranteed to exist.

So the job began from nothing every time, and the model told the user they had interrupted it. True, and not the user. Same shape as the pending-question abort fixed in #1660; that fix covered questions, this is the general case.

## The marker

Only the job runner sends `deadline_s`, clamped above the interactive ceiling. `LONG_JOB_DEADLINE_THRESHOLD_S = 600` mirrors `agentcore_wrapper.LONG_JOB_DEADLINE_THRESHOLD_SECONDS`, which already uses the same number to select the long proxy drain. A test asserts the two literals agree — two modules keying off one constant is how this silently regresses.

Interactive turns keep the abort. It exists for a real failure (2026-07-01: a surviving reply session made every follow-up return "I encountered an error") and nothing here touches it. Cron sends its own bounded deadline and stays interactive by the same threshold.

```
restore the unconditional abort -> test_a_promoted_job_turn_sends_no_pre_send_abort FAILS
```

830 image tests, bootstrap budget clean.