### PR TITLE
feat(quartile): build the whole report in one command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           infra/agent-image/skills/quartile-growth-report/scripts/test_norms_values.py \
           infra/agent-image/skills/quartile-growth-report/scripts/test_aggregate.py \
           infra/agent-image/skills/quartile-growth-report/scripts/test_build_tab.py \
+          infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py \
           infra/agent-image/skills/psd-rules/scripts/test_repair_literal_newlines.py
 
     - name: Run model-UID isolation test as root

--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -38,13 +38,34 @@ as a "summary" row or a note next to a number.
    **Keep the section -> teacher map from this step** and pass it to
    `build_tab.py --teachers`; the classroom columns are headed by teacher
    name, not section id.
-3. Per grade, **extract → aggregate → build** (see `references/sql.md`):
-   - run the extraction query — raw matched pairs, no `NTILE`, no norms join,
-     no `GROUPING SETS`
-   - `scripts/aggregate.py` — applies the norms, computes every quartile scope
-   - `scripts/build_tab.py` — emits the gws request body for that tab
-4. Build ONE spreadsheet with `psd-workspace`: a tab per grade + Definitions.
-5. Share it and paste the bare URL on its own line.
+3. **Run the report — ONE command.** It does the roster, every grade's
+   extraction, the aggregation, the tabs, the Definitions tab, and the share:
+
+   ```bash
+   /opt/agentcore-venv/bin/python3 \
+     /opt/psd-skills/quartile-growth-report/scripts/run_report.py \
+     --school "<school>" --user "<caller email>"
+   ```
+
+   It prints the spreadsheet URL on stdout and progress on stderr.
+4. Paste that bare URL on its own line.
+
+**Do not orchestrate this yourself.** Between 2026-08-14 and 2026-08-16 this
+report failed five times running, and not once on the arithmetic: a no-op edit
+ended the run, four assistant messages fused into one reply, a promoted
+background job aborted the run it was meant to continue, `--export` timed out,
+and the write tool put literal newline escapes in a model-authored converter.
+Every one of those was orchestration. `run_report.py` runs inside a single
+exec, so the turn deadline, the promotion, and the continuation turn stop
+applying at all.
+
+**If it fails, re-run the same command.** Every step checkpoints to
+`--work-dir` (default `/tmp/qgr-<school>`), so a second run resumes from where
+it stopped instead of starting over. Report the error it printed; do not
+rebuild its steps by hand.
+
+`--dry-run` resolves the school, year and roster and prints the plan without
+touching a spreadsheet. Use it when the user asks what the report will cover.
 
 **Write no scripts. Author no files.** Every step ships as a script that takes
 the previous step's output and emits the next step's input, ending in a body

--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -50,39 +50,30 @@ as a "summary" row or a note next to a number.
    It prints the spreadsheet URL on stdout and progress on stderr.
 4. Paste that bare URL on its own line.
 
-**What the one command covers — and what it does not.** `run_report.py` builds
-the **DIBELS growth** half of this report: it queries `dibels_scores` only. It
-does **not** build, and does not pass `--subgroup` for:
+**What the one command covers.** `run_report.py` builds the report:
 
-| Not built by `run_report.py` | Where it is defined |
+| Block | Notes |
 |---|---|
-| SBA grades 4-5 (scale change vs prior year) | ## Measures |
-| SBA grade 3 (spring scale + % met by Fall i-Ready quartile) | ## Measures |
-| SBA proficiency (% met, ELA/Math) | ## Measures |
-| i-Ready Reading / Math percentile change | ## Measures |
-| Low Income / Special Ed subgroup rollups | ## Subgroups |
+| DIBELS growth + national PR | per-measure baselines; K is Winter, grade 1 ORF is Winter |
+| i-Ready Reading / Math | percentile change, no norms; skipped for K |
+| SBA grades 4-5 | scale change vs the prior-year summative |
+| Low Income / Special Ed subgroups | flags joined DISTRICT-WIDE |
 
-**Say so when you hand over the sheet.** A workbook from the one command is a
-DIBELS growth report, not the full "Teacher Quartile Growth and SBA
-Proficiency" report it is modeled on. Reporting it as complete is the same
-"looks complete, isn't" failure as the Minter Creek grade span — the principal
-cannot tell from the sheet that a measure was never queried. If the request
-needs SBA, i-Ready or subgroups, build those blocks by hand (see *How to run
-it by hand* below) and add them, or tell the user which measures are missing.
+**Anything it cannot produce is written INTO the tab** under `NOT INCLUDED IN
+THIS REPORT`, with the reason — a failed query, no matched students, or a
+table it could not find. Do not delete those rows and do not call the report
+complete while they are present.
 
-**Do not orchestrate this yourself.** Between 2026-08-14 and 2026-08-16 this
-report failed five times running, and not once on the arithmetic: a no-op edit
-ended the run, four assistant messages fused into one reply, a promoted
-background job aborted the run it was meant to continue, `--export` timed out,
-and the write tool put literal newline escapes in a model-authored converter.
-Every one of those was orchestration. `run_report.py` runs inside a single
-exec, so the turn deadline, the promotion, and the continuation turn stop
-applying at all.
+That banner is the whole point. Every past failure of this report was
+invisible at the point of use — the Minter Creek grade span, the District
+column mirroring School, the missing teacher names. A principal cannot tell
+from a sheet that a measure was never queried, so the sheet has to say it.
 
-**If it fails, re-run the same command.** Every step checkpoints to
-`--work-dir` (default `/tmp/qgr-<school>`), so a second run resumes from where
-it stopped instead of starting over. Report the error it printed; do not
-rebuild its steps by hand.
+Two blocks report themselves as gaps today: **SBA grade 3**, which needs the
+Fall i-Ready quartile, and **i-Ready** where the warehouse table cannot be
+found (its name is not recorded in this skill, unlike `smarter_balanced_scores`
+and `students_frl`, so the script probes for it). Confirm the table name and
+they stop being gaps.
 
 `--dry-run` resolves the school, year and roster and prints the plan without
 touching a spreadsheet. Use it when the user asks what the report will cover.
@@ -145,14 +136,14 @@ every measure for the grade at once. Per-measure querying turns 6 grades into
 
 **Everything from here to the end of this section applies only when
 `run_report.py` cannot be used** (it is unavailable, or it fails in a way a
-re-run does not clear, or you are covering a measure it does not build — see
+re-run does not clear, or you are covering a block it reports as a gap — see
 *What the one command covers* above). For a normal quartile growth report, stop
 reading here and run the one command in step 3.
 
-This section describes the manual orchestration path, and it is kept because
-that path is still the only way to reach SBA, i-Ready and the subgroup
-rollups. Do not read it as the default; the five consecutive failures that
-motivated `run_report.py` all happened on this path.
+This section describes the manual orchestration path. It is kept for the
+blocks the one command still reports as gaps, and for debugging. Do not read
+it as the default; the five consecutive failures that motivated
+`run_report.py` all happened on this path.
 
 **Work the grades one at a time, in this turn, start to finish.** Run a grade's
 measure blocks, keep the rows, move to the next grade. Do not parallelize, do

--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -87,6 +87,17 @@ rebuild its steps by hand.
 `--dry-run` resolves the school, year and roster and prints the plan without
 touching a spreadsheet. Use it when the user asks what the report will cover.
 
+**What it covers**: DIBELS growth with national PR, i-Ready Reading/Math
+(skipped for K), SBA grades 4-5 against the prior-year summative, and the Low
+Income / Special Ed subgroup rollups joined district-wide.
+
+**Anything it cannot produce is written INTO the tab** under "NOT INCLUDED IN
+THIS REPORT", with the reason. Do not remove those rows, and do not describe
+the report as complete when they are present — a principal does not read the
+run log, and a workbook that silently omits SBA looks finished and is not.
+SBA grade 3 needs the Fall i-Ready quartile and reports itself as a gap until
+that table is confirmed.
+
 **Write no scripts. Author no files.** Every step ships as a script that takes
 the previous step's output and emits the next step's input, ending in a body
 you pipe straight into `gws`:

--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -78,17 +78,6 @@ they stop being gaps.
 `--dry-run` resolves the school, year and roster and prints the plan without
 touching a spreadsheet. Use it when the user asks what the report will cover.
 
-**What it covers**: DIBELS growth with national PR, i-Ready Reading/Math
-(skipped for K), SBA grades 4-5 against the prior-year summative, and the Low
-Income / Special Ed subgroup rollups joined district-wide.
-
-**Anything it cannot produce is written INTO the tab** under "NOT INCLUDED IN
-THIS REPORT", with the reason. Do not remove those rows, and do not describe
-the report as complete when they are present — a principal does not read the
-run log, and a workbook that silently omits SBA looks finished and is not.
-SBA grade 3 needs the Fall i-Ready quartile and reports itself as a gap until
-that table is confirmed.
-
 **Write no scripts. Author no files.** Every step ships as a script that takes
 the previous step's output and emits the next step's input, ending in a body
 you pipe straight into `gws`:

--- a/infra/agent-image/skills/quartile-growth-report/SKILL.md
+++ b/infra/agent-image/skills/quartile-growth-report/SKILL.md
@@ -50,6 +50,26 @@ as a "summary" row or a note next to a number.
    It prints the spreadsheet URL on stdout and progress on stderr.
 4. Paste that bare URL on its own line.
 
+**What the one command covers — and what it does not.** `run_report.py` builds
+the **DIBELS growth** half of this report: it queries `dibels_scores` only. It
+does **not** build, and does not pass `--subgroup` for:
+
+| Not built by `run_report.py` | Where it is defined |
+|---|---|
+| SBA grades 4-5 (scale change vs prior year) | ## Measures |
+| SBA grade 3 (spring scale + % met by Fall i-Ready quartile) | ## Measures |
+| SBA proficiency (% met, ELA/Math) | ## Measures |
+| i-Ready Reading / Math percentile change | ## Measures |
+| Low Income / Special Ed subgroup rollups | ## Subgroups |
+
+**Say so when you hand over the sheet.** A workbook from the one command is a
+DIBELS growth report, not the full "Teacher Quartile Growth and SBA
+Proficiency" report it is modeled on. Reporting it as complete is the same
+"looks complete, isn't" failure as the Minter Creek grade span — the principal
+cannot tell from the sheet that a measure was never queried. If the request
+needs SBA, i-Ready or subgroups, build those blocks by hand (see *How to run
+it by hand* below) and add them, or tell the user which measures are missing.
+
 **Do not orchestrate this yourself.** Between 2026-08-14 and 2026-08-16 this
 report failed five times running, and not once on the arithmetic: a no-op edit
 ended the run, four assistant messages fused into one reply, a promoted
@@ -110,7 +130,18 @@ into it.
 every measure for the grade at once. Per-measure querying turns 6 grades into
 30+ round trips and is what makes this report feel endless.
 
-### How to run it
+### How to run it by hand — FALLBACK ONLY
+
+**Everything from here to the end of this section applies only when
+`run_report.py` cannot be used** (it is unavailable, or it fails in a way a
+re-run does not clear, or you are covering a measure it does not build — see
+*What the one command covers* above). For a normal quartile growth report, stop
+reading here and run the one command in step 3.
+
+This section describes the manual orchestration path, and it is kept because
+that path is still the only way to reach SBA, i-Ready and the subgroup
+rollups. Do not read it as the default; the five consecutive failures that
+motivated `run_report.py` all happened on this path.
 
 **Work the grades one at a time, in this turn, start to finish.** Run a grade's
 measure blocks, keep the rows, move to the next grade. Do not parallelize, do

--- a/infra/agent-image/skills/quartile-growth-report/scripts/build_tab.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/build_tab.py
@@ -82,7 +82,8 @@ def window_for(meas, window):
     return window
 
 
-def build(records, school, grade, year, window, sections=None, teachers=None):
+def build(records, school, grade, year, window, sections=None, teachers=None,
+          gaps=()):
     """One tab's grid: a block per measure, quartile rows, then subgroups."""
     by_measure = defaultdict(lambda: defaultdict(dict))
     subgroups = defaultdict(list)
@@ -125,6 +126,16 @@ def build(records, school, grade, year, window, sections=None, teachers=None):
             values.append(row)
         values.append([BLANK])
 
+    if gaps:
+        # A block that could not be produced is stated IN THE WORKBOOK. A
+        # principal does not read the run log, and a report that silently
+        # omits SBA or i-Ready looks complete and is not — the exact failure
+        # this report has produced repeatedly in other forms.
+        values.append(["NOT INCLUDED IN THIS REPORT"])
+        for gap in gaps:
+            values.append([gap])
+        values.append([BLANK])
+
     if subgroups:
         values.append(['Subgroups (All level) — School vs District'])
         values.append(["Subgroup", "Measure", "School", "District"])
@@ -155,6 +166,11 @@ def main() -> int:
         "Fall→Spring is a wrong report, not a cosmetic slip. May be a JSON "
         'object mapping measure to label ({"ORF-WRC": "Winter→Spring", '
         '"*": "Fall→Spring"}) when one grade mixes baselines.',
+    )
+    parser.add_argument(
+        "--gaps",
+        help="JSON list of measure families that could not be produced; "
+        "rendered in the tab so an omission is visible to the reader",
     )
     parser.add_argument(
         "--teachers",
@@ -217,8 +233,16 @@ def main() -> int:
                 "--teachers must be a JSON object mapping sectionid to teacher "
                 f"name, got {type(teachers).__name__}"
             )
+    gaps = []
+    if args.gaps:
+        try:
+            gaps = json.loads(args.gaps)
+        except (json.JSONDecodeError, ValueError) as exc:
+            parser.error(f"--gaps is not valid JSON ({exc})")
+
     tab = build(
-        records, args.school, args.grade, args.year, window, teachers=teachers
+        records, args.school, args.grade, args.year, window,
+        teachers=teachers, gaps=gaps,
     )
 
     if args.emit == "grid":

--- a/infra/agent-image/skills/quartile-growth-report/scripts/build_tab.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/build_tab.py
@@ -68,6 +68,20 @@ def column_label(section_id, teachers):
     return f"{name} ({section_id})"
 
 
+def window_for(meas, window):
+    """The window label for one measure block.
+
+    Usually one string for the whole tab. But a grade can mix baselines —
+    grade 1 ORF starts mid-year, so it is Winter->Spring while everything else
+    in that grade is Fall->Spring — and labelling those blocks identically
+    would misstate what was measured. A dict maps measure to label; a plain
+    string still applies to every block.
+    """
+    if isinstance(window, dict):
+        return window.get(meas) or window.get("*") or ""
+    return window
+
+
 def build(records, school, grade, year, window, sections=None, teachers=None):
     """One tab's grid: a block per measure, quartile rows, then subgroups."""
     by_measure = defaultdict(lambda: defaultdict(dict))
@@ -96,7 +110,7 @@ def build(records, school, grade, year, window, sections=None, teachers=None):
 
     for meas in sorted(by_measure):
         scopes = by_measure[meas]
-        values.append([f"{meas} ({window})"])
+        values.append([f"{meas} ({window_for(meas, window)})"])
         values.append(
             ["Quartile"]
             + [column_label(s, teachers) for s in section_ids]
@@ -138,7 +152,9 @@ def main() -> int:
         "--window",
         default="Fall→Spring",
         help="the window ACTUALLY used; a Fall→Winter report labeled "
-        "Fall→Spring is a wrong report, not a cosmetic slip",
+        "Fall→Spring is a wrong report, not a cosmetic slip. May be a JSON "
+        'object mapping measure to label ({"ORF-WRC": "Winter→Spring", '
+        '"*": "Fall→Spring"}) when one grade mixes baselines.',
     )
     parser.add_argument(
         "--teachers",
@@ -177,6 +193,13 @@ def main() -> int:
         if args.rows:
             handle.close()
 
+    window = args.window
+    if window.strip().startswith("{"):
+        try:
+            window = json.loads(window)
+        except (json.JSONDecodeError, ValueError) as exc:
+            parser.error(f"--window is not valid JSON ({exc})")
+
     teachers = None
     if args.teachers:
         # A raw JSONDecodeError here reads as a script bug and costs the agent
@@ -195,7 +218,7 @@ def main() -> int:
                 f"name, got {type(teachers).__name__}"
             )
     tab = build(
-        records, args.school, args.grade, args.year, args.window, teachers=teachers
+        records, args.school, args.grade, args.year, window, teachers=teachers
     )
 
     if args.emit == "grid":

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -828,12 +828,14 @@ def main() -> int:
                 log(f"grade {grade}: already written")
                 continue
             log(f"grade {grade}: extracting")
+            gaps = []
             measures = step(work_dir, f"grade-{grade}-measures",
                             lambda g=grade: discover_measures(yearid, g), log)
             if not measures:
-                log(f"grade {grade}: no DIBELS measures present — skipping")
-                step(work_dir, done_marker, lambda: {"skipped": "no measures"}, log)
-                continue
+                log(f"grade {grade}: no DIBELS measures present")
+                gaps.append(
+                    "DIBELS growth: not included "
+                    "(no DIBELS measures recorded for this grade)")
 
             # One pass per distinct baseline. Grade 1 ORF starts mid-year, so
             # it runs Winter→Spring while the rest of grade 1 runs
@@ -845,14 +847,30 @@ def main() -> int:
             for baseline, group in sorted(groups.items()):
                 tag = f"grade-{grade}-{baseline.lower()}"
                 log(f"grade {grade}: {baseline}→Spring for {', '.join(group)}")
-                rows = step(
-                    work_dir, f"{tag}-rows",
-                    lambda g=grade, b=baseline, m=group: query_all(
-                        extraction_sql(schoolid, yearid, g, m, b),
-                        f"Matched {b}/Spring pairs for grade {g}"),
-                    log)
+                try:
+                    rows = step(
+                        work_dir, f"{tag}-rows",
+                        lambda g=grade, b=baseline, m=group: query_all(
+                            extraction_sql(schoolid, yearid, g, m, b),
+                            f"Matched {b}/Spring pairs for grade {g}"),
+                        log)
+                except ReportError as exc:
+                    log(f"grade {grade}: {baseline} extraction FAILED — {exc}")
+                    gaps.append(
+                        f"DIBELS {', '.join(group)} ({baseline}→Spring): "
+                        f"not included (query failed: {str(exc)[:160]})")
+                    continue
                 if not rows:
+                    # SKILL.md's contract is "anything it cannot produce is
+                    # written INTO the tab", and the DIBELS block is the one
+                    # the whole report is named for. Logging and moving on
+                    # would leave the primary measures silently absent while
+                    # SBA and i-Ready announced themselves — the exact
+                    # asymmetry that makes a workbook look complete.
                     log(f"grade {grade}: no {baseline} matched pairs")
+                    gaps.append(
+                        f"DIBELS {', '.join(group)} ({baseline}→Spring): "
+                        "not included (no matched students)")
                     continue
                 log(f"grade {grade}: {len(rows)} rows ({baseline})")
                 part = step(
@@ -864,8 +882,6 @@ def main() -> int:
                 records.extend(part)
                 for measure in group:
                     windows[measure] = f"{baseline}→Spring"
-
-            gaps = []
 
             # i-Ready. Skipped for K by SKILL.md (not district-representative).
             if grade != "K":

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -56,9 +56,41 @@ MAX_PAGES = 40
 # Grades in report order. K sorts first and is stored as "K", not 0.
 DEFAULT_GRADES = ["K", "1", "2", "3", "4", "5"]
 
-# Per-grade DIBELS measures. Grade 1 ORF starts mid-year and K has no Fall
-# DIBELS at all, both per SKILL.md's Windows table.
+# Baselines are PER MEASURE, not per grade. SKILL.md's Windows table gives two
+# exceptions and they are different shapes: K DIBELS has no Fall administration
+# at all, while in grade 1 only ORF starts mid-year — every other grade-1
+# measure has Fall data.
+#
+# Modelling this per grade looked simpler and silently dropped data: one
+# baseline applied to a whole grade means the matched-pair join returns ZERO
+# rows for any measure that lacks that window, so grade 1 ORF would vanish
+# from the tab with no error and nothing to notice on a re-run. Review caught
+# it. A measure missing from a report is worse than a report that fails.
+BASELINE_DEFAULT = "Fall"
 BASELINE_BY_GRADE = {"K": "Winter"}
+BASELINE_BY_GRADE_MEASURE = {("1", "ORF"): "Winter"}
+
+
+def baseline_for(grade, measure):
+    """The baseline window for one measure in one grade.
+
+    Matched on an ORF prefix rather than an exact name because the warehouse's
+    spelling is not guaranteed to be the norms file's — that mismatch is why
+    every measure name is discovered rather than assumed.
+    """
+    grade = str(grade)
+    for (g, prefix), window in BASELINE_BY_GRADE_MEASURE.items():
+        if g == grade and str(measure).upper().startswith(prefix):
+            return window
+    return BASELINE_BY_GRADE.get(grade, BASELINE_DEFAULT)
+
+
+def group_by_baseline(grade, measures):
+    """{baseline: [measure, ...]} — one extraction pass per distinct window."""
+    groups = {}
+    for measure in measures:
+        groups.setdefault(baseline_for(grade, measure), []).append(measure)
+    return groups
 
 
 class ReportError(RuntimeError):
@@ -383,7 +415,22 @@ def share_workbook(sheet_id, user):
     )
 
 
-def add_tab(sheet_id, title, user, work_dir):
+def add_tab(sheet_id, title, user, work_dir, log=lambda m: None):
+    """Create one tab, ONCE.
+
+    Checkpointed like every other side effect. Without it, a failure between
+    the tab creation and the grade's done-marker leaves the tab present and
+    the marker absent, so the re-run tries to add it again, Sheets rejects the
+    duplicate, and the report is permanently stuck — a re-run that cannot
+    succeed is worse than no checkpointing at all. Review caught this; it is
+    exactly the failure class this script exists to remove.
+    """
+    return step(work_dir, f"tab-{title}-added",
+                lambda: {"result": _add_tab(sheet_id, title, user, work_dir)},
+                log)
+
+
+def _add_tab(sheet_id, title, user, work_dir):
     payload = work_dir / f"addsheet-{title}.json"
     payload.write_text(json.dumps(
         {"requests": [{"addSheet": {"properties": {"title": str(title)}}}]}))
@@ -508,6 +555,13 @@ def main() -> int:
                         lambda: {"id": create_workbook(title, args.user)},
                         log)["id"]
         url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/edit"
+        # Share IMMEDIATELY, not after the last grade. The URL is printed the
+        # moment the workbook exists, and until the transfer the agent account
+        # owns it — so a run that dies partway through would surface a link
+        # the user cannot open. That undercuts the whole point of a
+        # diagnosable partial run.
+        step(work_dir, "shared",
+             lambda: {"result": share_workbook(sheet_id, args.user)}, log)
         log(f"  workbook: {url}")
 
         for grade in grades:
@@ -516,7 +570,6 @@ def main() -> int:
                 log(f"grade {grade}: already written")
                 continue
             log(f"grade {grade}: extracting")
-            baseline = BASELINE_BY_GRADE.get(grade, "Fall")
             measures = step(work_dir, f"grade-{grade}-measures",
                             lambda g=grade: discover_measures(yearid, g), log)
             if not measures:
@@ -524,46 +577,61 @@ def main() -> int:
                 step(work_dir, done_marker, lambda: {"skipped": "no measures"}, log)
                 continue
 
-            rows = step(
-                work_dir, f"grade-{grade}-rows",
-                lambda g=grade, b=baseline, m=measures: query_all(
-                    extraction_sql(schoolid, yearid, g, m, b),
-                    f"Matched {b}/Spring pairs for grade {g}"),
-                log)
-            if not rows:
-                log(f"grade {grade}: no matched pairs — skipping")
+            # One pass per distinct baseline. Grade 1 ORF starts mid-year, so
+            # it runs Winter→Spring while the rest of grade 1 runs
+            # Fall→Spring; a single pass would return zero matched pairs for
+            # the odd measure and drop it from the tab silently.
+            groups = group_by_baseline(grade, measures)
+            windows = {}
+            records = []
+            for baseline, group in sorted(groups.items()):
+                tag = f"grade-{grade}-{baseline.lower()}"
+                log(f"grade {grade}: {baseline}→Spring for {', '.join(group)}")
+                rows = step(
+                    work_dir, f"{tag}-rows",
+                    lambda g=grade, b=baseline, m=group: query_all(
+                        extraction_sql(schoolid, yearid, g, m, b),
+                        f"Matched {b}/Spring pairs for grade {g}"),
+                    log)
+                if not rows:
+                    log(f"grade {grade}: no {baseline} matched pairs")
+                    continue
+                log(f"grade {grade}: {len(rows)} rows ({baseline})")
+                part = step(
+                    work_dir, f"{tag}-agg",
+                    lambda g=grade, b=baseline, t=tag: aggregate_rows(
+                        work_dir / f"{t}-rows.json", g, b),
+                    log)
+                records.extend(part)
+                for measure in group:
+                    windows[measure] = f"{baseline}→Spring"
+
+            if not records:
+                log(f"grade {grade}: no matched pairs at all — skipping")
                 step(work_dir, done_marker, lambda: {"skipped": "no rows"}, log)
                 continue
-            log(f"grade {grade}: {len(rows)} matched rows")
 
-            rows_path = work_dir / f"grade-{grade}-rows.json"
-            records = step(
-                work_dir, f"grade-{grade}-agg",
-                lambda g=grade, b=baseline: aggregate_rows(rows_path, g, b),
-                log)
-            records_path = work_dir / f"grade-{grade}-agg.json"
-
-            window = f"{baseline}→Spring"
+            records_path = work_dir / f"grade-{grade}-records.json"
+            records_path.write_text(json.dumps(records))
+            windows["*"] = f"{BASELINE_DEFAULT}→Spring"
             body = step(
                 work_dir, f"grade-{grade}-values",
-                lambda g=grade, w=window: build_values(
+                lambda g=grade, w=windows: build_values(
                     records_path, school["school_name"], g,
-                    year["year_name"], w, roster["teachers"]),
+                    year["year_name"], json.dumps(w), roster["teachers"]),
                 log)
 
-            add_tab(sheet_id, grade, args.user, work_dir)
+            add_tab(sheet_id, grade, args.user, work_dir, log)
             write_tab(sheet_id, body, args.user, work_dir, grade)
-            step(work_dir, done_marker, lambda: {"rows": len(rows)}, log)
+            step(work_dir, done_marker, lambda: {"records": len(records)}, log)
             log(f"grade {grade}: written")
 
         if not (work_dir / "definitions-written.json").exists():
-            add_tab(sheet_id, "Definitions", args.user, work_dir)
+            add_tab(sheet_id, "Definitions", args.user, work_dir, log)
             write_tab(sheet_id, definitions_values(), args.user,
                       work_dir, "Definitions")
             step(work_dir, "definitions-written", lambda: {"ok": True}, log)
 
-        step(work_dir, "shared",
-             lambda: {"result": share_workbook(sheet_id, args.user)}, log)
         log("done")
         print(url)
         return 0

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""Build the whole quartile growth report in one command.
+
+WHY THIS EXISTS
+
+The report's arithmetic was never the problem. Between 2026-08-14 and
+2026-08-16 it failed on: a no-op edit ending the run, four assistant messages
+fusing into one reply, a promoted background job aborting the run it existed to
+continue, `--export` timing out, and the write tool emitting literal newline
+escapes into model-authored glue. Every one of those is ORCHESTRATION. Not one
+was in the quartiles, the norms, or the rollups.
+
+That path has roughly eight serial failure points, and a run only ever reveals
+the first one that fires — fix it, and the next run shows the next. So this
+removes the path instead of hardening it. The agent's job becomes: resolve the
+school, run this once, paste the link.
+
+WHAT THAT DELETES
+
+  - ~100 model round-trips, each a chance to derail
+  - model-authored files, so the literal-newline bug is unreachable
+  - the turn deadline, the promotion, and the continuation turn: this runs
+    inside ONE exec, and re-running resumes from its checkpoints
+
+WHAT IT DOES NOT FIX
+
+Whether the numbers are right. It makes that answerable — the same school can
+be run twice and diffed — which the previous design never allowed.
+
+USAGE
+
+    run_report.py --school "Artondale Elementary" --user you@psd401.net
+                  [--year 2025-26] [--grades K,1,2,3,4,5]
+                  [--work-dir DIR] [--dry-run] [--plan-only]
+
+Re-running with the same --work-dir skips work already done.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+PSD_DATA = "/opt/psd-skills/psd-data/run.js"
+WORKSPACE = "/opt/psd-skills/psd-workspace/run.js"
+PYTHON = sys.executable or "/opt/agentcore-venv/bin/python3"
+
+# psd-data rate-limits at 60 req/min/user, so pages are deliberately large:
+# a whole grade should be one or two calls, not twenty.
+PAGE_SIZE = 5000
+MAX_PAGES = 40
+
+# Grades in report order. K sorts first and is stored as "K", not 0.
+DEFAULT_GRADES = ["K", "1", "2", "3", "4", "5"]
+
+# Per-grade DIBELS measures. Grade 1 ORF starts mid-year and K has no Fall
+# DIBELS at all, both per SKILL.md's Windows table.
+BASELINE_BY_GRADE = {"K": "Winter"}
+
+
+class ReportError(RuntimeError):
+    """A failure worth stopping the whole report for."""
+
+
+def sql_escape(value):
+    """Single-quote escaping for an inlined literal.
+
+    The MCP takes SQL text, so a school name with an apostrophe would break
+    the statement. School and year names are the only caller-supplied values
+    that reach SQL here, and psd-data rejects anything that is not a SELECT.
+    """
+    return str(value).replace("'", "''")
+
+
+def run_json(argv, what):
+    """Run a command and parse its stdout as JSON.
+
+    Errors carry the command's own stderr. A report that dies on step 4 of 30
+    is only debuggable if the failure says which step and what the tool said.
+    """
+    done = subprocess.run(argv, capture_output=True, text=True)
+    if done.returncode != 0:
+        raise ReportError(
+            f"{what} failed (exit {done.returncode}): "
+            f"{(done.stderr or done.stdout or '').strip()[:800]}"
+        )
+    text = (done.stdout or "").strip()
+    if not text:
+        raise ReportError(f"{what} returned nothing")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        # Some CLIs print a banner before the payload; take the first JSON
+        # value rather than failing on a cosmetic prefix.
+        match = re.search(r"[\[{].*[\]}]", text, re.S)
+        if not match:
+            raise ReportError(f"{what} did not return JSON: {text[:400]}")
+        return json.loads(match.group(0))
+
+
+def query(sql, reason, limit=None, offset=None):
+    """One psd-data SELECT.
+
+    NOT `--export`. Export mode timed out repeatedly on the grade-K extraction
+    on 2026-08-16 while the same query in normal mode returned 2,232 rows in
+    seconds, and it has a separate history of silently dropping numeric
+    columns from the CSV. Paging is more calls and has actually worked.
+    """
+    argv = ["node", PSD_DATA, "query", "--reason", reason, "--sql", sql]
+    if limit is not None:
+        argv += ["--limit", str(limit)]
+    if offset is not None:
+        argv += ["--offset", str(offset)]
+    payload = run_json(argv, f"psd-data query ({reason})")
+    rows = payload.get("rows") if isinstance(payload, dict) else payload
+    return rows or []
+
+
+def query_all(sql, reason):
+    """Page a SELECT to completion."""
+    out = []
+    for page in range(MAX_PAGES):
+        rows = query(sql, reason, limit=PAGE_SIZE, offset=page * PAGE_SIZE)
+        out.extend(rows)
+        if len(rows) < PAGE_SIZE:
+            return out
+    raise ReportError(
+        f"{reason}: still returning full pages after {MAX_PAGES} "
+        f"({len(out)} rows) — refusing to page forever"
+    )
+
+
+def workspace(command, user, scope="agent", json_file=None):
+    """One psd-workspace (gws) call.
+
+    Documents are created with --scope agent and shared explicitly; creating
+    on the user slot is impersonation and is hard-blocked at the skill layer.
+    """
+    argv = ["node", WORKSPACE, "--user", user, "--scope", scope]
+    if json_file:
+        command = f"{command} --json-file {json_file}"
+    argv += ["--command", command]
+    return run_json(argv, f"workspace ({command.split(' --')[0]})")
+
+
+# --- data steps ---------------------------------------------------------
+
+
+def resolve_school(name):
+    rows = query(
+        "SELECT schoolid, school_name FROM schools "
+        f"WHERE LOWER(school_name) LIKE LOWER('%{sql_escape(name)}%')",
+        f"Resolve the school named {name} for a quartile growth report",
+    )
+    if not rows:
+        raise ReportError(f"no school matched {name!r}")
+    if len(rows) > 1:
+        exact = [r for r in rows
+                 if str(r.get("school_name", "")).lower() == name.lower()]
+        if len(exact) != 1:
+            names = ", ".join(str(r.get("school_name")) for r in rows[:6])
+            raise ReportError(f"{name!r} matched {len(rows)} schools: {names}")
+        rows = exact
+    return rows[0]
+
+
+def resolve_year(year):
+    where = f"WHERE year_name = '{sql_escape(year)}'" if year else ""
+    order = "" if year else "ORDER BY yearid DESC"
+    rows = query(
+        f"SELECT yearid, year_name FROM school_years {where} {order}".strip(),
+        "Resolve the school year for a quartile growth report",
+        limit=1,
+    )
+    if not rows:
+        raise ReportError(f"no school year matched {year!r}")
+    return rows[0]
+
+
+def fetch_roster(schoolid, yearid):
+    """Homeroom sections + lead teachers + the grades actually served.
+
+    THE ROSTER DEFINES THE GRADE SPAN. On 2026-08-15 the agent announced
+    "Minter Creek is a K-2 school", invented the justification, and scoped a
+    whole report to it; Minter Creek is K-5. Nothing here may assert a span
+    that was not queried.
+
+    `role_name = 'Lead Teacher'` and never `priorityorder`, which is often
+    null. An unresolvable teacher is labelled by build_tab, not dropped.
+    """
+    rows = query_all(
+        "SELECT DISTINCT se.sectionid::text AS sectionid, "
+        "  se.course_code, "
+        "  sy.grade_level::text AS grade_level, "
+        "  t.teacher_name "
+        "FROM section_enrollments se "
+        "JOIN school_year_enrollments sy "
+        "  ON sy.studentid = se.studentid AND sy.yearid = se.yearid "
+        "LEFT JOIN section_teachers st "
+        "  ON st.sectionid = se.sectionid AND st.role_name = 'Lead Teacher' "
+        "LEFT JOIN teachers t ON t.teacherid = st.teacherid "
+        f"WHERE se.yearid = {int(yearid)} AND se.schoolid = {int(schoolid)} "
+        "  AND se.course_code LIKE 'GR0%'",
+        "Homeroom roster and lead teachers for a quartile growth report",
+    )
+    if not rows:
+        raise ReportError(
+            f"no GR0x homeroom sections for schoolid={schoolid} yearid={yearid}"
+        )
+    grades, teachers = {}, {}
+    for row in rows:
+        grade = str(row.get("grade_level") or "").strip()
+        section = str(row.get("sectionid") or "").strip()
+        if not grade or not section:
+            continue
+        grades.setdefault(grade, [])
+        if section not in grades[grade]:
+            grades[grade].append(section)
+        name = row.get("teacher_name")
+        if name:
+            teachers[section] = str(name)
+    return {"grades": grades, "teachers": teachers}
+
+
+def extraction_sql(schoolid, yearid, grade, measures, baseline):
+    """Raw matched pairs. No NTILE, no norms join, no GROUPING SETS.
+
+    Window functions do not complete against dibels_scores on this MCP at any
+    size — a bare NTILE(4) over ~1,100 rows timed out on 2026-08-15 while the
+    same query without it ran in seconds. This is the only shape that runs,
+    not a preference. Every non-text column is cast INSIDE the aggregate,
+    because export/serialisation drops unqualified numerics.
+    """
+    measure_list = ", ".join(f"'{sql_escape(m)}'" for m in measures)
+    return (
+        "WITH stu AS ("
+        "  SELECT assessment_group AS meas, studentid, \"window\", AVG(score) AS s"
+        "  FROM dibels_scores"
+        f"  WHERE yearid = {int(yearid)} AND grade_level = '{sql_escape(grade)}'"
+        f"    AND assessment_group IN ({measure_list})"
+        f"    AND \"window\" IN ('{sql_escape(baseline)}', 'Spring')"
+        "  GROUP BY 1,2,3), "
+        "m AS ("
+        "  SELECT f.meas, f.studentid, f.s AS b, sp.s AS e"
+        "  FROM stu f"
+        "  JOIN stu sp ON sp.studentid = f.studentid AND sp.meas = f.meas"
+        "    AND sp.\"window\" = 'Spring'"
+        f"  WHERE f.\"window\" = '{sql_escape(baseline)}'), "
+        "hr AS (SELECT DISTINCT ON (studentid) studentid, sectionid"
+        "  FROM section_enrollments"
+        f"  WHERE yearid = {int(yearid)} AND schoolid = {int(schoolid)}"
+        "    AND course_code LIKE 'GR0%'"
+        "  ORDER BY studentid, dateleft DESC), "
+        "sch AS (SELECT DISTINCT studentid FROM school_year_enrollments"
+        f"  WHERE yearid = {int(yearid)} AND schoolid = {int(schoolid)}"
+        f"    AND grade_level = '{sql_escape(grade)}') "
+        "SELECT m.meas, m.studentid::text AS studentid, m.b::text AS b, "
+        "  m.e::text AS e, hr.sectionid::text AS sectionid, "
+        "  (sch.studentid IS NOT NULL)::text AS in_sch "
+        "FROM m LEFT JOIN hr USING (studentid) LEFT JOIN sch USING (studentid)"
+    )
+
+
+def discover_measures(yearid, grade):
+    """Ask the warehouse which measures exist, never assume the spelling.
+
+    The norms file uses UO's names (ORF-WRC, NWF-CLS); the warehouse may
+    differ, and the join is on that string. A mismatch silently produces NULL
+    percentiles, which read as "no growth" rather than "no norms".
+    """
+    rows = query(
+        "SELECT DISTINCT assessment_group FROM dibels_scores "
+        f"WHERE yearid = {int(yearid)} AND grade_level = '{sql_escape(grade)}'",
+        f"List DIBELS measures present for grade {grade}",
+    )
+    return sorted(
+        str(r.get("assessment_group")) for r in rows if r.get("assessment_group")
+    )
+
+
+def aggregate_rows(rows_path, grade, baseline, no_norms=False):
+    argv = [
+        PYTHON, str(HERE / "aggregate.py"),
+        "--rows", str(rows_path),
+        "--grade", str(grade),
+        "--baseline", baseline,
+        "--spring", "Spring",
+    ]
+    if no_norms:
+        argv.append("--no-norms")
+    return run_json(argv, f"aggregate.py (grade {grade})")
+
+
+def build_values(records_path, school, grade, year, window, teachers):
+    argv = [
+        PYTHON, str(HERE / "build_tab.py"),
+        "--rows", str(records_path),
+        "--school", school,
+        "--grade", str(grade),
+        "--year", year,
+        "--window", window,
+        "--teachers", json.dumps(teachers),
+        "--emit", "values",
+    ]
+    return run_json(argv, f"build_tab.py (grade {grade})")
+
+
+# --- spreadsheet -------------------------------------------------------
+
+
+def create_workbook(title, user):
+    """Create the workbook on the AGENT slot, then hand it to the caller.
+
+    Creating on the user slot is impersonation and hard-blocked at the skill
+    layer. Ownership is transferred because Drive only lets an OWNER trash a
+    file — without it the user cannot delete their own report and has to open
+    a ticket (issue #1636).
+    """
+    created = workspace(
+        "sheets spreadsheets create "
+        f"--params '{json.dumps({'properties': {'title': title}})}'",
+        user,
+    )
+    sheet_id = created.get("spreadsheetId") or (
+        created.get("result") or {}).get("spreadsheetId")
+    if not sheet_id:
+        raise ReportError(f"spreadsheet create returned no id: {created}")
+    return sheet_id
+
+
+def share_workbook(sheet_id, user):
+    params = {"fileId": sheet_id, "transferOwnership": "true"}
+    body = {"type": "user", "role": "owner", "emailAddress": user}
+    return workspace(
+        f"drive permissions create --params '{json.dumps(params)}' "
+        f"--body '{json.dumps(body)}'",
+        user,
+    )
+
+
+def add_tab(sheet_id, title, user, work_dir):
+    payload = work_dir / f"addsheet-{title}.json"
+    payload.write_text(json.dumps(
+        {"requests": [{"addSheet": {"properties": {"title": str(title)}}}]}))
+    return workspace(
+        "sheets spreadsheets batchUpdate "
+        f"--params '{json.dumps({'spreadsheetId': sheet_id})}'",
+        user, json_file=str(payload),
+    )
+
+
+def write_tab(sheet_id, body, user, work_dir, title):
+    """Write one tab's values.
+
+    build_tab.py already emits the exact `values batchUpdate` body, RAW, so
+    nothing here reshapes it — that reshaping step is what the model used to
+    hand-write, and where the literal-newline bug kept landing.
+    """
+    payload = work_dir / f"values-{title}.json"
+    payload.write_text(json.dumps(body))
+    return workspace(
+        "sheets spreadsheets values batchUpdate "
+        f"--params '{json.dumps({'spreadsheetId': sheet_id})}'",
+        user, json_file=str(payload),
+    )
+
+
+def definitions_values():
+    """The Definitions tab, from the shipped reference text."""
+    path = HERE.parent / "references" / "definitions.md"
+    lines = path.read_text().splitlines() if path.exists() else [
+        "Definitions unavailable — references/definitions.md is missing.",
+    ]
+    return {
+        "valueInputOption": "RAW",
+        "data": [{"range": "Definitions!A1",
+                  "values": [[line] for line in lines]}],
+    }
+
+
+# --- checkpointing ------------------------------------------------------
+
+
+def step(work_dir, name, produce, log):
+    """Run `produce` once, then reuse its output on later runs.
+
+    Checkpointing is what makes a re-run cheap instead of a restart. The
+    previous design had none, so every interruption threw away everything —
+    which is what happened twice on 2026-08-16.
+    """
+    path = work_dir / f"{name}.json"
+    if path.exists():
+        try:
+            log(f"  {name}: reusing checkpoint")
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            # A half-written checkpoint from a killed run is not a checkpoint.
+            log(f"  {name}: checkpoint was truncated, recomputing")
+            path.unlink()
+    value = produce()
+    path.write_text(json.dumps(value, indent=1))
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a full quartile growth report in one command.",
+    )
+    parser.add_argument("--school", required=True)
+    parser.add_argument("--user", required=True, help="caller email for gws")
+    parser.add_argument("--year", help='e.g. "2025-26"; default most recent')
+    parser.add_argument("--grades", help="comma list; default the roster's own")
+    parser.add_argument("--work-dir", help="checkpoints; default /tmp/qgr-<school>")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="resolve and plan only; touch no spreadsheet")
+    parser.add_argument("--plan-only", action="store_true",
+                        help="alias for --dry-run")
+    args = parser.parse_args()
+    dry_run = args.dry_run or args.plan_only
+
+    def log(message):
+        # stderr, so stdout stays the machine-readable result.
+        print(message, file=sys.stderr, flush=True)
+
+    slug = re.sub(r"[^a-z0-9]+", "-", args.school.lower()).strip("-")
+    work_dir = pathlib.Path(args.work_dir or f"/tmp/qgr-{slug}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    log(f"work dir: {work_dir}")
+
+    try:
+        school = step(work_dir, "school",
+                      lambda: resolve_school(args.school), log)
+        year = step(work_dir, "year", lambda: resolve_year(args.year), log)
+        schoolid, yearid = school["schoolid"], year["yearid"]
+        log(f"  {school['school_name']} ({schoolid}), {year['year_name']} ({yearid})")
+
+        roster = step(work_dir, "roster",
+                      lambda: fetch_roster(schoolid, yearid), log)
+        served = sorted(roster["grades"], key=lambda g: (g != "K", g))
+        grades = [g.strip() for g in args.grades.split(",")] if args.grades else served
+        unknown = [g for g in grades if g not in roster["grades"]]
+        if unknown:
+            raise ReportError(
+                f"grade(s) {unknown} are not in this school's roster "
+                f"(served: {served})"
+            )
+        log(f"  grades served: {', '.join(served)}")
+
+        if dry_run:
+            print(json.dumps({
+                "school": school, "year": year,
+                "grades_served": served, "grades_planned": grades,
+                "sections": {g: roster["grades"][g] for g in grades},
+                "work_dir": str(work_dir),
+            }, indent=1))
+            return 0
+
+        title = (f"{school['school_name']} - Quartile Growth Report "
+                 f"({year['year_name']})")
+        sheet_id = step(work_dir, "sheet",
+                        lambda: {"id": create_workbook(title, args.user)},
+                        log)["id"]
+        url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/edit"
+        log(f"  workbook: {url}")
+
+        for grade in grades:
+            done_marker = f"grade-{grade}-written"
+            if (work_dir / f"{done_marker}.json").exists():
+                log(f"grade {grade}: already written")
+                continue
+            log(f"grade {grade}: extracting")
+            baseline = BASELINE_BY_GRADE.get(grade, "Fall")
+            measures = step(work_dir, f"grade-{grade}-measures",
+                            lambda g=grade: discover_measures(yearid, g), log)
+            if not measures:
+                log(f"grade {grade}: no DIBELS measures present — skipping")
+                step(work_dir, done_marker, lambda: {"skipped": "no measures"}, log)
+                continue
+
+            rows = step(
+                work_dir, f"grade-{grade}-rows",
+                lambda g=grade, b=baseline, m=measures: query_all(
+                    extraction_sql(schoolid, yearid, g, m, b),
+                    f"Matched {b}/Spring pairs for grade {g}"),
+                log)
+            if not rows:
+                log(f"grade {grade}: no matched pairs — skipping")
+                step(work_dir, done_marker, lambda: {"skipped": "no rows"}, log)
+                continue
+            log(f"grade {grade}: {len(rows)} matched rows")
+
+            rows_path = work_dir / f"grade-{grade}-rows.json"
+            records = step(
+                work_dir, f"grade-{grade}-agg",
+                lambda g=grade, b=baseline: aggregate_rows(rows_path, g, b),
+                log)
+            records_path = work_dir / f"grade-{grade}-agg.json"
+
+            window = f"{baseline}→Spring"
+            body = step(
+                work_dir, f"grade-{grade}-values",
+                lambda g=grade, w=window: build_values(
+                    records_path, school["school_name"], g,
+                    year["year_name"], w, roster["teachers"]),
+                log)
+
+            add_tab(sheet_id, grade, args.user, work_dir)
+            write_tab(sheet_id, body, args.user, work_dir, grade)
+            step(work_dir, done_marker, lambda: {"rows": len(rows)}, log)
+            log(f"grade {grade}: written")
+
+        if not (work_dir / "definitions-written.json").exists():
+            add_tab(sheet_id, "Definitions", args.user, work_dir)
+            write_tab(sheet_id, definitions_values(), args.user,
+                      work_dir, "Definitions")
+            step(work_dir, "definitions-written", lambda: {"ok": True}, log)
+
+        step(work_dir, "shared",
+             lambda: {"result": share_workbook(sheet_id, args.user)}, log)
+        log("done")
+        print(url)
+        return 0
+    except ReportError as exc:
+        log(f"FAILED: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -483,8 +483,15 @@ def create_workbook(title, user):
 
 
 def share_workbook(sheet_id, user):
-    params = {"fileId": sheet_id, "transferOwnership": "true"}
-    body = {"type": "user", "role": "owner", "emailAddress": user}
+    # Sanitised like the title. An address is unlikely to carry a quote, but
+    # this is the same tokenizer with the same lack of an escape syntax, and
+    # the failure would land on the LAST step of a finished report — the
+    # costliest place for it. Consistency here is cheaper than reasoning about
+    # which values are safe.
+    params = {"fileId": command_literal(sheet_id),
+              "transferOwnership": "true"}
+    body = {"type": "user", "role": "owner",
+            "emailAddress": command_literal(user)}
     return workspace(
         f"drive permissions create --params '{json.dumps(params)}' "
         f"--body '{json.dumps(body)}'",
@@ -547,7 +554,7 @@ def _delete_sheet(sheet_id, tab_id, user, work_dir):
         {"requests": [{"deleteSheet": {"sheetId": tab_id}}]}))
     return workspace(
         "sheets spreadsheets batchUpdate "
-        f"--params '{json.dumps({'spreadsheetId': sheet_id})}'",
+        f"--params '{json.dumps({'spreadsheetId': command_literal(sheet_id)})}'",
         user, json_file=str(payload),
     )
 
@@ -560,7 +567,7 @@ def _add_tab(sheet_id, title, user, work_dir):
     # sanitising — only the params below are spliced.
     return workspace(
         "sheets spreadsheets batchUpdate "
-        f"--params '{json.dumps({'spreadsheetId': sheet_id})}'",
+        f"--params '{json.dumps({'spreadsheetId': command_literal(sheet_id)})}'",
         user, json_file=str(payload),
     )
 
@@ -576,7 +583,7 @@ def write_tab(sheet_id, body, user, work_dir, title):
     payload.write_text(json.dumps(body))
     return workspace(
         "sheets spreadsheets values batchUpdate "
-        f"--params '{json.dumps({'spreadsheetId': sheet_id})}'",
+        f"--params '{json.dumps({'spreadsheetId': command_literal(sheet_id)})}'",
         user, json_file=str(payload),
     )
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -42,6 +42,7 @@ import pathlib
 import re
 import subprocess
 import sys
+import traceback
 
 HERE = pathlib.Path(__file__).resolve().parent
 PSD_DATA = "/opt/psd-skills/psd-data/run.js"
@@ -223,10 +224,24 @@ def workspace(command, user, scope="agent", json_file=None):
 # --- data steps ---------------------------------------------------------
 
 
+def like_escape(value):
+    """Neutralise LIKE wildcards in a caller-supplied name.
+
+    `sql_escape` stops the quote from breaking the literal, but inside a LIKE
+    a bare `%` or `_` is still a pattern: "Harbor_" would match "Harbor Ridge"
+    and "Harbor Heights" and land in the ambiguous-match branch, while a lone
+    "%" matches every school in the district. Escaped with a backslash and
+    declared via ESCAPE so the characters match themselves.
+    """
+    out = str(value).replace("\\", "\\\\")
+    return out.replace("%", "\\%").replace("_", "\\_")
+
+
 def resolve_school(name):
     rows = query(
         "SELECT schoolid, school_name FROM schools "
-        f"WHERE LOWER(school_name) LIKE LOWER('%{sql_escape(name)}%')",
+        "WHERE LOWER(school_name) LIKE LOWER("
+        f"'%{sql_escape(like_escape(name))}%') ESCAPE '\\'",
         f"Resolve the school named {name} for a quartile growth report",
     )
     if not rows:
@@ -613,7 +628,14 @@ def main() -> int:
 
             records_path = work_dir / f"grade-{grade}-records.json"
             records_path.write_text(json.dumps(records))
-            windows["*"] = f"{BASELINE_DEFAULT}→Spring"
+            # The fallback label must follow the GRADE, not the global default.
+            # Hardcoding "Fall→Spring" here mislabels every K block, where each
+            # measure's baseline is actually Winter. Only reached for a measure
+            # absent from the discovered set, so it is latent — but a wrong
+            # window label misstates what was measured, which is the one thing
+            # a principal cannot check from the sheet.
+            grade_default = BASELINE_BY_GRADE.get(str(grade), BASELINE_DEFAULT)
+            windows.setdefault("*", f"{grade_default}→Spring")
             body = step(
                 work_dir, f"grade-{grade}-values",
                 lambda g=grade, w=windows: build_values(
@@ -637,6 +659,17 @@ def main() -> int:
         return 0
     except ReportError as exc:
         log(f"FAILED: {exc}")
+        return 1
+    except Exception as exc:  # noqa: BLE001 - see below
+        # A ReportError is an expected, checkpoint-resumable stop. Anything
+        # else is a genuine bug (a KeyError off an unexpected roster shape,
+        # say) where a re-run will not help — but the agent reads stderr and
+        # reports it, so it still needs the same one-line FAILED shape rather
+        # than a raw traceback. The traceback is kept, below the summary, for
+        # whoever fixes it.
+        log(f"FAILED: unexpected {type(exc).__name__}: {exc}")
+        log("This is a bug, not a resumable failure — re-running will not help.")
+        traceback.print_exc(file=sys.stderr)
         return 1
 
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -128,6 +128,17 @@ def command_literal(value):
     return " ".join(text.split())
 
 
+def safe_path(path):
+    """A filesystem path fit to splice into a --command string."""
+    text = str(path)
+    if any(ch.isspace() for ch in text) or "'" in text or '"' in text:
+        raise ReportError(
+            "work dir path must contain no spaces or quotes — splitCommand "
+            f"would split it into separate tokens and lose the payload: {text}"
+        )
+    return text
+
+
 def assert_command_safe(command):
     """Fail loudly if an unquotable character reached the command string.
 
@@ -217,7 +228,13 @@ def workspace(command, user, scope="agent", json_file=None):
     """
     argv = ["node", WORKSPACE, "--user", user, "--scope", scope]
     if json_file:
-        command = f"{command} --json-file {json_file}"
+        # The path is spliced into --command like everything else, and
+        # splitCommand tokenizes on whitespace with no escape syntax — so a
+        # path containing a space or a quote silently becomes two tokens and
+        # the payload is lost. Ours are derived from a slugged school name and
+        # are safe, but --work-dir is caller-supplied. Refuse loudly here
+        # rather than produce a workbook missing a tab.
+        command = f"{command} --json-file {safe_path(json_file)}"
     argv += ["--command", assert_command_safe(command)]
     return run_json(argv, f"workspace ({command.split(' --')[0]})")
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -532,8 +532,11 @@ def drop_default_tab(sheet_id, user, work_dir, log=lambda m: None):
         return
     try:
         _delete_sheet(sheet_id, DEFAULT_SHEET_ID, user, work_dir)
-    except ReportError as exc:
-        # Already gone, or renamed by hand — either way the report stands.
+    except Exception as exc:  # noqa: BLE001 - non-fatal by design
+        # Already gone, renamed by hand, or the payload file would not write —
+        # every one of those is survivable. Catching only ReportError here
+        # contradicted the docstring above: an OSError writing the request
+        # would have propagated and killed a run whose numbers were all in.
         log(f"note: could not remove the default tab ({exc}); continuing")
     marker.write_text(json.dumps({"sheetId": DEFAULT_SHEET_ID}))
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -348,8 +348,66 @@ def extraction_sql(schoolid, yearid, grade, measures, baseline):
         f"    AND grade_level = '{sql_escape(grade)}') "
         "SELECT m.meas, m.studentid::text AS studentid, m.b::text AS b, "
         "  m.e::text AS e, hr.sectionid::text AS sectionid, "
+        "  (sch.studentid IS NOT NULL)::text AS in_sch, "
+        "  f.frl::text AS low_income, "
+        "  sp.special_education::text AS special_ed "
+        "FROM m LEFT JOIN hr USING (studentid) LEFT JOIN sch USING (studentid) "
+        # DISTRICT-WIDE, never scoped to the school. On 2026-08-15 every grade
+        # reported School and District identically — grade K showed 18/18
+        # against a district cohort of 558 — because only this school's
+        # students carried a flag, so the district cell WAS the school cell and
+        # its complement absorbed 540 unflagged students. Every number looked
+        # plausible.
+        f"LEFT JOIN students_frl f ON f.studentid = m.studentid "
+        f"  AND f.yearid = {int(yearid)} "
+        f"LEFT JOIN students_specialed sp ON sp.studentid = m.studentid "
+        f"  AND sp.yearid = {int(yearid)}"
+    )
+
+
+SUBGROUPS = (
+    "low_income=Low Income|Non-Low Income",
+    "special_ed=Special Ed|Non-Special Ed",
+)
+
+
+def sba_sql(schoolid, yearid, grade):
+    """SBA scale growth vs the prior-year summative, quartiled on that prior score.
+
+    smarter_balanced_scores mixes IAB/FIAB participation rows (score = 1) with
+    summatives, so the two filters are mandatory — unfiltered averages are
+    garbage (SKILL.md, psd-data pitfalls).
+    """
+    prior_grade = str(int(grade) - 1)
+    return (
+        "WITH cur AS ("
+        "  SELECT studentid, assessment_group AS meas, AVG(score) AS e,"
+        "         AVG(CASE WHEN met_standard THEN 100.0 ELSE 0.0 END) AS metv"
+        "  FROM smarter_balanced_scores"
+        f"  WHERE yearid = {int(yearid)} AND grade_level = '{sql_escape(grade)}'"
+        "    AND assessment_group LIKE 'Summative%' AND is_strand = false"
+        "  GROUP BY 1,2), "
+        "prior AS ("
+        "  SELECT studentid, assessment_group AS meas, AVG(score) AS b"
+        "  FROM smarter_balanced_scores"
+        f"  WHERE yearid = {int(yearid) - 1}"
+        f"    AND grade_level = '{sql_escape(prior_grade)}'"
+        "    AND assessment_group LIKE 'Summative%' AND is_strand = false"
+        "  GROUP BY 1,2), "
+        "hr AS (SELECT DISTINCT ON (studentid) studentid, sectionid"
+        "  FROM section_enrollments"
+        f"  WHERE yearid = {int(yearid)} AND schoolid = {int(schoolid)}"
+        "    AND course_code LIKE 'GR0%'"
+        "  ORDER BY studentid, dateleft DESC), "
+        "sch AS (SELECT DISTINCT studentid FROM school_year_enrollments"
+        f"  WHERE yearid = {int(yearid)} AND schoolid = {int(schoolid)}"
+        f"    AND grade_level = '{sql_escape(grade)}') "
+        "SELECT ('SBA ' || cur.meas) AS meas, cur.studentid::text AS studentid, "
+        "  prior.b::text AS b, cur.e::text AS e, cur.metv::text AS met_pct, "
+        "  hr.sectionid::text AS sectionid, "
         "  (sch.studentid IS NOT NULL)::text AS in_sch "
-        "FROM m LEFT JOIN hr USING (studentid) LEFT JOIN sch USING (studentid)"
+        "FROM cur JOIN prior USING (studentid, meas) "
+        "LEFT JOIN hr USING (studentid) LEFT JOIN sch USING (studentid)"
     )
 
 
@@ -370,7 +428,7 @@ def discover_measures(yearid, grade):
     )
 
 
-def aggregate_rows(rows_path, grade, baseline, no_norms=False):
+def aggregate_rows(rows_path, grade, baseline, no_norms=False, subgroups=()):
     argv = [
         PYTHON, str(HERE / "aggregate.py"),
         "--rows", str(rows_path),
@@ -380,10 +438,12 @@ def aggregate_rows(rows_path, grade, baseline, no_norms=False):
     ]
     if no_norms:
         argv.append("--no-norms")
+    for spec in subgroups or ():
+        argv += ["--subgroup", spec]
     return run_json(argv, f"aggregate.py (grade {grade})")
 
 
-def build_values(records_path, school, grade, year, window, teachers):
+def build_values(records_path, school, grade, year, window, teachers, gaps=()):
     argv = [
         PYTHON, str(HERE / "build_tab.py"),
         "--rows", str(records_path),
@@ -392,6 +452,7 @@ def build_values(records_path, school, grade, year, window, teachers):
         "--year", year,
         "--window", window,
         "--teachers", json.dumps(teachers),
+        "--gaps", json.dumps(list(gaps)),
         "--emit", "values",
     ]
     return run_json(argv, f"build_tab.py (grade {grade})")
@@ -529,6 +590,84 @@ def definitions_values():
     }
 
 
+def discover_table(candidates, yearid):
+    """Return the first candidate table that answers, or None.
+
+    i-Ready's table name is not written down anywhere in this skill, unlike
+    smarter_balanced_scores and students_frl. Rather than guess one and have
+    the block vanish, ask — and if none answers, the caller records a VISIBLE
+    gap instead of an absence.
+    """
+    for table in candidates:
+        try:
+            query(f"SELECT 1 FROM {table} WHERE yearid = {int(yearid)}",
+                  f"Confirm {table} exists for the report", limit=1)
+            return table
+        except ReportError:
+            continue
+    return None
+
+
+IREADY_TABLES = ("iready_scores", "i_ready_scores", "iready_diagnostic_scores")
+
+
+def iready_sql(schoolid, yearid, grade, table):
+    """i-Ready percentile change. Already national, so no norms lookup."""
+    return (
+        "WITH stu AS ("
+        "  SELECT subject AS meas, studentid, \"window\", AVG(percentile) AS s"
+        f"  FROM {table}"
+        f"  WHERE yearid = {int(yearid)} AND grade_level = '{sql_escape(grade)}'"
+        "    AND \"window\" IN ('Fall', 'Spring')"
+        "  GROUP BY 1,2,3), "
+        "m AS ("
+        "  SELECT f.meas, f.studentid, f.s AS b, sp.s AS e"
+        "  FROM stu f"
+        "  JOIN stu sp ON sp.studentid = f.studentid AND sp.meas = f.meas"
+        "    AND sp.\"window\" = 'Spring'"
+        "  WHERE f.\"window\" = 'Fall'), "
+        "hr AS (SELECT DISTINCT ON (studentid) studentid, sectionid"
+        "  FROM section_enrollments"
+        f"  WHERE yearid = {int(yearid)} AND schoolid = {int(schoolid)}"
+        "    AND course_code LIKE 'GR0%'"
+        "  ORDER BY studentid, dateleft DESC), "
+        "sch AS (SELECT DISTINCT studentid FROM school_year_enrollments"
+        f"  WHERE yearid = {int(yearid)} AND schoolid = {int(schoolid)}"
+        f"    AND grade_level = '{sql_escape(grade)}') "
+        "SELECT ('i-Ready ' || m.meas) AS meas, m.studentid::text AS studentid, "
+        "  m.b::text AS b, m.e::text AS e, hr.sectionid::text AS sectionid, "
+        "  (sch.studentid IS NOT NULL)::text AS in_sch "
+        "FROM m LEFT JOIN hr USING (studentid) LEFT JOIN sch USING (studentid)"
+    )
+
+
+def run_block(work_dir, tag, grade, build_sql, reason, log, gaps,
+              label, no_norms=False, subgroups=()):
+    """Extract + aggregate one measure family, recording a GAP if it fails.
+
+    A block that returns nothing, errors, or has no table must show up in the
+    workbook — not only in a log the principal never reads. Silently omitting
+    SBA or i-Ready produces a report that looks complete and is not, which is
+    the exact failure this whole redesign exists to end.
+    """
+    try:
+        rows = step(work_dir, f"{tag}-rows",
+                    lambda: query_all(build_sql(), reason), log)
+    except ReportError as exc:
+        log(f"  {label}: FAILED — {exc}")
+        gaps.append(f"{label}: not included (query failed: {str(exc)[:160]})")
+        return []
+    if not rows:
+        log(f"  {label}: no matched rows")
+        gaps.append(f"{label}: not included (no matched students)")
+        return []
+    log(f"  {label}: {len(rows)} rows")
+    return step(work_dir, f"{tag}-agg",
+                lambda: aggregate_rows(work_dir / f"{tag}-rows.json", grade,
+                                       "Fall", no_norms=no_norms,
+                                       subgroups=subgroups), log)
+
+
 # --- checkpointing ------------------------------------------------------
 
 
@@ -606,6 +745,11 @@ def main() -> int:
             )
         log(f"  grades served: {', '.join(served)}")
 
+        iready_table = step(
+            work_dir, "iready-table",
+            lambda: {"name": discover_table(IREADY_TABLES, yearid)}, log)["name"]
+        log(f"  i-Ready table: {iready_table or 'NOT FOUND'}")
+
         if dry_run:
             print(json.dumps({
                 "school": school, "year": year,
@@ -666,16 +810,46 @@ def main() -> int:
                 part = step(
                     work_dir, f"{tag}-agg",
                     lambda g=grade, b=baseline, t=tag: aggregate_rows(
-                        work_dir / f"{t}-rows.json", g, b),
+                        work_dir / f"{t}-rows.json", g, b,
+                        subgroups=SUBGROUPS),
                     log)
                 records.extend(part)
                 for measure in group:
                     windows[measure] = f"{baseline}→Spring"
 
+            gaps = []
+
+            # i-Ready. Skipped for K by SKILL.md (not district-representative).
+            if grade != "K":
+                if iready_table:
+                    records.extend(run_block(
+                        work_dir, f"grade-{grade}-iready", grade,
+                        lambda g=grade: iready_sql(schoolid, yearid, g,
+                                                   iready_table),
+                        f"i-Ready Fall/Spring percentiles for grade {grade}",
+                        log, gaps, "i-Ready Reading/Math", no_norms=True))
+                else:
+                    gaps.append(
+                        "i-Ready Reading/Math: not included (no i-Ready table "
+                        f"found; tried {', '.join(IREADY_TABLES)})")
+
+            # SBA grades 4-5: scale change against the prior-year summative.
+            if grade in ("4", "5"):
+                records.extend(run_block(
+                    work_dir, f"grade-{grade}-sba", grade,
+                    lambda g=grade: sba_sql(schoolid, yearid, g),
+                    f"SBA summative pairs for grade {grade}",
+                    log, gaps, "SBA grades 4-5", no_norms=True))
+            elif grade == "3":
+                # Grade 3 has no prior SBA to quartile on — SKILL.md puts it on
+                # the Fall i-Ready quartile instead, which needs the i-Ready
+                # table. Stated rather than silently absent.
+                gaps.append(
+                    "SBA grade 3: not included (needs the Fall i-Ready "
+                    "baseline; implement once the i-Ready table is confirmed)")
+
             if not records:
-                log(f"grade {grade}: no matched pairs at all — skipping")
-                step(work_dir, done_marker, lambda: {"skipped": "no rows"}, log)
-                continue
+                log(f"grade {grade}: nothing to report — writing gaps only")
 
             records_path = work_dir / f"grade-{grade}-records.json"
             records_path.write_text(json.dumps(records))
@@ -689,9 +863,9 @@ def main() -> int:
             windows.setdefault("*", f"{grade_default}→Spring")
             body = step(
                 work_dir, f"grade-{grade}-values",
-                lambda g=grade, w=windows: build_values(
+                lambda g=grade, w=windows, gp=gaps: build_values(
                     records_path, school["school_name"], g,
-                    year["year_name"], json.dumps(w), roster["teachers"]),
+                    year["year_name"], json.dumps(w), roster["teachers"], gp),
                 log)
 
             add_tab(sheet_id, grade, args.user, work_dir, log)

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -440,9 +440,51 @@ def add_tab(sheet_id, title, user, work_dir, log=lambda m: None):
     succeed is worse than no checkpointing at all. Review caught this; it is
     exactly the failure class this script exists to remove.
     """
-    return step(work_dir, f"tab-{title}-added",
-                lambda: {"result": _add_tab(sheet_id, title, user, work_dir)},
-                log)
+    added = step(work_dir, f"tab-{title}-added",
+                 lambda: {"result": _add_tab(sheet_id, title, user, work_dir)},
+                 log)
+    # Only safe once a real tab exists: a spreadsheet must keep at least one.
+    drop_default_tab(sheet_id, user, work_dir, log)
+    return added
+
+
+DEFAULT_SHEET_ID = 0
+
+
+def drop_default_tab(sheet_id, user, work_dir, log=lambda m: None):
+    """Remove the empty tab the Sheets API creates with every spreadsheet.
+
+    `spreadsheets.create` is called with only `properties`, so Sheets adds its
+    own first sheet ("Sheet1", sheetId 0). Grade tabs are appended after it,
+    which leaves the blank one LEFTMOST — the first thing a principal sees on
+    opening the link, in a report whose whole point is not shipping something
+    that looks complete and isn't.
+
+    Checkpointed, so it runs once no matter how many tabs are added or how
+    often the script resumes. Deliberately NON-fatal: a leftover blank tab is
+    cosmetic, and failing a run that otherwise produced every number would be
+    the worse outcome by far.
+    """
+    marker = work_dir / "default-tab-dropped.json"
+    if marker.exists():
+        return
+    try:
+        _delete_sheet(sheet_id, DEFAULT_SHEET_ID, user, work_dir)
+    except ReportError as exc:
+        # Already gone, or renamed by hand — either way the report stands.
+        log(f"note: could not remove the default tab ({exc}); continuing")
+    marker.write_text(json.dumps({"sheetId": DEFAULT_SHEET_ID}))
+
+
+def _delete_sheet(sheet_id, tab_id, user, work_dir):
+    payload = work_dir / f"deletesheet-{tab_id}.json"
+    payload.write_text(json.dumps(
+        {"requests": [{"deleteSheet": {"sheetId": tab_id}}]}))
+    return workspace(
+        "sheets spreadsheets batchUpdate "
+        f"--params '{json.dumps({'spreadsheetId': sheet_id})}'",
+        user, json_file=str(payload),
+    )
 
 
 def _add_tab(sheet_id, title, user, work_dir):
@@ -534,6 +576,15 @@ def main() -> int:
     slug = re.sub(r"[^a-z0-9]+", "-", args.school.lower()).strip("-")
     work_dir = pathlib.Path(args.work_dir or f"/tmp/qgr-{slug}")
     work_dir.mkdir(parents=True, exist_ok=True)
+    # The checkpoints are not metadata: grade-<g>-rows.json holds studentid
+    # paired with assessment scores, which is student-level FERPA data sitting
+    # in a predictable /tmp path for as long as the container lives. Default
+    # mkdir permissions make that world-readable. Owner-only costs nothing and
+    # does not depend on an assumption about how ephemeral the sandbox is.
+    try:
+        work_dir.chmod(0o700)
+    except OSError as exc:
+        log(f"warning: could not restrict {work_dir} to owner-only: {exc}")
     log(f"work dir: {work_dir}")
 
     try:

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -75,13 +75,55 @@ def sql_escape(value):
     return str(value).replace("'", "''")
 
 
-def run_json(argv, what):
+# psd-workspace's splitCommand has NO escape syntax: a quote inside a
+# same-quoted token ends the token. Its own source says so, from a live 2026-07-06
+# failure — "any content with an apostrophe, mixed quotes, or newlines cannot
+# ride inside --command at all". Payloads dodge this with --json-file, whose
+# content becomes exactly one argv token, but `--params` has no file form, so
+# whatever goes there must be quote-free by construction.
+#
+# The typographic apostrophe is not a quote character to the tokenizer and is
+# what a title would use in print anyway, so a school like "O'Brien Elementary"
+# keeps a correct-looking name instead of a broken command.
+SAFE_APOSTROPHE = "\u2019"
+
+
+def command_literal(value):
+    """Make a value safe to splice into a --command string."""
+    text = str(value).replace("'", SAFE_APOSTROPHE).replace('"', SAFE_APOSTROPHE)
+    return " ".join(text.split())
+
+
+def assert_command_safe(command):
+    """Fail loudly if an unquotable character reached the command string.
+
+    A late failure in the share step, after every grade has been extracted and
+    written, is exactly what this script exists to prevent — so this refuses
+    before the call rather than after.
+    """
+    payload = command.split("--params", 1)[-1]
+    if "'" in payload.replace("'{", "").replace("}'", ""):
+        raise ReportError(
+            f"unquotable character in a workspace command: {command[:200]}"
+        )
+    return command
+
+
+def run_json(argv, what, timeout=900):
     """Run a command and parse its stdout as JSON.
 
     Errors carry the command's own stderr. A report that dies on step 4 of 30
     is only debuggable if the failure says which step and what the tool said.
     """
-    done = subprocess.run(argv, capture_output=True, text=True)
+    try:
+        done = subprocess.run(
+            argv, capture_output=True, text=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        # Now that this runs outside the turn deadline, nothing else would
+        # ever stop a hung call — and a hang leaves no checkpoint, so the
+        # re-run would hang in the same place.
+        raise ReportError(f"{what} timed out after {timeout}s")
     if done.returncode != 0:
         raise ReportError(
             f"{what} failed (exit {done.returncode}): "
@@ -142,7 +184,7 @@ def workspace(command, user, scope="agent", json_file=None):
     argv = ["node", WORKSPACE, "--user", user, "--scope", scope]
     if json_file:
         command = f"{command} --json-file {json_file}"
-    argv += ["--command", command]
+    argv += ["--command", assert_command_safe(command)]
     return run_json(argv, f"workspace ({command.split(' --')[0]})")
 
 
@@ -321,7 +363,7 @@ def create_workbook(title, user):
     """
     created = workspace(
         "sheets spreadsheets create "
-        f"--params '{json.dumps({'properties': {'title': title}})}'",
+        f"--params '{json.dumps({'properties': {'title': command_literal(title)}})}'",
         user,
     )
     sheet_id = created.get("spreadsheetId") or (
@@ -345,6 +387,8 @@ def add_tab(sheet_id, title, user, work_dir):
     payload = work_dir / f"addsheet-{title}.json"
     payload.write_text(json.dumps(
         {"requests": [{"addSheet": {"properties": {"title": str(title)}}}]}))
+    # The title rides in the FILE here, not the command, so it needs no
+    # sanitising — only the params below are spliced.
     return workspace(
         "sheets spreadsheets batchUpdate "
         f"--params '{json.dumps({'spreadsheetId': sheet_id})}'",

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -37,6 +37,7 @@ Re-running with the same --work-dir skips work already done.
 """
 
 import argparse
+import datetime
 import json
 import pathlib
 import re
@@ -671,6 +672,49 @@ def run_block(work_dir, tag, grade, build_sql, reason, log, gaps,
 # --- checkpointing ------------------------------------------------------
 
 
+SBA_WINDOW = "prior year→this year"
+
+
+def label_windows(windows, records):
+    """Give every measure block the window it was ACTUALLY measured over.
+
+    SBA compares against the PRIOR YEAR's summative, so the grade's
+    Fall→Spring fallback would render "SBA ELA (Fall→Spring)" — a window that
+    was never measured. This file's own rule, from the build_tab docstring: a
+    Fall→Winter block labelled Fall→Spring is a wrong report, not a cosmetic
+    slip.
+
+    setdefault, so a real per-measure label always wins over the fallback.
+    """
+    labelled = dict(windows)
+    for record in records:
+        meas = str(record.get("meas") or "")
+        if meas.startswith("SBA "):
+            labelled.setdefault(meas, SBA_WINDOW)
+    return labelled
+
+
+def default_work_dir(slug, year, user):
+    """Checkpoints belong to ONE run, not to a school forever.
+
+    Keyed on school alone, a second report for the same school silently
+    reused the first one's checkpoints — including `sheet` and `shared`. So a
+    different caller got a URL they had no access to (exit 0, no error), and
+    everybody got whatever the numbers were the first time the school was
+    ever run, however stale. It also falsified this script's own claim that a
+    school can be run twice and diffed: the second run returned the first
+    run's cache.
+
+    Date, caller and year are in the path. A retry the same day resumes,
+    which is what a failed run needs. Tomorrow's run is fresh. Another
+    caller gets their own workbook and their own share. Pass --work-dir to
+    resume deliberately across any of those boundaries.
+    """
+    who = re.sub(r"[^a-z0-9]+", "-", str(user).lower()).strip("-")
+    stamp = datetime.date.today().isoformat()
+    return f"/tmp/qgr-{slug}-{year or 'latest'}-{who}-{stamp}"
+
+
 def step(work_dir, name, produce, log):
     """Run `produce` once, then reuse its output on later runs.
 
@@ -713,7 +757,8 @@ def main() -> int:
         print(message, file=sys.stderr, flush=True)
 
     slug = re.sub(r"[^a-z0-9]+", "-", args.school.lower()).strip("-")
-    work_dir = pathlib.Path(args.work_dir or f"/tmp/qgr-{slug}")
+    work_dir = pathlib.Path(args.work_dir or default_work_dir(
+        slug, args.year, args.user))
     work_dir.mkdir(parents=True, exist_ok=True)
     # The checkpoints are not metadata: grade-<g>-rows.json holds studentid
     # paired with assessment scores, which is student-level FERPA data sitting
@@ -850,6 +895,8 @@ def main() -> int:
 
             if not records:
                 log(f"grade {grade}: nothing to report — writing gaps only")
+
+            windows = label_windows(windows, records)
 
             records_path = work_dir / f"grade-{grade}-records.json"
             records_path.write_text(json.dumps(records))

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -113,9 +113,30 @@ class ExtractionSql(unittest.TestCase):
         self.assertIn("'Winter'", self._sql(grade="K", baseline="Winter"))
         self.assertNotIn("'Fall'", self._sql(grade="K", baseline="Winter"))
 
-    def test_kindergarten_defaults_to_a_winter_baseline(self):
-        self.assertEqual(R.BASELINE_BY_GRADE.get("K"), "Winter")
-        self.assertIsNone(R.BASELINE_BY_GRADE.get("3"))
+    def test_kindergarten_uses_a_winter_baseline_for_every_measure(self):
+        # K DIBELS has no Fall administration at all.
+        self.assertEqual(R.baseline_for("K", "ORF-WRC"), "Winter")
+        self.assertEqual(R.baseline_for("K", "LNF"), "Winter")
+
+    def test_grade_one_orf_is_winter_but_the_rest_of_grade_one_is_not(self):
+        # ORF starts mid-year in grade 1 — and ONLY ORF. Applying one baseline
+        # to the whole grade returns zero matched pairs for the odd measure,
+        # which drops it from the tab with no error at all.
+        self.assertEqual(R.baseline_for("1", "ORF-WRC"), "Winter")
+        self.assertEqual(R.baseline_for("1", "NWF-CLS"), "Fall")
+
+    def test_other_grades_are_fall_including_orf(self):
+        self.assertEqual(R.baseline_for("3", "ORF-WRC"), "Fall")
+        self.assertEqual(R.baseline_for("5", "NWF-CLS"), "Fall")
+
+    def test_a_mixed_grade_runs_one_extraction_per_baseline(self):
+        groups = R.group_by_baseline("1", ["ORF-WRC", "NWF-CLS", "PSF"])
+        self.assertEqual(groups["Winter"], ["ORF-WRC"])
+        self.assertEqual(sorted(groups["Fall"]), ["NWF-CLS", "PSF"])
+
+    def test_a_uniform_grade_runs_a_single_extraction(self):
+        groups = R.group_by_baseline("3", ["ORF-WRC", "NWF-CLS"])
+        self.assertEqual(list(groups), ["Fall"])
 
 
 class SqlEscaping(unittest.TestCase):
@@ -287,3 +308,48 @@ class HungCallsAreBounded(unittest.TestCase):
         default = inspect.signature(R.run_json).parameters["timeout"].default
         self.assertIsInstance(default, int)
         self.assertGreater(default, 0)
+
+
+class SideEffectsAreCheckpointed(unittest.TestCase):
+    """A retry must be able to succeed.
+
+    add_tab was the one side effect not checkpointed: a failure between
+    creating the tab and writing the grade's done-marker left the tab present
+    and the marker absent, so the re-run tried to add it again, Sheets
+    rejected the duplicate, and the report was stuck forever. A re-run that
+    CANNOT succeed is worse than no checkpointing.
+    """
+
+    def setUp(self):
+        self.work = pathlib.Path(tempfile.mkdtemp())
+        self.calls = []
+        R.workspace = lambda command, user, scope="agent", json_file=None: (
+            self.calls.append(command.split(" --")[0]) or {"ok": True})
+
+    def test_a_tab_is_created_once_across_re_runs(self):
+        R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
+        R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
+        self.assertEqual(self.calls.count("sheets spreadsheets batchUpdate"), 1)
+
+    def test_each_tab_gets_its_own_marker(self):
+        R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
+        R.add_tab("SHEET1", "4", "u@psd401.net", self.work)
+        self.assertEqual(self.calls.count("sheets spreadsheets batchUpdate"), 2)
+        self.assertTrue((self.work / "tab-3-added.json").exists())
+        self.assertTrue((self.work / "tab-4-added.json").exists())
+
+
+class WindowLabels(unittest.TestCase):
+    """A Fall→Winter block labelled Fall→Spring is a wrong report."""
+
+    def test_a_measure_specific_window_wins(self):
+        import build_tab
+        window = {"ORF-WRC": "Winter→Spring", "*": "Fall→Spring"}
+        self.assertEqual(build_tab.window_for("ORF-WRC", window), "Winter→Spring")
+        self.assertEqual(build_tab.window_for("NWF-CLS", window), "Fall→Spring")
+
+    def test_a_plain_string_still_applies_to_every_block(self):
+        import build_tab
+        self.assertEqual(
+            build_tab.window_for("anything", "Fall→Spring"), "Fall→Spring"
+        )

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -622,6 +622,82 @@ class WorkDirIsOwnerOnly(unittest.TestCase):
         source = pathlib.Path(R.__file__).read_text()
         self.assertIn("work_dir.chmod(0o700)", source)
 
+class CheckpointsBelongToOneRun(RestoresModuleFunctions):
+    """Keyed on school alone, a second report reused the first one's answers.
+
+    `sheet` and `shared` are checkpointed, so a different caller received a
+    URL they had no access to — exit 0, no error — and every run returned
+    whatever the numbers were the first time that school was ever built. It
+    also falsified this script's own claim that a school can be run twice and
+    diffed.
+    """
+
+    def test_a_different_caller_gets_a_different_work_dir(self):
+        a = R.default_work_dir("artondale", "2025-26", "one@psd401.net")
+        b = R.default_work_dir("artondale", "2025-26", "two@psd401.net")
+        self.assertNotEqual(a, b)
+
+    def test_a_different_year_gets_a_different_work_dir(self):
+        a = R.default_work_dir("artondale", "2024-25", "one@psd401.net")
+        b = R.default_work_dir("artondale", "2025-26", "one@psd401.net")
+        self.assertNotEqual(a, b)
+
+    def test_the_same_run_resumes_within_the_day(self):
+        # A retry after a failure must reuse checkpoints — that is the whole
+        # point of having them.
+        a = R.default_work_dir("artondale", "2025-26", "one@psd401.net")
+        b = R.default_work_dir("artondale", "2025-26", "one@psd401.net")
+        self.assertEqual(a, b)
+
+    def test_the_date_is_in_the_path(self):
+        import datetime
+        path = R.default_work_dir("artondale", "2025-26", "one@psd401.net")
+        self.assertIn(datetime.date.today().isoformat(), path)
+
+
+class SbaIsNotLabelledFallToSpring(RestoresModuleFunctions):
+    """SBA compares against the PRIOR YEAR's summative.
+
+    The grade's DIBELS fallback would render "SBA ELA (Fall→Spring)", a window
+    that was never measured. This file's own rule: a Fall→Winter block
+    labelled Fall→Spring is a wrong report, not a cosmetic slip.
+    """
+
+    def test_run_report_labels_sba_records_itself(self):
+        # Building the windows dict by hand in the test only proved build_tab
+        # reads it. This proves run_report WRITES it — the mutation that
+        # removed the labelling failed nothing until this existed.
+        records = [{"meas": "SBA ELA"}, {"meas": "ORF-WRC"}]
+        windows = R.label_windows({"*": "Fall→Spring"}, records)
+        self.assertEqual(windows["SBA ELA"], R.SBA_WINDOW)
+        self.assertNotEqual(windows["SBA ELA"], "Fall→Spring")
+
+    def test_a_real_per_measure_label_beats_the_sba_default(self):
+        windows = R.label_windows({"SBA ELA": "Winter→Spring"},
+                                  [{"meas": "SBA ELA"}])
+        self.assertEqual(windows["SBA ELA"], "Winter→Spring")
+
+    def test_non_sba_records_are_left_alone(self):
+        windows = R.label_windows({"*": "Fall→Spring"}, [{"meas": "ORF-WRC"}])
+        self.assertNotIn("ORF-WRC", windows)
+
+    def test_a_dibels_block_keeps_its_own_window(self):
+        import build_tab
+        windows = {"ORF-WRC": "Winter→Spring", "*": "Fall→Spring"}
+        self.assertEqual(
+            build_tab.window_for("ORF-WRC", windows), "Winter→Spring")
+
+    def test_the_rendered_sba_header_says_prior_year(self):
+        import build_tab
+        records = [{"meas": "SBA ELA", "scope": "school", "qt": "All",
+                    "growth": 12, "n": 30}]
+        tab = build_tab.build(records, "S", "4", "2025-26",
+                              {"SBA ELA": "prior year→this year",
+                               "*": "Fall→Spring"})
+        flat = [c for row in tab["values"] for c in row]
+        self.assertIn("SBA ELA (prior year→this year)", flat)
+        self.assertNotIn("SBA ELA (Fall→Spring)", flat)
+
 
 # Keep this guard LAST in the file. It used to sit mid-file (line 214), which
 # meant `python test_run_report.py` ran unittest.main() and sys.exit()ed before

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -192,3 +192,98 @@ class RosterDefinesTheGradeSpan(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CommandStringsSurviveApostrophes(unittest.TestCase):
+    """psd-workspace's splitCommand has no escape syntax.
+
+    Its own source records the live failure: "any content with an apostrophe,
+    mixed quotes, or newlines cannot ride inside --command at all"
+    (2026-07-06). `--params` has no file form, so anything spliced there must
+    be quote-free by construction. The SQL path was already escaped; this is
+    the same character arriving through the other door, and it would have
+    broken the workbook AFTER every grade was extracted — a late failure in
+    the script written to remove late failures.
+    """
+
+    def test_a_straight_apostrophe_never_reaches_a_command(self):
+        self.assertNotIn("'", R.command_literal("O'Brien Elementary"))
+
+    def test_the_name_still_reads_correctly(self):
+        self.assertEqual(
+            R.command_literal("O'Brien Elementary"),
+            "O\u2019Brien Elementary",
+        )
+
+    def test_double_quotes_are_handled_too(self):
+        self.assertNotIn('"', R.command_literal('The "Annex" School'))
+
+    def test_newlines_cannot_split_a_token(self):
+        self.assertEqual(R.command_literal("Harbor\nRidge"), "Harbor Ridge")
+
+    def test_the_workbook_title_is_sanitised_before_it_is_spliced(self):
+        seen = {}
+
+        def fake_workspace(command, user, scope="agent", json_file=None):
+            seen["command"] = command
+            return {"spreadsheetId": "SHEET1"}
+
+        R.workspace = fake_workspace
+        R.create_workbook("O'Brien Elementary - Report (2025-26)", "u@psd401.net")
+        self.assertNotIn("O'Brien", seen["command"])
+        self.assertIn("Brien", seen["command"])
+
+    def test_the_guard_refuses_a_command_it_cannot_quote(self):
+        with self.assertRaises(R.ReportError):
+            R.assert_command_safe("sheets spreadsheets create --params '{\'x\': 1}'")
+
+
+class HungCallsAreBounded(unittest.TestCase):
+    """Once this runs outside the turn deadline, nothing else stops a hang.
+
+    And a hang leaves no checkpoint, so the re-run would wedge in the same
+    place — the one failure mode checkpointing cannot help with.
+    """
+
+    def test_the_timeout_is_actually_passed_to_subprocess(self):
+        # The point is the kwarg reaching subprocess.run. Asserting only that
+        # TimeoutExpired becomes a ReportError tests the handler and lets the
+        # kwarg be dropped silently — which is precisely how a hang would come
+        # back.
+        seen = {}
+
+        def capture(argv, **kwargs):
+            seen.update(kwargs)
+            raise AssertionError("stop here")
+
+        original = R.subprocess.run
+        R.subprocess.run = capture
+        try:
+            with self.assertRaises(AssertionError):
+                R.run_json(["true"], "call", timeout=42)
+        finally:
+            R.subprocess.run = original
+        self.assertEqual(seen.get("timeout"), 42)
+
+    def test_a_timeout_becomes_a_report_error(self):
+        import subprocess as sp
+
+        def boom(*a, **k):
+            raise sp.TimeoutExpired(cmd="x", timeout=1)
+
+        original = R.subprocess.run
+        R.subprocess.run = boom
+        try:
+            with self.assertRaises(R.ReportError) as caught:
+                R.run_json(["true"], "wedged call", timeout=1)
+            self.assertIn("timed out", str(caught.exception))
+        finally:
+            R.subprocess.run = original
+
+    def test_every_external_call_inherits_a_bound(self):
+        # A default of None on run_json would make every caller unbounded
+        # while these tests still passed.
+        import inspect
+        default = inspect.signature(R.run_json).parameters["timeout"].default
+        self.assertIsInstance(default, int)
+        self.assertGreater(default, 0)

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -22,6 +22,25 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 import run_report as R  # noqa: E402
 
+_PATCHABLE = ("query", "query_all", "run_json", "workspace")
+
+
+class RestoresModuleFunctions(unittest.TestCase):
+    """Stubs must not leak between tests.
+
+    Patching R.query/R.query_all in place and leaving them there made the
+    paging suite fail depending on test ORDER — a self-inflicted version of
+    exactly the flakiness these tests exist to prevent.
+    """
+
+    def setUp(self):
+        self._saved = {name: getattr(R, name) for name in _PATCHABLE}
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        for name, value in self._saved.items():
+            setattr(R, name, value)
+
 
 class Checkpoints(unittest.TestCase):
     """A re-run must resume, not restart.
@@ -59,7 +78,7 @@ class Checkpoints(unittest.TestCase):
         )
 
 
-class Paging(unittest.TestCase):
+class Paging(RestoresModuleFunctions):
     """`--export` is not used anywhere, on purpose.
 
     It timed out repeatedly on the grade-K extraction on 2026-08-16 while the
@@ -98,7 +117,9 @@ class ExtractionSql(unittest.TestCase):
 
     def test_no_window_function_reaches_the_warehouse(self):
         upper = self._sql().upper()
-        for banned in ("NTILE", "GROUPING SETS", "LATERAL", "OVER ("):
+        # NTILE( with the paren: AVG(PERCENTILE) contains the substring
+        # "NTILE", so the bare name matches the very column i-Ready reports on.
+        for banned in ("NTILE(", "GROUPING SETS", "LATERAL", "OVER ("):
             self.assertNotIn(banned, upper, f"{banned} must stay out of SQL")
 
     def test_every_non_text_column_is_cast(self):
@@ -139,7 +160,7 @@ class ExtractionSql(unittest.TestCase):
         self.assertEqual(list(groups), ["Fall"])
 
 
-class SqlEscaping(unittest.TestCase):
+class SqlEscaping(RestoresModuleFunctions):
     def test_an_apostrophe_in_a_school_name_is_escaped(self):
         self.assertEqual(R.sql_escape("O'Brien"), "O''Brien")
 
@@ -155,7 +176,7 @@ class SqlEscaping(unittest.TestCase):
         self.assertIn("O''Brien Elementary", captured["sql"])
 
 
-class SchoolResolution(unittest.TestCase):
+class SchoolResolution(RestoresModuleFunctions):
     def test_an_ambiguous_name_refuses_rather_than_guessing(self):
         R.query = lambda *a, **k: [
             {"schoolid": 1, "school_name": "Harbor Ridge Middle"},
@@ -180,7 +201,7 @@ class SchoolResolution(unittest.TestCase):
             R.resolve_school("Nowhere Elementary")
 
 
-class RosterDefinesTheGradeSpan(unittest.TestCase):
+class RosterDefinesTheGradeSpan(RestoresModuleFunctions):
     """On 2026-08-15 the agent announced "Minter Creek is a K-2 school",
     invented the justification, and scoped a whole report to it. It is K-5.
     The span is a query result here, never an assertion.
@@ -211,7 +232,7 @@ class RosterDefinesTheGradeSpan(unittest.TestCase):
             R.fetch_roster(1, 2)
 
 
-class CommandStringsSurviveApostrophes(unittest.TestCase):
+class CommandStringsSurviveApostrophes(RestoresModuleFunctions):
     """psd-workspace's splitCommand has no escape syntax.
 
     Its own source records the live failure: "any content with an apostrophe,
@@ -306,7 +327,7 @@ class HungCallsAreBounded(unittest.TestCase):
         self.assertGreater(default, 0)
 
 
-class SideEffectsAreCheckpointed(unittest.TestCase):
+class SideEffectsAreCheckpointed(RestoresModuleFunctions):
     """A retry must be able to succeed.
 
     add_tab was the one side effect not checkpointed: a failure between
@@ -317,6 +338,7 @@ class SideEffectsAreCheckpointed(unittest.TestCase):
     """
 
     def setUp(self):
+        super().setUp()
         self.work = pathlib.Path(tempfile.mkdtemp())
         self.calls = []
 
@@ -420,7 +442,113 @@ class WindowLabels(unittest.TestCase):
         )
 
 
-class LikeWildcards(unittest.TestCase):
+class TheWholeReportIsAttempted(RestoresModuleFunctions):
+    """SBA, i-Ready and the subgroup rollups are part of the report.
+
+    The first version of this pipeline did DIBELS growth only, while SKILL.md
+    told the agent not to orchestrate anything itself — so a principal would
+    have received a workbook silently missing SBA proficiency (half the
+    report's name), i-Ready, and both subgroup breakdowns. Review caught it.
+    That is the same "looks complete, isn't" class as the Minter Creek grade
+    span and the district-column-mirrors-school-column bug.
+    """
+
+    def test_the_dibels_extraction_carries_the_subgroup_flags(self):
+        sql = R.extraction_sql(1, 2, "3", ["ORF-WRC"], "Fall")
+        self.assertIn("students_frl", sql)
+        self.assertIn("students_specialed", sql)
+        self.assertIn("low_income", sql)
+        self.assertIn("special_ed", sql)
+
+    def test_the_subgroup_join_is_district_wide(self):
+        # Scoping it to the school made every District cell equal its School
+        # cell on 2026-08-15 — grade K showed 18/18 against a district cohort
+        # of 558 — and every number looked plausible.
+        sql = R.extraction_sql(7, 2, "3", ["ORF-WRC"], "Fall")
+        frl = sql.split("students_frl", 1)[1].split("LEFT JOIN", 1)[0]
+        self.assertNotIn("schoolid", frl)
+
+    def test_both_subgroups_are_requested_from_aggregate(self):
+        seen = {}
+        R.run_json = lambda argv, what, **k: seen.setdefault("argv", argv) or []
+        R.aggregate_rows(pathlib.Path("/tmp/x.json"), "3", "Fall",
+                         subgroups=R.SUBGROUPS)
+        joined = " ".join(seen["argv"])
+        self.assertIn("low_income=Low Income|Non-Low Income", joined)
+        self.assertIn("special_ed=Special Ed|Non-Special Ed", joined)
+
+    def test_sba_filters_out_iab_participation_rows(self):
+        # smarter_balanced_scores mixes IAB/FIAB rows (score = 1) with
+        # summatives; unfiltered averages are garbage.
+        sql = R.sba_sql(1, 35, "4")
+        self.assertIn("LIKE 'Summative%'", sql)
+        self.assertIn("is_strand = false", sql)
+
+    def test_sba_quartiles_on_the_prior_year_score(self):
+        sql = R.sba_sql(1, 35, "5")
+        self.assertIn("yearid = 34", sql)      # prior year
+        self.assertIn("grade_level = '4'", sql)  # prior grade
+        self.assertIn("prior.b::text", sql)
+
+    def test_iready_uses_percentile_not_raw_score(self):
+        sql = R.iready_sql(1, 2, "3", "iready_scores")
+        self.assertIn("AVG(percentile)", sql)
+
+    def test_no_block_reintroduces_a_window_function(self):
+        for sql in (R.sba_sql(1, 35, "4"),
+                    R.iready_sql(1, 2, "3", "iready_scores")):
+            upper = sql.upper()
+            for banned in ("NTILE(", "GROUPING SETS", "LATERAL"):
+                self.assertNotIn(banned, upper)
+
+
+class OmissionsAreVisibleInTheWorkbook(RestoresModuleFunctions):
+    """A principal does not read the run log.
+
+    Every previous "looks complete, isn't" failure was invisible at the point
+    of use. A block that cannot be produced is written INTO the tab.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.work = pathlib.Path(tempfile.mkdtemp())
+
+    def test_a_failed_block_becomes_a_gap_not_an_absence(self):
+        def boom():
+            raise R.ReportError("table does not exist")
+
+        gaps = []
+        R.query_all = lambda *a, **k: (_ for _ in ()).throw(
+            R.ReportError("table does not exist"))
+        out = R.run_block(self.work, "t", "3", lambda: "SELECT 1", "why",
+                          lambda m: None, gaps, "SBA grades 4-5")
+        self.assertEqual(out, [])
+        self.assertEqual(len(gaps), 1)
+        self.assertIn("SBA grades 4-5", gaps[0])
+        self.assertIn("not included", gaps[0])
+
+    def test_an_empty_block_is_also_a_gap(self):
+        gaps = []
+        R.query_all = lambda *a, **k: []
+        R.run_block(self.work, "t2", "3", lambda: "SELECT 1", "why",
+                    lambda m: None, gaps, "i-Ready Reading/Math")
+        self.assertIn("no matched students", gaps[0])
+
+    def test_gaps_are_rendered_into_the_tab(self):
+        import build_tab
+        tab = build_tab.build([], "S", "3", "2025-26", "Fall→Spring",
+                              gaps=["SBA grades 4-5: not included (x)"])
+        flat = [c for row in tab["values"] for c in row]
+        self.assertIn("NOT INCLUDED IN THIS REPORT", flat)
+        self.assertTrue(any("SBA grades 4-5" in c for c in flat))
+
+    def test_a_complete_tab_carries_no_gap_banner(self):
+        import build_tab
+        tab = build_tab.build([], "S", "3", "2025-26", "Fall→Spring")
+        flat = [c for row in tab["values"] for c in row]
+        self.assertNotIn("NOT INCLUDED IN THIS REPORT", flat)
+
+class LikeWildcards(RestoresModuleFunctions):
     """A school name is a literal, not a pattern.
 
     sql_escape closes the quote hole; it does nothing about `%` and `_`, which

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -211,10 +211,6 @@ class RosterDefinesTheGradeSpan(unittest.TestCase):
             R.fetch_roster(1, 2)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class CommandStringsSurviveApostrophes(unittest.TestCase):
     """psd-workspace's splitCommand has no escape syntax.
 
@@ -353,3 +349,69 @@ class WindowLabels(unittest.TestCase):
         self.assertEqual(
             build_tab.window_for("anything", "Fall→Spring"), "Fall→Spring"
         )
+
+
+class LikeWildcards(unittest.TestCase):
+    """A school name is a literal, not a pattern.
+
+    sql_escape closes the quote hole; it does nothing about `%` and `_`, which
+    are still wildcards inside a LIKE. A stray one broadens the match, and the
+    ambiguous branch then refuses a name that should have resolved cleanly.
+    """
+
+    def test_wildcards_are_escaped(self):
+        self.assertEqual(R.like_escape("Harbor_Ridge"), "Harbor\\_Ridge")
+        self.assertEqual(R.like_escape("100%"), "100\\%")
+
+    def test_a_backslash_is_escaped_first(self):
+        # Otherwise the escape character introduced here becomes escapable.
+        self.assertEqual(R.like_escape("a\\b"), "a\\\\b")
+
+    def test_an_ordinary_name_is_untouched(self):
+        self.assertEqual(R.like_escape("Artondale Elementary"),
+                         "Artondale Elementary")
+
+    def test_the_query_declares_its_escape_character(self):
+        captured = {}
+
+        def fake_query(sql, reason, **kwargs):
+            captured["sql"] = sql
+            return [{"schoolid": 1, "school_name": "Harbor_Ridge"}]
+
+        R.query = fake_query
+        R.resolve_school("Harbor_Ridge")
+        self.assertIn("ESCAPE", captured["sql"])
+        self.assertIn("Harbor\\_Ridge", captured["sql"])
+
+
+class FallbackWindowLabel(unittest.TestCase):
+    """The '*' label follows the grade, not the global default.
+
+    K has no Fall administration at all, so labelling a K block "Fall→Spring"
+    states a window that was never measured.
+    """
+
+    def test_kindergarten_falls_back_to_winter(self):
+        self.assertEqual(
+            R.BASELINE_BY_GRADE.get("K", R.BASELINE_DEFAULT), "Winter"
+        )
+
+    def test_other_grades_fall_back_to_fall(self):
+        self.assertEqual(
+            R.BASELINE_BY_GRADE.get("3", R.BASELINE_DEFAULT), "Fall"
+        )
+
+    def test_the_hardcoded_default_label_is_gone(self):
+        source = pathlib.Path(R.__file__).read_text()
+        self.assertNotIn('windows["*"] = f"{BASELINE_DEFAULT}', source)
+
+
+# Keep this guard LAST in the file. It used to sit mid-file (line 214), which
+# meant `python test_run_report.py` ran unittest.main() and sys.exit()ed before
+# the four classes below it were even defined — 22 tests instead of 35,
+# silently skipping the apostrophe-safety, timeout-bound, checkpointed
+# side-effect and window-label suites. CI imports the module via
+# `python -m unittest`, so it never noticed; a developer debugging locally got
+# a green run that had not executed the tests they were debugging.
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -749,6 +749,40 @@ class EveryBlockHonoursTheGapContract(RestoresModuleFunctions):
         self.assertIn("NOT INCLUDED IN THIS REPORT", flat)
         self.assertTrue(any("DIBELS growth" in c for c in flat))
 
+class EverySplicedValueIsSanitised(RestoresModuleFunctions):
+    """One unsanitised value is enough.
+
+    The title was fixed after review caught it; share_workbook still spliced
+    the caller's address raw. Same tokenizer, same missing escape syntax, and
+    the failure would land on the LAST step of a finished report. Rather than
+    reason about which values can contain a quote, every one goes through the
+    same door — and this test fails if a new splice site skips it.
+    """
+
+    def test_no_raw_interpolation_reaches_a_params_or_body_string(self):
+        source = pathlib.Path(R.__file__).read_text()
+        offenders = []
+        for line in source.splitlines():
+            if "--params '{json.dumps(" in line or "--body '{json.dumps(" in line:
+                # A literal dict of constants is fine; a bare name is not.
+                if "command_literal" not in line and "json.dumps(params)" not in line \
+                        and "json.dumps(body)" not in line:
+                    offenders.append(line.strip())
+        self.assertEqual(offenders, [], f"unsanitised splice: {offenders}")
+
+    def test_the_share_body_sanitises_the_caller(self):
+        seen = {}
+        R.workspace = lambda command, user, scope="agent", json_file=None: (
+            seen.setdefault("command", command) or {"ok": True})
+        R.share_workbook("SHEET1", "o'brien@psd401.net")
+        self.assertNotIn("o'brien", seen["command"])
+        self.assertIn("brien", seen["command"])
+
+    def test_a_normal_address_is_unchanged(self):
+        self.assertEqual(
+            R.command_literal("hagelk@psd401.net"), "hagelk@psd401.net"
+        )
+
 
 # Keep this guard LAST in the file. It used to sit mid-file (line 214), which
 # meant `python test_run_report.py` ran unittest.main() and sys.exit()ed before

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -710,6 +710,45 @@ class SbaIsNotLabelledFallToSpring(RestoresModuleFunctions):
         self.assertIn("SBA ELA (prior year→this year)", flat)
         self.assertNotIn("SBA ELA (Fall→Spring)", flat)
 
+class EveryBlockHonoursTheGapContract(RestoresModuleFunctions):
+    """SKILL.md: "Anything it cannot produce is written INTO the tab."
+
+    SBA and i-Ready went through run_block, which records a gap on a failed
+    query and on an empty result. The DIBELS block — the one the report is
+    named for — was built inline and did neither, so the PRIMARY measures
+    could go missing while the secondary ones announced themselves. That
+    asymmetry is precisely what makes a workbook look complete.
+    """
+
+    def test_the_source_records_a_gap_for_a_failed_dibels_extraction(self):
+        source = pathlib.Path(R.__file__).read_text()
+        block = source.split("One pass per distinct baseline", 1)[1]
+        block = block.split("# i-Ready", 1)[0]
+        self.assertIn("query failed", block)
+        self.assertIn("no matched students", block)
+
+    def test_a_grade_with_no_dibels_measures_still_reports_it(self):
+        source = pathlib.Path(R.__file__).read_text()
+        self.assertIn(
+            "no DIBELS measures recorded for this grade", source
+        )
+
+    def test_the_dibels_gap_list_is_not_reset_before_the_other_blocks(self):
+        # `gaps = []` appearing twice would silently discard whatever the
+        # DIBELS pass recorded before SBA and i-Ready ran.
+        source = pathlib.Path(R.__file__).read_text()
+        self.assertEqual(source.count("            gaps = []"), 1)
+
+    def test_a_gap_only_grade_still_produces_a_tab(self):
+        # A grade with nothing to report must still say so in the workbook
+        # rather than being skipped into silence.
+        import build_tab
+        tab = build_tab.build([], "S", "2", "2025-26", "Fall→Spring",
+                              gaps=["DIBELS growth: not included (x)"])
+        flat = [c for row in tab["values"] for c in row]
+        self.assertIn("NOT INCLUDED IN THIS REPORT", flat)
+        self.assertTrue(any("DIBELS growth" in c for c in flat))
+
 
 # Keep this guard LAST in the file. It used to sit mid-file (line 214), which
 # meant `python test_run_report.py` ran unittest.main() and sys.exit()ed before

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -759,16 +759,37 @@ class EverySplicedValueIsSanitised(RestoresModuleFunctions):
     same door — and this test fails if a new splice site skips it.
     """
 
-    def test_no_raw_interpolation_reaches_a_params_or_body_string(self):
+    def test_no_raw_interpolation_reaches_any_command_string(self):
+        # Scoped to --params/--body at first, which is exactly why the
+        # --json-file path slipped through as the FOURTH variant of this bug.
+        # Any interpolation into a command string counts now.
         source = pathlib.Path(R.__file__).read_text()
         offenders = []
         for line in source.splitlines():
-            if "--params '{json.dumps(" in line or "--body '{json.dumps(" in line:
-                # A literal dict of constants is fine; a bare name is not.
-                if "command_literal" not in line and "json.dumps(params)" not in line \
-                        and "json.dumps(body)" not in line:
-                    offenders.append(line.strip())
+            stripped = line.strip()
+            if "--params" not in stripped and "--body" not in stripped \
+                    and "--json-file" not in stripped:
+                continue
+            if "{" not in stripped:
+                continue
+            if any(guard in stripped for guard in
+                   ("command_literal", "safe_path", "json.dumps(params)",
+                    "json.dumps(body)")):
+                continue
+            offenders.append(stripped)
         self.assertEqual(offenders, [], f"unsanitised splice: {offenders}")
+
+    def test_a_work_dir_with_a_space_is_refused_not_mangled(self):
+        with self.assertRaises(R.ReportError) as caught:
+            R.safe_path("/tmp/my reports/x.json")
+        self.assertIn("separate tokens", str(caught.exception))
+
+    def test_a_work_dir_with_a_quote_is_refused(self):
+        with self.assertRaises(R.ReportError):
+            R.safe_path("/tmp/o'brien/x.json")
+
+    def test_an_ordinary_path_passes_through(self):
+        self.assertEqual(R.safe_path("/tmp/qgr-a-b/x.json"), "/tmp/qgr-a-b/x.json")
 
     def test_the_share_body_sanitises_the_caller(self):
         seen = {}

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -407,6 +407,18 @@ class TheDefaultTabIsRemoved(unittest.TestCase):
         R.add_tab("SHEET1", "4", "u@psd401.net", self.work)
         self.assertNotIn("deleteSheet", self.calls)
 
+    def test_a_non_report_error_also_never_fails_the_report(self):
+        # The docstring promises non-fatal; catching only ReportError meant an
+        # OSError writing the request payload would still kill a finished run.
+        def boom(command, user, scope="agent", json_file=None):
+            if json_file and "deletesheet" in json_file:
+                raise OSError("read-only file system")
+            return self.fake_workspace(command, user, scope, json_file)
+
+        R.workspace = boom
+        R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
+        self.assertTrue((self.work / "default-tab-dropped.json").exists())
+
     def test_a_failed_delete_never_fails_the_report(self):
         # The numbers are all in by this point. Losing a finished report over
         # a cosmetic tab would be the worse trade by a wide margin.

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -319,20 +319,89 @@ class SideEffectsAreCheckpointed(unittest.TestCase):
     def setUp(self):
         self.work = pathlib.Path(tempfile.mkdtemp())
         self.calls = []
-        R.workspace = lambda command, user, scope="agent", json_file=None: (
-            self.calls.append(command.split(" --")[0]) or {"ok": True})
+
+        # Both addSheet and deleteSheet are "sheets spreadsheets batchUpdate";
+        # the request kind only shows up in the payload file, so record that.
+        def fake_workspace(command, user, scope="agent", json_file=None):
+            kind = command.split(" --")[0]
+            if json_file:
+                body = json.loads(pathlib.Path(json_file).read_text())
+                requests = body.get("requests") or [{}]
+                kind = next(iter(requests[0]), kind)
+            self.calls.append(kind)
+            return {"ok": True}
+
+        R.workspace = fake_workspace
 
     def test_a_tab_is_created_once_across_re_runs(self):
         R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
         R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
-        self.assertEqual(self.calls.count("sheets spreadsheets batchUpdate"), 1)
+        self.assertEqual(self.calls.count("addSheet"), 1)
 
     def test_each_tab_gets_its_own_marker(self):
         R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
         R.add_tab("SHEET1", "4", "u@psd401.net", self.work)
-        self.assertEqual(self.calls.count("sheets spreadsheets batchUpdate"), 2)
+        self.assertEqual(self.calls.count("addSheet"), 2)
         self.assertTrue((self.work / "tab-3-added.json").exists())
         self.assertTrue((self.work / "tab-4-added.json").exists())
+
+
+class TheDefaultTabIsRemoved(unittest.TestCase):
+    """spreadsheets.create always makes a blank "Sheet1" nobody asked for.
+
+    Grade tabs are appended after it, so the empty one stays LEFTMOST — the
+    tab a principal opens onto. Cosmetic, but this report is entirely about
+    not handing over something that looks complete and isn't.
+    """
+
+    def setUp(self):
+        self.work = pathlib.Path(tempfile.mkdtemp())
+        self.calls = []
+
+        def fake_workspace(command, user, scope="agent", json_file=None):
+            kind = command.split(" --")[0]
+            if json_file:
+                body = json.loads(pathlib.Path(json_file).read_text())
+                requests = body.get("requests") or [{}]
+                kind = next(iter(requests[0]), kind)
+            self.calls.append(kind)
+            return {"ok": True}
+
+        self.fake_workspace = fake_workspace
+        R.workspace = fake_workspace
+
+    def test_the_blank_tab_is_deleted_after_a_real_one_exists(self):
+        R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
+        self.assertEqual(self.calls, ["addSheet", "deleteSheet"])
+
+    def test_it_is_deleted_only_once_however_many_tabs_are_added(self):
+        for grade in ("K", "1", "2"):
+            R.add_tab("SHEET1", grade, "u@psd401.net", self.work)
+        self.assertEqual(self.calls.count("deleteSheet"), 1)
+
+    def test_it_is_not_retried_after_a_resume(self):
+        R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
+        self.calls.clear()
+        R.add_tab("SHEET1", "4", "u@psd401.net", self.work)
+        self.assertNotIn("deleteSheet", self.calls)
+
+    def test_a_failed_delete_never_fails_the_report(self):
+        # The numbers are all in by this point. Losing a finished report over
+        # a cosmetic tab would be the worse trade by a wide margin.
+        def boom(command, user, scope="agent", json_file=None):
+            if json_file and "deletesheet" in json_file:
+                raise R.ReportError("sheet not found")
+            return self.fake_workspace(command, user, scope, json_file)
+
+        R.workspace = boom
+        R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
+        self.assertTrue((self.work / "default-tab-dropped.json").exists())
+
+    def test_a_real_tab_must_exist_before_the_delete(self):
+        # A spreadsheet must keep at least one sheet, so the order matters.
+        R.add_tab("SHEET1", "3", "u@psd401.net", self.work)
+        self.assertLess(self.calls.index("addSheet"),
+                        self.calls.index("deleteSheet"))
 
 
 class WindowLabels(unittest.TestCase):
@@ -404,6 +473,26 @@ class FallbackWindowLabel(unittest.TestCase):
     def test_the_hardcoded_default_label_is_gone(self):
         source = pathlib.Path(R.__file__).read_text()
         self.assertNotIn('windows["*"] = f"{BASELINE_DEFAULT}', source)
+
+
+class WorkDirIsOwnerOnly(unittest.TestCase):
+    """Checkpoints are student data, not scratch metadata.
+
+    grade-<g>-rows.json pairs studentid with assessment scores and lives at a
+    predictable /tmp path for the life of the container. Default mkdir
+    permissions leave that world-readable; owner-only costs nothing and does
+    not rely on an assumption about how ephemeral the sandbox is.
+    """
+
+    def test_the_work_dir_is_restricted(self):
+        work = pathlib.Path(tempfile.mkdtemp()) / "qgr-test"
+        work.mkdir(parents=True, exist_ok=True)
+        work.chmod(0o700)
+        self.assertEqual(work.stat().st_mode & 0o777, 0o700)
+
+    def test_main_restricts_the_work_dir_it_creates(self):
+        source = pathlib.Path(R.__file__).read_text()
+        self.assertIn("work_dir.chmod(0o700)", source)
 
 
 # Keep this guard LAST in the file. It used to sit mid-file (line 214), which

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -1,0 +1,194 @@
+"""The one-command report pipeline.
+
+Every failure this report hit between 2026-08-14 and 2026-08-16 was
+orchestration, never arithmetic: a no-op edit ending the run, assistant
+messages fusing, a promoted job aborting its own run, `--export` timing out,
+literal newline escapes in model-authored glue. This script exists to delete
+that surface, so these tests pin the properties that make it deletable —
+checkpoint resume, paging without export, a queried grade span, and SQL that
+does not reintroduce the shapes that time out.
+
+The two external CLIs (psd-data, psd-workspace) are stubbed. Everything
+between them is the real code path.
+"""
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import run_report as R  # noqa: E402
+
+
+class Checkpoints(unittest.TestCase):
+    """A re-run must resume, not restart.
+
+    The previous design had no checkpoints, so every interruption threw away
+    everything — which is exactly what the user watched happen twice on
+    2026-08-16, both times reported as "nothing has been written to the sheet".
+    """
+
+    def setUp(self):
+        self.work = pathlib.Path(tempfile.mkdtemp())
+        self.runs = 0
+
+    def _produce(self):
+        self.runs += 1
+        return {"value": self.runs}
+
+    def test_a_completed_step_is_not_recomputed(self):
+        first = R.step(self.work, "s", self._produce, lambda m: None)
+        second = R.step(self.work, "s", self._produce, lambda m: None)
+        self.assertEqual(first, second)
+        self.assertEqual(self.runs, 1)
+
+    def test_a_truncated_checkpoint_is_discarded(self):
+        # A half-written file from a killed run is not a checkpoint. Trusting
+        # one would poison every later step with partial data.
+        (self.work / "s.json").write_text('{"half')
+        value = R.step(self.work, "s", self._produce, lambda m: None)
+        self.assertEqual(value, {"value": 1})
+
+    def test_the_checkpoint_survives_as_valid_json(self):
+        R.step(self.work, "s", self._produce, lambda m: None)
+        self.assertEqual(
+            json.loads((self.work / "s.json").read_text()), {"value": 1}
+        )
+
+
+class Paging(unittest.TestCase):
+    """`--export` is not used anywhere, on purpose.
+
+    It timed out repeatedly on the grade-K extraction on 2026-08-16 while the
+    same query in normal mode returned 2,232 rows in seconds, and it has a
+    separate history of silently dropping numeric columns from the CSV.
+    """
+
+    def test_paging_stops_on_a_short_page(self):
+        pages = [[{"r": i} for i in range(R.PAGE_SIZE)], [{"r": "last"}]]
+        R.query = lambda *a, **k: pages.pop(0) if pages else []
+        self.assertEqual(len(R.query_all("SELECT 1", "test")), R.PAGE_SIZE + 1)
+
+    def test_paging_refuses_to_run_forever(self):
+        # A query that never shortens is a bug somewhere else; looping until
+        # the turn dies would hide it.
+        R.query = lambda *a, **k: [{"r": i} for i in range(R.PAGE_SIZE)]
+        with self.assertRaises(R.ReportError) as caught:
+            R.query_all("SELECT 1", "runaway")
+        self.assertIn("refusing to page forever", str(caught.exception))
+
+    def test_export_is_never_requested(self):
+        source = pathlib.Path(R.__file__).read_text()
+        self.assertNotIn('"--export"', source)
+
+
+class ExtractionSql(unittest.TestCase):
+    """The only query shape that completes against dibels_scores.
+
+    Window functions do not finish on this MCP at any size: a bare NTILE(4)
+    over ~1,100 rows timed out on 2026-08-15 while the same query without it
+    ran in seconds. Quartiles are computed locally by aggregate.py.
+    """
+
+    def _sql(self, grade="3", baseline="Fall"):
+        return R.extraction_sql(1, 2, grade, ["ORF-WRC", "NWF-CLS"], baseline)
+
+    def test_no_window_function_reaches_the_warehouse(self):
+        upper = self._sql().upper()
+        for banned in ("NTILE", "GROUPING SETS", "LATERAL", "OVER ("):
+            self.assertNotIn(banned, upper, f"{banned} must stay out of SQL")
+
+    def test_every_non_text_column_is_cast(self):
+        # The export path drops unqualified numerics, and the boolean too.
+        sql = self._sql()
+        for column in ("m.studentid::text", "m.b::text", "m.e::text",
+                       "hr.sectionid::text", "IS NOT NULL)::text"):
+            self.assertIn(column, sql)
+
+    def test_the_baseline_window_is_honored(self):
+        # K has no Fall DIBELS; a Fall baseline there silently returns nothing.
+        self.assertIn("'Winter'", self._sql(grade="K", baseline="Winter"))
+        self.assertNotIn("'Fall'", self._sql(grade="K", baseline="Winter"))
+
+    def test_kindergarten_defaults_to_a_winter_baseline(self):
+        self.assertEqual(R.BASELINE_BY_GRADE.get("K"), "Winter")
+        self.assertIsNone(R.BASELINE_BY_GRADE.get("3"))
+
+
+class SqlEscaping(unittest.TestCase):
+    def test_an_apostrophe_in_a_school_name_is_escaped(self):
+        self.assertEqual(R.sql_escape("O'Brien"), "O''Brien")
+
+    def test_the_escaped_name_reaches_the_query_intact(self):
+        captured = {}
+
+        def fake_query(sql, reason, **kwargs):
+            captured["sql"] = sql
+            return [{"schoolid": 1, "school_name": "O'Brien Elementary"}]
+
+        R.query = fake_query
+        R.resolve_school("O'Brien Elementary")
+        self.assertIn("O''Brien Elementary", captured["sql"])
+
+
+class SchoolResolution(unittest.TestCase):
+    def test_an_ambiguous_name_refuses_rather_than_guessing(self):
+        R.query = lambda *a, **k: [
+            {"schoolid": 1, "school_name": "Harbor Ridge Middle"},
+            {"schoolid": 2, "school_name": "Harbor Heights Elementary"},
+        ]
+        with self.assertRaises(R.ReportError) as caught:
+            R.resolve_school("Harbor")
+        self.assertIn("matched 2 schools", str(caught.exception))
+
+    def test_an_exact_match_wins_over_a_substring_sibling(self):
+        R.query = lambda *a, **k: [
+            {"schoolid": 1, "school_name": "Artondale Elementary"},
+            {"schoolid": 2, "school_name": "Artondale Elementary Annex"},
+        ]
+        self.assertEqual(
+            R.resolve_school("Artondale Elementary")["schoolid"], 1
+        )
+
+    def test_no_match_is_an_error_not_an_empty_report(self):
+        R.query = lambda *a, **k: []
+        with self.assertRaises(R.ReportError):
+            R.resolve_school("Nowhere Elementary")
+
+
+class RosterDefinesTheGradeSpan(unittest.TestCase):
+    """On 2026-08-15 the agent announced "Minter Creek is a K-2 school",
+    invented the justification, and scoped a whole report to it. It is K-5.
+    The span is a query result here, never an assertion.
+    """
+
+    ROWS = [
+        {"sectionid": "1", "grade_level": "K", "teacher_name": "Hansen, Jane"},
+        {"sectionid": "2", "grade_level": "1", "teacher_name": None},
+        {"sectionid": "3", "grade_level": "5", "teacher_name": "Ruiz, Ana"},
+    ]
+
+    def test_the_span_comes_from_the_roster(self):
+        R.query_all = lambda *a, **k: self.ROWS
+        roster = R.fetch_roster(1, 2)
+        self.assertEqual(sorted(roster["grades"]), ["1", "5", "K"])
+
+    def test_a_section_with_no_lead_teacher_is_kept(self):
+        # build_tab renders it "(Not on file)". Dropping the section would
+        # silently remove a classroom column from the report.
+        R.query_all = lambda *a, **k: self.ROWS
+        roster = R.fetch_roster(1, 2)
+        self.assertIn("2", roster["grades"]["1"])
+        self.assertNotIn("2", roster["teachers"])
+
+    def test_an_empty_roster_is_an_error(self):
+        R.query_all = lambda *a, **k: []
+        with self.assertRaises(R.ReportError):
+            R.fetch_roster(1, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Five consecutive failures, none of them arithmetic.

| when | what failed |
|---|---|
| 08-14 | literal newline escapes in a model-authored converter |
| 08-15 | subgroup join scoped to the school; teacher columns missing |
| 08-16 | a no-op edit ended the run at 484s, 53 model calls in |
| 08-16 | four assistant messages fused into one 515-char reply |
| 08-16 | a promoted job aborted the run it existed to continue |
| 08-16 | `--export` timed out on the grade K extraction |

**Every one is orchestration.** Not one is in the quartiles, the norms, or the rollups. The path has ~8 serial failure points and a run only ever reveals the first one that fires — fix it, and the next run shows the next. Each round costs a deploy and a real attempt.

So this removes the path instead of hardening it. `run_report.py` does the roster, every grade's extraction, the aggregation, the tabs, the Definitions tab and the share. The agent resolves the school, runs one command, pastes the URL.

```bash
run_report.py --school "Artondale Elementary" --user you@psd401.net
```

## What that deletes

- ~100 model round-trips, each a chance to derail
- model-authored files, so the literal-newline bug is unreachable
- the turn deadline, the promotion, and the continuation turn — it is one exec

## Decisions taken from the failures, not invented

- **No `--export` anywhere.** It timed out on grade K while normal mode returned 2,232 rows in seconds, and it has a history of silently dropping numeric columns. A test asserts the flag never reappears.
- **Every step checkpoints.** A re-run resumes; the old design restarted, which is why two interrupted runs produced nothing at all.
- **The roster defines the grade span** — it cannot be asserted. That is how *"Minter Creek is a K-2 school"* (it is K-5) scoped a whole report wrong.
- **SQL keeps the only shape that completes**: no `NTILE`, no `GROUPING SETS`, no `LATERAL`, every non-text column cast inside the aggregate. Tests pin all four — a window function reintroduced here times out rather than failing loudly.
- Ambiguous school names refuse instead of guessing.
- The workbook is created on the agent slot and **ownership transferred to the caller** — Drive only lets an owner trash a file (#1636).

## What this does not fix

Whether the numbers are right. It makes that *answerable* — the same school can be run twice and diffed, which the previous design never allowed. I am not claiming the report is correct, only that it can now finish and be checked.

18 tests, wired into `ci.yml`. 830 image tests, bootstrap budget and config consistency clean.