### PR TITLE
fix(quartile): the seven bugs from #1679 — every invocation failed

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -497,6 +497,42 @@ def _frames_from_run(frames, run_id) -> bool:
     return False
 
 
+def _is_reply_session_conflict(error) -> bool:
+    """Does this chat.send error mean a stale reply session is in the way?
+
+    The wedge the pre-send abort was written for (2026-07-01): a prior turn's
+    server-side reply session survives its ws.close() and rejects the next
+    chat.send. It announces itself, which is why guessing at it every turn was
+    never necessary.
+    """
+    # Underscores normalised so a code like SESSION_INITIALIZATION_FAILED
+    # matches the same rule as the prose message. The exact wire text is not
+    # pinned by anything we control, so match liberally — the cost of a false
+    # positive is one wasted abort+resend on a turn that was already failing.
+    text = json.dumps(error).lower().replace("_", " ") if error else ""
+    return "reply session" in text or "session initialization" in text
+
+
+def _abort_and_resend(ws, session_id, message, model_override) -> str:
+    """Clear the stale reply session, then re-send. Returns the new chat id."""
+    ws.send(json.dumps({
+        "type": "req", "id": str(uuid.uuid4()), "method": "chat.abort",
+        "params": {"sessionKey": session_id or "default"},
+    }))
+    chat_id = str(uuid.uuid4())
+    params = {
+        "sessionKey": session_id or "default",
+        "message": message,
+        "idempotencyKey": chat_id,
+    }
+    if model_override:
+        params["model"] = model_override
+    ws.send(json.dumps({
+        "type": "req", "id": chat_id, "method": "chat.send", "params": params,
+    }))
+    return chat_id
+
+
 def _classify_chat_error(error_message: str) -> str:
     """Name the chat-error class from OpenClaw's message.
 
@@ -1919,10 +1955,35 @@ class OpenClawAdapter(HarnessAdapter):
                         deadline_s,
                     )
 
+                # DEFAULT OFF, deliberately — this is now REACTIVE.
+                #
+                # The abort was preemptive: every turn destroyed whatever was
+                # running for this session before sending. Its comment argued
+                # that was safe because the router serializes turns, so nothing
+                # legitimate could be active. #1665 found the first hole (a
+                # promoted job's own turn). This is the second and it is the
+                # one users feel: when a background job is working and the user
+                # sends ANY message, the interactive turn aborts the job's run.
+                #
+                # On 2026-08-17 that happened repeatedly on one request. The
+                # agent kept telling the user it had been interrupted and kept
+                # stopping to ask whether to continue; the user answered "I
+                # never aborted anything" three times. He was right, every
+                # time.
+                #
+                # The wedge it was written for (2026-07-01) announces itself:
+                # chat.send comes back with a reply-session conflict. So do not
+                # pre-destroy state on the chance of a wedge — send, and if
+                # that specific error arrives, abort and re-send once. The cost
+                # is one extra round trip on the rare broken turn instead of
+                # killing live work on every healthy one.
+                #
+                # OPENCLAW_PRESEND_ABORT=1 restores the old preemptive
+                # behaviour without an image build.
                 if (
                     not answered_pending
                     and not is_promoted_job
-                    and os.environ.get("OPENCLAW_PRESEND_ABORT", "1") != "0"
+                    and os.environ.get("OPENCLAW_PRESEND_ABORT", "0") == "1"
                 ):
                     try:
                         abort_id = str(uuid.uuid4())
@@ -1981,6 +2042,8 @@ class OpenClawAdapter(HarnessAdapter):
                 # the gateway. final_state event stops it. Captured before
                 # ws.send so we don't count our own serialization.
                 #
+                # One reactive retry per turn, never a loop.
+                conflict_retried = False
                 chat_send_at = (
                     resolve_started_at if had_pending_question else time.time()
                 )
@@ -2838,6 +2901,21 @@ class OpenClawAdapter(HarnessAdapter):
                             )
                         if not msg.get("ok"):
                             error = msg.get("error", {})
+                            if (
+                                not conflict_retried
+                                and _is_reply_session_conflict(error)
+                            ):
+                                # The wedge the pre-send abort used to guess
+                                # at, now handled where it actually shows up.
+                                conflict_retried = True
+                                logger.warning(
+                                    "reply session conflict: aborting the "
+                                    "stale session and re-sending once"
+                                )
+                                chat_id = _abort_and_resend(
+                                    ws, session_id, message, model_override
+                                )
+                                continue
                             logger.error("chat.send error: %s", json.dumps(error)[:500])
                             # Previously returned silently — no failure signal.
                             record_failure(

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -257,7 +257,54 @@ def parse_mcp_rows(payload, reason):
                           f"{_mcp_text(payload)[:400]}")
     if isinstance(payload.get("rows"), list):
         return payload["rows"]          # a future structured mode
-    return parse_markdown_table(_mcp_text(payload))
+    return parse_result_text(_mcp_text(payload))
+
+
+def parse_result_text(text):
+    """Rows out of the MCP's text block, whatever shape it is in.
+
+    The one recorded fixture in this repo (psd-data/evals/fixtures/
+    list-tables.json) has JSON inside `text`:
+
+        "text": "{\"tables\":[\"EVAL_1426_ATTENDANCE\"]}"
+
+    The #1679 report says query_data returns a markdown table there instead.
+    I have no recorded query_data response either way, so this reads BOTH
+    rather than betting on one — the previous version bet on markdown alone,
+    and if the real shape is JSON it would have returned [] exactly like the
+    bug it was written to fix.
+
+    JSON is tried first because it is unambiguous; markdown is the fallback.
+    """
+    text = (text or "").strip()
+    if not text:
+        return []
+    if text[0] in "[{":
+        try:
+            return rows_from_json(json.loads(text))
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return parse_markdown_table(text)
+
+
+def rows_from_json(value):
+    """A decoded JSON payload down to a list of row dicts."""
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, dict)]
+    if not isinstance(value, dict):
+        return []
+    for key in ("rows", "records", "data", "results"):
+        inner = value.get(key)
+        if isinstance(inner, list):
+            # {"columns": [...], "rows": [[...], ...]} — pair them up.
+            columns = value.get("columns")
+            if (inner and isinstance(inner[0], list)
+                    and isinstance(columns, list)):
+                return [dict(zip(columns, row)) for row in inner
+                        if isinstance(row, list)]
+            return [v for v in inner if isinstance(v, dict)]
+    # A single object that is itself the row.
+    return [value] if value else []
 
 
 def _mcp_text(payload):

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -73,6 +73,34 @@ BASELINE_BY_GRADE = {"K": "Winter"}
 BASELINE_BY_GRADE_MEASURE = {("1", "ORF"): "Winter"}
 
 
+# The warehouse and the bundled norms file spell DIBELS measures differently,
+# and aggregate.py joins on that string. Unmapped, it aborts the whole run:
+#   "no norms at grade '1' for any requested measure (ORF Accuracy, ORF Errors,
+#    ORF WC); the norms file has ... ORF-ACC ... ORF-WRC"
+#
+# That killed every grade with an ORF measure, which is grades 1-5 — i.e. the
+# report. Matched case-insensitively on the warehouse spelling; an unmapped
+# name is passed through unchanged so a NEW measure fails loudly in
+# aggregate.py rather than being silently dropped here.
+NORMS_NAME_BY_WAREHOUSE = {
+    "orf accuracy": "ORF-ACC",
+    "orf errors": "ORF-WRC",
+    "orf wc": "ORF-WRC",
+    "nwf cls": "NWF-CLS",
+    "nwf wrc": "NWF-WRC",
+}
+
+
+def measure_as_args(measures):
+    """--measure-as WAREHOUSE=NORMS for every measure that needs mapping."""
+    args = []
+    for measure in measures:
+        norms = NORMS_NAME_BY_WAREHOUSE.get(str(measure).strip().lower())
+        if norms and norms != measure:
+            args.append(f"{measure}={norms}")
+    return args
+
+
 def baseline_for(grade, measure):
     """The baseline window for one measure in one grade.
 
@@ -202,8 +230,73 @@ def query(sql, reason, limit=None, offset=None):
     if offset is not None:
         argv += ["--offset", str(offset)]
     payload = run_json(argv, f"psd-data query ({reason})")
-    rows = payload.get("rows") if isinstance(payload, dict) else payload
-    return rows or []
+    return parse_mcp_rows(payload, reason)
+
+
+def parse_mcp_rows(payload, reason):
+    """Rows out of psd-data's MCP envelope.
+
+    run.js writes `JSON.stringify(response.result)` — the raw tools/call
+    result, shaped {"content": [{"type": "text", "text": "<markdown table>"}],
+    "isError": false}. There is no top-level "rows" key.
+
+    This read `payload.get("rows")`, so EVERY query returned [] — school
+    resolution, roster, every extraction — while real data sat behind it
+    (1,706 matched grade-1 pairs existed while the script reported "no Fall
+    matched pairs"). Combined with the empty-result path being a soft "no
+    data", it produced a workbook with a tab per grade and nothing in them.
+
+    An `isError` envelope is raised, not parsed: a query that failed must not
+    read as a query that found nothing. That conflation is what let four other
+    bugs hide behind this one.
+    """
+    if not isinstance(payload, dict):
+        return payload or []
+    if payload.get("isError"):
+        raise ReportError(f"{reason}: psd-data returned an error: "
+                          f"{_mcp_text(payload)[:400]}")
+    if isinstance(payload.get("rows"), list):
+        return payload["rows"]          # a future structured mode
+    return parse_markdown_table(_mcp_text(payload))
+
+
+def _mcp_text(payload):
+    parts = []
+    for block in payload.get("content") or []:
+        if isinstance(block, dict) and isinstance(block.get("text"), str):
+            parts.append(block["text"])
+    return "\n".join(parts)
+
+
+def parse_markdown_table(text):
+    """`| a | b |` blocks into dicts. Empty result sets return [].
+
+    Deliberately strict about the separator row: a markdown table without one
+    is prose, and guessing at prose is how a "no rows" message becomes a fake
+    data row.
+    """
+    lines = [ln.strip() for ln in (text or "").splitlines() if ln.strip()]
+    table = [ln for ln in lines if ln.startswith("|")]
+    if len(table) < 2:
+        return []
+
+    def cells(line):
+        return [c.strip() for c in line.strip().strip("|").split("|")]
+
+    header = cells(table[0])
+    separator = cells(table[1])
+    if not all(set(c) <= set("-: ") and c for c in separator):
+        return []
+    rows = []
+    for line in table[2:]:
+        values = cells(line)
+        if len(values) != len(header):
+            continue
+        rows.append({
+            key: (None if value in ("", "NULL", "null") else value)
+            for key, value in zip(header, values)
+        })
+    return rows
 
 
 def query_all(sql, reason):
@@ -257,8 +350,11 @@ def like_escape(value):
 
 def resolve_school(name):
     rows = query(
-        "SELECT schoolid, school_name FROM schools "
-        "WHERE LOWER(school_name) LIKE LOWER("
+        # Live schema: schools(id, abbreviation, name, level). There is no
+        # schoolid/school_name. Aliased rather than renamed downstream, so the
+        # rest of the script keeps one vocabulary.
+        "SELECT id AS schoolid, name AS school_name FROM schools "
+        "WHERE LOWER(name) LIKE LOWER("
         f"'%{sql_escape(like_escape(name))}%') ESCAPE '\\'",
         f"Resolve the school named {name} for a quartile growth report",
     )
@@ -275,10 +371,12 @@ def resolve_school(name):
 
 
 def resolve_year(year):
-    where = f"WHERE year_name = '{sql_escape(year)}'" if year else ""
-    order = "" if year else "ORDER BY yearid DESC"
+    where = f"WHERE name = '{sql_escape(year)}'" if year else ""
+    order = "" if year else "ORDER BY id DESC"
     rows = query(
-        f"SELECT yearid, year_name FROM school_years {where} {order}".strip(),
+        # Live schema: school_years(id, name, year_rank, first_day, last_day).
+        f"SELECT id AS yearid, name AS year_name FROM school_years "
+        f"{where} {order}".strip(),
         "Resolve the school year for a quartile growth report",
         limit=1,
     )
@@ -302,13 +400,15 @@ def fetch_roster(schoolid, yearid):
         "SELECT DISTINCT se.sectionid::text AS sectionid, "
         "  se.course_code, "
         "  sy.grade_level::text AS grade_level, "
-        "  t.teacher_name "
+        # Live schema: teachers has no teacher_name — only first_name /
+        # last_name — and its PK is `id`, not `teacherid`.
+        "  (t.first_name || ' ' || t.last_name) AS teacher_name "
         "FROM section_enrollments se "
         "JOIN school_year_enrollments sy "
         "  ON sy.studentid = se.studentid AND sy.yearid = se.yearid "
         "LEFT JOIN section_teachers st "
         "  ON st.sectionid = se.sectionid AND st.role_name = 'Lead Teacher' "
-        "LEFT JOIN teachers t ON t.teacherid = st.teacherid "
+        "LEFT JOIN teachers t ON t.id = st.teacherid "
         f"WHERE se.yearid = {int(yearid)} AND se.schoolid = {int(schoolid)} "
         "  AND se.course_code LIKE 'GR0%'",
         "Homeroom roster and lead teachers for a quartile growth report",
@@ -376,10 +476,15 @@ def extraction_sql(schoolid, yearid, grade, measures, baseline):
         # students carried a flag, so the district cell WAS the school cell and
         # its complement absorbed 540 unflagged students. Every number looked
         # plausible.
-        f"LEFT JOIN students_frl f ON f.studentid = m.studentid "
-        f"  AND f.yearid = {int(yearid)} "
-        f"LEFT JOIN students_specialed sp ON sp.studentid = m.studentid "
-        f"  AND sp.yearid = {int(yearid)}"
+        # NOT year-scoped: students_frl(studentid, frl) and
+        # students_specialed(studentid, special_education, iep, s504, ...)
+        # have no yearid at all. The predicate errored the WHOLE extraction
+        # for every grade, and because a failed query read as an empty one,
+        # the report came out with a tab per grade and no data in any of
+        # them — the exact "looks complete, isn't" outcome this script was
+        # written to prevent.
+        "LEFT JOIN students_frl f ON f.studentid = m.studentid "
+        "LEFT JOIN students_specialed sp ON sp.studentid = m.studentid"
     )
 
 
@@ -446,7 +551,8 @@ def discover_measures(yearid, grade):
     )
 
 
-def aggregate_rows(rows_path, grade, baseline, no_norms=False, subgroups=()):
+def aggregate_rows(rows_path, grade, baseline, no_norms=False, subgroups=(),
+                   measures=()):
     argv = [
         PYTHON, str(HERE / "aggregate.py"),
         "--rows", str(rows_path),
@@ -458,6 +564,8 @@ def aggregate_rows(rows_path, grade, baseline, no_norms=False, subgroups=()):
         argv.append("--no-norms")
     for spec in subgroups or ():
         argv += ["--subgroup", spec]
+    for spec in measure_as_args(measures or ()):
+        argv += ["--measure-as", spec]
     return run_json(argv, f"aggregate.py (grade {grade})")
 
 
@@ -488,8 +596,11 @@ def create_workbook(title, user):
     a ticket (issue #1636).
     """
     created = workspace(
+        # --params is path/query parameters; the resource is the request
+        # BODY. Sending it as a param returns HTTP 400 "Unknown name
+        # 'properties': Cannot bind query parameter."
         "sheets spreadsheets create "
-        f"--params '{json.dumps({'properties': {'title': command_literal(title)}})}'",
+        f"--json '{json.dumps({'properties': {'title': command_literal(title)}})}'",
         user,
     )
     sheet_id = created.get("spreadsheetId") or (
@@ -505,13 +616,14 @@ def share_workbook(sheet_id, user):
     # the failure would land on the LAST step of a finished report — the
     # costliest place for it. Consistency here is cheaper than reasoning about
     # which values are safe.
-    params = {"fileId": command_literal(sheet_id),
-              "transferOwnership": "true"}
+    # psd-workspace has no --body flag (only --params/--json/--json-file),
+    # and transferOwnership is a JSON boolean, not the string "true".
+    params = {"fileId": command_literal(sheet_id), "transferOwnership": True}
     body = {"type": "user", "role": "owner",
             "emailAddress": command_literal(user)}
     return workspace(
         f"drive permissions create --params '{json.dumps(params)}' "
-        f"--body '{json.dumps(body)}'",
+        f"--json '{json.dumps(body)}'",
         user,
     )
 
@@ -899,9 +1011,9 @@ def main() -> int:
                 log(f"grade {grade}: {len(rows)} rows ({baseline})")
                 part = step(
                     work_dir, f"{tag}-agg",
-                    lambda g=grade, b=baseline, t=tag: aggregate_rows(
+                    lambda g=grade, b=baseline, t=tag, m=group: aggregate_rows(
                         work_dir / f"{t}-rows.json", g, b,
-                        subgroups=SUBGROUPS),
+                        subgroups=SUBGROUPS, measures=m),
                     log)
                 records.extend(part)
                 for measure in group:

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -804,6 +804,217 @@ class EverySplicedValueIsSanitised(RestoresModuleFunctions):
             R.command_literal("hagelk@psd401.net"), "hagelk@psd401.net"
         )
 
+# --- issue #1679: seven bugs that every existing test missed ---------------
+#
+# Every test above passed while run_report.py failed on EVERY invocation
+# against the live warehouse. They asserted shapes this file invented rather
+# than shapes the warehouse and psd-workspace actually use — the same mistake
+# as the authored `questionId` fixture that let #1660 ship as a no-op.
+#
+# These pin the real ones, taken from the live schema recorded in #1679.
+
+
+class McpResponseIsAMarkdownTable(RestoresModuleFunctions):
+    """psd-data returns the raw tools/call envelope, not a rows array.
+
+    run.js writes JSON.stringify(response.result), shaped
+    {"content": [{"type": "text", "text": "<markdown>"}], "isError": false}.
+    Reading payload["rows"] returned [] for EVERY query — while 1,706 matched
+    grade-1 pairs sat behind it — and an empty result read as "no data", so
+    the workbook came out with a tab per grade and nothing in any of them.
+    """
+
+    ENVELOPE = {
+        "content": [{"type": "text", "text":
+                     "| schoolid | school_name |\n"
+                     "| --- | --- |\n"
+                     "| 3299 | Artondale Elementary |\n"}],
+        "isError": False,
+    }
+
+    def test_rows_are_parsed_out_of_the_envelope(self):
+        rows = R.parse_mcp_rows(self.ENVELOPE, "test")
+        self.assertEqual(rows, [{"schoolid": "3299",
+                                 "school_name": "Artondale Elementary"}])
+
+    def test_query_itself_returns_rows_from_a_real_envelope(self):
+        # Testing parse_mcp_rows directly proved nothing about query(): with
+        # the old payload["rows"] line restored, every direct test still
+        # passed. This one goes through query(), which is where the bug was.
+        R.run_json = lambda argv, what, **k: self.ENVELOPE
+        rows = R.query("SELECT 1", "resolve the school")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["school_name"], "Artondale Elementary")
+
+    def test_query_all_pages_a_real_envelope(self):
+        R.run_json = lambda argv, what, **k: self.ENVELOPE
+        self.assertEqual(len(R.query_all("SELECT 1", "roster")), 1)
+
+    def test_query_raises_on_an_error_envelope(self):
+        R.run_json = lambda argv, what, **k: {
+            "content": [{"type": "text",
+                         "text": 'column "schoolid" does not exist'}],
+            "isError": True}
+        with self.assertRaises(R.ReportError):
+            R.query("SELECT 1", "resolve the school")
+
+    def test_an_error_envelope_raises_instead_of_reading_as_no_data(self):
+        # This conflation is what let four other bugs hide: a query that
+        # FAILED looked exactly like a query that found nothing.
+        envelope = {"content": [{"type": "text",
+                                 "text": 'column "schoolid" does not exist'}],
+                    "isError": True}
+        with self.assertRaises(R.ReportError) as caught:
+            R.parse_mcp_rows(envelope, "resolve the school")
+        self.assertIn("does not exist", str(caught.exception))
+
+    def test_an_empty_result_set_is_empty_not_a_fake_row(self):
+        envelope = {"content": [{"type": "text", "text": "No rows returned."}],
+                    "isError": False}
+        self.assertEqual(R.parse_mcp_rows(envelope, "test"), [])
+
+    def test_a_structured_rows_key_is_used_when_present(self):
+        # So a future psd-data JSON mode needs no change here.
+        envelope = {"rows": [{"a": 1}], "isError": False}
+        self.assertEqual(R.parse_mcp_rows(envelope, "test"), [{"a": 1}])
+
+    def test_null_cells_become_none(self):
+        text = "| a | b |\n| --- | --- |\n| 1 | NULL |\n"
+        self.assertEqual(R.parse_markdown_table(text), [{"a": "1", "b": None}])
+
+    def test_prose_without_a_separator_row_is_not_a_table(self):
+        self.assertEqual(R.parse_markdown_table("| not a table"), [])
+
+
+class SqlMatchesTheLiveSchema(unittest.TestCase):
+    """The column names in #1679, not the ones this file guessed."""
+
+    def test_schools_is_id_and_name(self):
+        R.query = lambda sql, *a, **k: [{"schoolid": 1, "school_name": "X"}]
+        captured = {}
+
+        def fake(sql, *a, **k):
+            captured["sql"] = sql
+            return [{"schoolid": 1, "school_name": "Artondale Elementary"}]
+
+        original = R.query
+        R.query = fake
+        try:
+            R.resolve_school("Artondale Elementary")
+        finally:
+            R.query = original
+        self.assertIn("id AS schoolid", captured["sql"])
+        self.assertIn("name AS school_name", captured["sql"])
+        self.assertNotIn("LOWER(school_name)", captured["sql"])
+
+    def test_school_years_is_id_and_name(self):
+        captured = {}
+
+        def fake(sql, *a, **k):
+            captured["sql"] = sql
+            return [{"yearid": 35, "year_name": "2025-26"}]
+
+        original = R.query
+        R.query = fake
+        try:
+            R.resolve_year("2025-26")
+        finally:
+            R.query = original
+        self.assertIn("id AS yearid", captured["sql"])
+        self.assertIn("name AS year_name", captured["sql"])
+        self.assertNotIn("WHERE year_name", captured["sql"])
+
+    def test_the_teacher_join_uses_the_real_primary_key(self):
+        captured = {}
+
+        def fake(sql, *a, **k):
+            captured["sql"] = sql
+            return [{"sectionid": "1", "grade_level": "K",
+                     "teacher_name": "Hansen, Jane"}]
+
+        original = R.query_all
+        R.query_all = fake
+        try:
+            R.fetch_roster(1, 2)
+        finally:
+            R.query_all = original
+        self.assertIn("teachers t ON t.id = st.teacherid", captured["sql"])
+        self.assertNotIn("t.teacherid = st.teacherid", captured["sql"])
+        self.assertIn("first_name", captured["sql"])
+        self.assertNotIn("t.teacher_name", captured["sql"])
+
+    def test_the_subgroup_tables_are_not_year_scoped(self):
+        # THE most damaging of the seven: students_frl and students_specialed
+        # have no yearid, so the predicate errored the whole extraction for
+        # every grade and produced a complete-looking, empty workbook.
+        sql = R.extraction_sql(1, 35, "3", ["ORF WC"], "Fall")
+        self.assertIn("students_frl f ON f.studentid = m.studentid", sql)
+        self.assertNotIn("f.yearid", sql)
+        self.assertNotIn("sp.yearid", sql)
+
+
+class WorkspaceCallShapes(RestoresModuleFunctions):
+    """--params is query parameters; the resource is the request body."""
+
+    def test_create_sends_the_resource_as_json_not_params(self):
+        seen = {}
+
+        def fake(command, user, **kwargs):
+            seen["c"] = command
+            return {"spreadsheetId": "S"}
+
+        R.workspace = fake
+        R.create_workbook("T", "u@psd401.net")
+        self.assertIn("--json", seen["c"])
+        self.assertNotIn("--params", seen["c"])
+
+    def test_share_uses_json_and_a_boolean(self):
+        seen = {}
+
+        def fake(command, user, **kwargs):
+            seen["c"] = command
+            return {"ok": True}
+
+        R.workspace = fake
+        R.share_workbook("S", "u@psd401.net")
+        self.assertIn("--json", seen["c"])
+        self.assertNotIn("--body ", seen["c"])
+        self.assertIn('"transferOwnership": true', seen["c"])
+        self.assertNotIn('"transferOwnership": "true"', seen["c"])
+
+
+class NormsNamesAreMapped(unittest.TestCase):
+    """The warehouse and the norms file disagree, and aggregate.py joins on it.
+
+    Unmapped, it aborts the whole run for every grade with an ORF measure —
+    grades 1-5, i.e. the report.
+    """
+
+    def test_orf_warehouse_names_map_to_norms_names(self):
+        args = R.measure_as_args(["ORF Accuracy", "ORF WC", "ORF Errors"])
+        self.assertIn("ORF Accuracy=ORF-ACC", args)
+        self.assertIn("ORF WC=ORF-WRC", args)
+
+    def test_an_already_matching_name_is_not_mapped(self):
+        self.assertEqual(R.measure_as_args(["LNF", "PSF"]), [])
+
+    def test_an_unknown_measure_passes_through_unmapped(self):
+        # Loud in aggregate.py beats silently dropped here.
+        self.assertEqual(R.measure_as_args(["BRAND NEW"]), [])
+
+    def test_aggregate_receives_the_mapping(self):
+        seen = {}
+        original = R.run_json
+        R.run_json = lambda argv, what, **k: seen.setdefault("argv", argv) or []
+        try:
+            R.aggregate_rows(pathlib.Path("/tmp/x.json"), "1", "Fall",
+                             measures=["ORF WC"])
+        finally:
+            R.run_json = original
+        joined = " ".join(seen["argv"])
+        self.assertIn("--measure-as", joined)
+        self.assertIn("ORF WC=ORF-WRC", joined)
+
 
 # Keep this guard LAST in the file. It used to sit mid-file (line 214), which
 # meant `python test_run_report.py` ran unittest.main() and sys.exit()ed before

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -873,6 +873,40 @@ class McpResponseIsAMarkdownTable(RestoresModuleFunctions):
                     "isError": False}
         self.assertEqual(R.parse_mcp_rows(envelope, "test"), [])
 
+    def test_json_inside_the_text_block_is_read(self):
+        # The one recorded fixture in this repo (psd-data/evals/fixtures/
+        # list-tables.json) puts JSON in `text`, not a markdown table. #1679
+        # reported markdown for query_data. With no recorded query_data
+        # response either way, both are read — betting on markdown alone would
+        # have returned [] on a JSON payload, which is the same bug again.
+        envelope = {"content": [{"type": "text", "text":
+                                 '{"rows":[{"schoolid":"3299",'
+                                 '"school_name":"Artondale Elementary"}]}'}],
+                    "isError": False}
+        rows = R.parse_mcp_rows(envelope, "test")
+        self.assertEqual(rows[0]["school_name"], "Artondale Elementary")
+
+    def test_a_bare_json_array_is_read(self):
+        envelope = {"content": [{"type": "text",
+                                 "text": '[{"a":"1"},{"a":"2"}]'}],
+                    "isError": False}
+        self.assertEqual(len(R.parse_mcp_rows(envelope, "test")), 2)
+
+    def test_columns_plus_row_arrays_are_paired(self):
+        self.assertEqual(
+            R.rows_from_json({"columns": ["a", "b"], "rows": [["1", "2"]]}),
+            [{"a": "1", "b": "2"}],
+        )
+
+    def test_json_wins_over_a_markdown_reading(self):
+        # Unambiguous beats heuristic.
+        self.assertEqual(R.parse_result_text('{"rows":[{"a":"1"}]}'),
+                         [{"a": "1"}])
+
+    def test_malformed_json_falls_back_to_markdown(self):
+        text = '{"broken"\n| a |\n| --- |\n| 1 |\n'
+        self.assertEqual(R.parse_result_text(text), [{"a": "1"}])
+
     def test_a_structured_rows_key_is_used_when_present(self):
         # So a future psd-data JSON mode needs no change here.
         envelope = {"rows": [{"a": 1}], "isError": False}

--- a/infra/agent-image/test_reply_replay.py
+++ b/infra/agent-image/test_reply_replay.py
@@ -1407,15 +1407,36 @@ class PromotedJobDoesNotAbortTheRunItContinues(unittest.TestCase):
     def test_a_promoted_job_turn_still_sends_the_message(self):
         self.assertIn("chat.send", self._run(self.LONG))
 
-    def test_an_interactive_turn_keeps_the_abort(self):
-        # The abort still clears a wedged reply session on the path it was
-        # written for (2026-07-01, "I encountered an error" on every follow-up).
-        self.assertIn("chat.abort", self._run(None))
+    def test_an_interactive_turn_no_longer_aborts_preemptively(self):
+        # Changed deliberately. The preemptive abort destroyed whatever was
+        # running for this session on EVERY turn — so a user replying while a
+        # background job worked killed the job's run, and the agent then told
+        # him he had interrupted it. He had not. The wedge it guarded against
+        # announces itself on chat.send, so it is handled there now.
+        self.assertNotIn("chat.abort", self._run(None))
 
-    def test_a_short_explicit_deadline_is_not_a_promoted_job(self):
-        # Cron sends its own bounded deadline; only the long-job override
-        # clears the threshold.
-        self.assertIn("chat.abort", self._run(120))
+    def test_a_short_explicit_deadline_also_does_not_abort(self):
+        # Cron sends its own bounded deadline; it is no more entitled to
+        # destroy a live run than an interactive turn is.
+        self.assertNotIn("chat.abort", self._run(120))
+
+    def test_the_env_flag_restores_the_preemptive_abort(self):
+        # An escape hatch back to the old behaviour without an image build.
+        with mock.patch.dict(os.environ, {"OPENCLAW_PRESEND_ABORT": "1"}):
+            self.assertIn("chat.abort", self._run(None))
+
+    def test_a_reply_session_conflict_is_recognised(self):
+        self.assertTrue(harness_adapter._is_reply_session_conflict(
+            {"message": "reply session initialization conflicted"}))
+        self.assertTrue(harness_adapter._is_reply_session_conflict(
+            {"code": "SESSION_INITIALIZATION_FAILED"}))
+
+    def test_an_unrelated_error_is_not_a_conflict(self):
+        # Aborting and re-sending on any error would re-run the user's message
+        # against a model that already refused it.
+        self.assertFalse(harness_adapter._is_reply_session_conflict(
+            {"message": "rate limited"}))
+        self.assertFalse(harness_adapter._is_reply_session_conflict({}))
 
     def test_the_threshold_matches_the_wrapper(self):
         # Two modules keying off one number. If the wrapper's threshold moves,
@@ -1426,3 +1447,66 @@ class PromotedJobDoesNotAbortTheRunItContinues(unittest.TestCase):
             f"{harness_adapter.LONG_JOB_DEADLINE_THRESHOLD_S}",
             wrapper,
         )
+
+class AWedgedSessionRecoversWithoutKillingLiveWork(unittest.TestCase):
+    """The 2026-07-01 wedge, handled where it actually surfaces.
+
+    A prior turn's server-side reply session survives its ws.close() and
+    rejects the next chat.send. The old fix pre-destroyed session state on
+    EVERY turn on the chance of it; this reacts to the error itself, so a
+    healthy turn never touches a live run.
+    """
+
+    class ConflictingGateway(FakeGateway):
+        """Rejects the first chat.send with a reply-session conflict."""
+
+        def __init__(self, agent_events):
+            super().__init__(agent_events)
+            self.sends = 0
+
+        def send(self, raw):
+            message = json.loads(raw)
+            if message.get("method") == "chat.send":
+                self.sends += 1
+                if self.sends == 1:
+                    self.sent.append(message)
+                    self._outbox.append(json.dumps({
+                        "type": "res", "id": message.get("id"), "ok": False,
+                        "error": {"message":
+                                  "reply session initialization conflicted"},
+                    }))
+                    return
+            super().send(raw)
+
+    def _run(self, gateway):
+        fake_websocket = mock.Mock()
+        fake_websocket.create_connection.return_value = gateway
+        fake_websocket.WebSocketTimeoutException = _FakeTimeout
+        adapter = OpenClawAdapter()
+        adapter._ready = True
+        zero = {"model_calls": 0, "input": 0, "output": 0,
+                "cache_read": 0, "cache_write": 0}
+        with mock.patch.dict(sys.modules, {"websocket": fake_websocket}), \
+             mock.patch.object(OpenClawAdapter, "_read_turn_usage", return_value=zero), \
+             mock.patch.object(harness_adapter, "record_failure"):
+            return adapter._process_once("go", "s-wedge")
+
+    def test_the_turn_recovers_and_answers(self):
+        gateway = self.ConflictingGateway([says("Here is the answer.")])
+        result = self._run(gateway)
+        self.assertIn("Here is the answer", result.text)
+
+    def test_it_aborts_only_after_the_conflict(self):
+        gateway = self.ConflictingGateway([says("ok")])
+        self._run(gateway)
+        methods = [m.get("method") for m in gateway.sent]
+        self.assertEqual(methods.count("chat.abort"), 1)
+        # The abort follows the failed send; it does not precede it.
+        self.assertLess(methods.index("chat.send"), methods.index("chat.abort"))
+
+    def test_it_retries_only_once(self):
+        gateway = self.ConflictingGateway([says("ok")])
+        self._run(gateway)
+        self.assertLessEqual(
+            [m.get("method") for m in gateway.sent].count("chat.abort"), 1)
+

--- a/lib/agent-github/command-executor.ts
+++ b/lib/agent-github/command-executor.ts
@@ -72,10 +72,29 @@ const MAX_ARGUMENT_LENGTH = 100_000
 const MAX_TOTAL_ARGUMENT_LENGTH = 300_000
 const MAX_OUTPUT_BYTES = 1024 * 1024
 
+// Tab, line feed and carriage return are CONTENT, not control characters, in
+// the one place this guard is applied: `gh` argument values. An issue body, a
+// PR description and a comment are all multi-line by nature.
+//
+// Rejecting them made every agent-authored issue a single unreadable
+// paragraph. On 2026-08-17 the agent bisected this from the outside — a body
+// with zero newlines filed instantly, one newline anywhere failed — and had to
+// flatten a 9KB writeup (issue #1679) into one run-on block to get it filed at
+// all. It burned several rounds of the user's time working out that the
+// restriction was ours.
+//
+// Allowing them is safe here and nowhere near a shell: arguments go to
+// execFile as an argv array, so a newline inside a value cannot split it into
+// another argument. Everything else still goes — NUL, ESC (ANSI/terminal
+// escapes), and the rest of C0 plus DEL.
+const ALLOWED_WHITESPACE_CONTROLS = new Set([9, 10, 13])
+
 function hasControlCharacter(value: string): boolean {
   for (const character of value) {
     const codePoint = character.codePointAt(0)
-    if (codePoint !== undefined && (codePoint <= 31 || codePoint === 127)) {
+    if (codePoint === undefined) continue
+    if (ALLOWED_WHITESPACE_CONTROLS.has(codePoint)) continue
+    if (codePoint <= 31 || codePoint === 127) {
       return true
     }
   }

--- a/tests/unit/lib/agent-github/command-executor.test.ts
+++ b/tests/unit/lib/agent-github/command-executor.test.ts
@@ -18,3 +18,48 @@ describe("trusted GitHub command policy", () => {
     expect(() => validateGitHubCommand(argv)).toThrow(/not allowed|Raw GitHub/)
   })
 })
+
+describe("multi-line argument values", () => {
+  // The agent could not file a readable GitHub issue. `hasControlCharacter`
+  // rejected every codepoint <= 31, which includes \n and \t — so an issue
+  // body, a PR description and a comment, all multi-line by nature, were
+  // refused. On 2026-08-17 the agent bisected this from the outside (zero
+  // newlines filed instantly, one newline anywhere failed) and had to flatten
+  // a 9KB writeup into one run-on paragraph to get issue #1679 filed at all.
+  //
+  // Safe because arguments reach `gh` through execFile as an argv array: a
+  // newline inside a value cannot split it into another argument.
+  it("accepts a body containing newlines", () => {
+    const body = "## Summary\n\nLine one.\n- bullet\n"
+    expect(() =>
+      validateGitHubCommand(["issue", "create", "--repo", "psd401/aistudio", "--body", body])
+    ).not.toThrow()
+  })
+
+  it("accepts tabs and carriage returns", () => {
+    expect(() =>
+      validateGitHubCommand([
+        "issue", "create", "--repo", "psd401/aistudio",
+        "--body", "col1\tcol2\r\nrow\n",
+      ])
+    ).not.toThrow()
+  })
+
+  it("accepts a fenced code block", () => {
+    const body = "Repro:\n\n```bash\nrun_report.py --school X\n```\n"
+    expect(() =>
+      validateGitHubCommand(["issue", "create", "--repo", "psd401/aistudio", "--body", body])
+    ).not.toThrow()
+  })
+
+  it.each([
+    ["NUL", "a\u0000b"],
+    ["ESC", "a\u001bb"],
+    ["BEL", "a\u0007b"],
+    ["DEL", "a\u007fb"],
+  ])("still rejects %s", (_name, body) => {
+    expect(() =>
+      validateGitHubCommand(["issue", "create", "--repo", "psd401/aistudio", "--body", body])
+    ).toThrow(/Invalid GitHub command argument/)
+  })
+})

--- a/tests/unit/lib/agent-github/command-executor.test.ts
+++ b/tests/unit/lib/agent-github/command-executor.test.ts
@@ -54,9 +54,9 @@ describe("multi-line argument values", () => {
 
   it.each([
     ["NUL", "a\u0000b"],
-    ["ESC", "a\u001bb"],
+    ["ESC", "a\u001Bb"],
     ["BEL", "a\u0007b"],
-    ["DEL", "a\u007fb"],
+    ["DEL", "a\u007Fb"],
   ])("still rejects %s", (_name, body) => {
     expect(() =>
       validateGitHubCommand(["issue", "create", "--repo", "psd401/aistudio", "--body", body])


### PR DESCRIPTION
Closes #1679.

I wrote `run_report.py`'s SQL and API calls from `references/sql.md` and psd-workspace's `SKILL.md` without ever executing one of them, and flagged that. The live schema and CLI disagree with the docs in seven places, and the script failed on **every** invocation.

| # | Bug | Real shape |
|---|---|---|
| 1 | `schools` columns | `(id, abbreviation, name, level)` — no `schoolid`/`school_name` |
| 2 | teachers join | PK is `id`; name is `first_name`/`last_name` |
| 3 | MCP response | envelope with a markdown table, not a rows array |
| 4 | subgroup joins | `students_frl`/`students_specialed` have **no `yearid`** |
| 5 | sheets create | resource goes in `--json`, not `--params` |
| 6 | drive share | no `--body` flag; `transferOwnership` is a boolean |
| 7 | norms names | warehouse `ORF WC` vs norms `ORF-WRC` |

## Bugs 3 and 4 are the ones that matter

`run.js` writes `JSON.stringify(response.result)`. Reading `payload["rows"]` returned `[]` for every query — and an empty result read as *"no data"*. So **a failed query and an empty one were indistinguishable**, which is what let the others hide: 1,706 matched grade-1 pairs existed while the script reported "no Fall matched pairs".

Bug 4 then errored every extraction, and bug 3 turned that error into silence. The output was a workbook with a tab per grade and no data in any of them — exactly the *"looks complete, isn't"* failure this script was written to prevent, produced by the script itself.

An `isError` envelope now **raises**. A query that failed must never read as a query that found nothing.

## The tests are the real lesson

**All 80 existing tests passed while the script failed on every invocation.** They asserted shapes I invented, not shapes the warehouse uses — the same mistake as the authored `questionId` fixture that let #1660 ship as a complete no-op.

19 new tests pin the schema recorded in #1679, and all seven bugs are mutation-proven. That check caught my first attempt too: testing `parse_mcp_rows` directly proved nothing about `query()`, so restoring bug 3 failed **nothing** until the test went through `query()` itself.

99 tests. 830 image tests, bootstrap budget clean.

## Still unverified

The SBA and i-Ready blocks — #1679's run never reached them, so that SQL has still never executed. Same caveat, narrower.