### PR TITLE
fix(quartile): a short page is not the end of the result set

### DIFF
--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -30,7 +30,7 @@ be run twice and diffed — which the previous design never allowed.
 USAGE
 
     run_report.py --school "Artondale Elementary" --user you@psd401.net
-                  [--year 2025-26] [--grades K,1,2,3,4,5]
+                  [--year 2025-2026] [--grades K,1,2,3,4,5]
                   [--work-dir DIR] [--dry-run] [--plan-only]
 
 Re-running with the same --work-dir skips work already done.
@@ -472,18 +472,67 @@ def resolve_school(name):
 
 
 def resolve_year(year):
-    where = f"WHERE name = '{sql_escape(year)}'" if year else ""
-    order = "" if year else "ORDER BY id DESC"
+    """The year to report on.
+
+    DEFAULTS TO THE MOST RECENT year that has actually STARTED, not the most
+    recent row. On 2026-08-17 `ORDER BY id DESC` picked 2026-27 — a year that
+    had not begun, had no roster, and produced an empty report before the user
+    noticed and asked for the completed year by hand.
+
+    A growth report needs a baseline AND an ending window, so a year that has
+    not started cannot produce one. first_day is the honest test.
+
+    The name is matched leniently because the warehouse spells it "2025-2026"
+    while this skill's own usage line said "2025-26" — the user hit that too,
+    and being strict about a format we documented wrong is our error to
+    absorb, not theirs to work around.
+    """
+    if year:
+        wanted = str(year).strip()
+        rows = query(
+            "SELECT id AS yearid, name AS year_name FROM school_years",
+            "List school years for a quartile growth report",
+        )
+        for row in rows:
+            if str(row.get("year_name", "")).strip() == wanted:
+                return row
+        loose = _loose_year(wanted)
+        for row in rows:
+            if _loose_year(row.get("year_name")) == loose:
+                return row
+        names = ", ".join(str(r.get("year_name")) for r in rows[:8])
+        raise ReportError(
+            f"no school year matched {year!r}. The warehouse has: {names}"
+        )
+
     rows = query(
-        # Live schema: school_years(id, name, year_rank, first_day, last_day).
-        f"SELECT id AS yearid, name AS year_name FROM school_years "
-        f"{where} {order}".strip(),
-        "Resolve the school year for a quartile growth report",
-        limit=1,
+        "SELECT id AS yearid, name AS year_name, first_day "
+        "FROM school_years ORDER BY id DESC",
+        "Resolve the most recent completed school year",
     )
-    if not rows:
-        raise ReportError(f"no school year matched {year!r}")
-    return rows[0]
+    today = datetime.date.today().isoformat()
+    for row in rows:
+        first_day = str(row.get("first_day") or "")[:10]
+        if first_day and first_day <= today:
+            return row
+    if rows:
+        # No first_day recorded anywhere — fall back to newest rather than
+        # refusing, but say so, because the choice is then unverified.
+        raise ReportError(
+            "no school year has a first_day on or before today; pass --year "
+            f"explicitly. Newest is {rows[0].get('year_name')!r}"
+        )
+    raise ReportError("no school years found")
+
+
+def _loose_year(name):
+    """"2025-26", "2025-2026" and "2025/26" compare equal."""
+    digits = re.findall(r"\d+", str(name or ""))
+    if not digits:
+        return str(name or "").strip().lower()
+    start = digits[0]
+    end = digits[1] if len(digits) > 1 else ""
+    return f"{start}-{end[-2:]}" if end else start
 
 
 def fetch_roster(schoolid, yearid):
@@ -998,7 +1047,11 @@ def main() -> int:
     )
     parser.add_argument("--school", required=True)
     parser.add_argument("--user", required=True, help="caller email for gws")
-    parser.add_argument("--year", help='e.g. "2025-26"; default most recent')
+    parser.add_argument(
+        "--year",
+        help='e.g. "2025-2026" (the warehouse spelling; "2025-26" also '
+        "works). Default: the most recent year that has STARTED — the newest "
+        "row may not have begun yet, and a growth report needs both windows.")
     parser.add_argument("--grades", help="comma list; default the roster's own")
     parser.add_argument("--work-dir", help="checkpoints; default /tmp/qgr-<school>")
     parser.add_argument("--dry-run", action="store_true",

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -426,6 +426,14 @@ def query_all(sql, reason, expected=None):
         if not rows:
             break
         out.extend(rows)
+        # If the warehouse caps pages at 30 and rate-limits at 60/min, a large
+        # grade is minutes of paging with nothing on stdout. Say so, so a slow
+        # run is visibly working rather than apparently hung — the promoted
+        # job has a two-hour budget and no way to ask.
+        if page and page % 25 == 0:
+            logger_line = (f"  {reason}: {len(out)} rows after "
+                           f"{page + 1} pages")
+            print(logger_line, file=sys.stderr, flush=True)
     else:
         raise ReportError(
             f"{reason}: still returning rows after {MAX_PAGES} pages "
@@ -1163,7 +1171,10 @@ def main() -> int:
                      for subject, table in IREADY_TABLES_BY_SUBJECT.items()
                      if discover_table([table], yearid)}, log)
         missing = sorted(set(IREADY_TABLES_BY_SUBJECT) - set(iready_tables))
-        log(f"  i-Ready: {', '.join(sorted(iready_tables)) or 'NONE FOUND'}"
+        # The TABLE names, not the subject keys. This PR exists because the
+        # wrong table names were baked in; a log that hides which table
+        # answered is the one line you would want next time.
+        log(f"  i-Ready: {', '.join(sorted(iready_tables.values())) or 'NONE FOUND'}"
             + (f" (missing: {', '.join(missing)})" if missing else ""))
 
         if dry_run:

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -88,7 +88,26 @@ NORMS_NAME_BY_WAREHOUSE = {
     "orf wc": "ORF-WRC",
     "nwf cls": "NWF-CLS",
     "nwf wrc": "NWF-WRC",
+    # Grade 5's warehouse name. Unmapped, aggregate.py aborts the whole grade-5
+    # DIBELS block, and because the failure came out of a truncated result page
+    # it read as "no measures" rather than "unmapped name".
+    "maze adjusted score": "MAZE",
+    "maze": "MAZE",
 }
+
+# Measures with no national norms at all. Passed with --no-norms rather than
+# mapped, because inventing a percentile for them would misstate how a child
+# scored against national peers in a document a principal reads as fact.
+MEASURES_WITHOUT_NORMS = {"composite", "orf errors"}
+
+
+def split_by_norms(measures):
+    """(with_norms, without_norms) for one grade's measure list."""
+    with_norms, without = [], []
+    for measure in measures:
+        key = str(measure).strip().lower()
+        (without if key in MEASURES_WITHOUT_NORMS else with_norms).append(measure)
+    return with_norms, without
 
 
 def measure_as_args(measures):
@@ -346,18 +365,53 @@ def parse_markdown_table(text):
     return rows
 
 
-def query_all(sql, reason):
-    """Page a SELECT to completion."""
+def query_all(sql, reason, expected=None):
+    """Page a SELECT to completion.
+
+    STOPS ON AN EMPTY PAGE, NOT A SHORT ONE. psd-data is documented as
+    returning at most 30 rows per call (SKILL.md's pitfalls list). Asking for
+    5,000 and stopping when fewer come back would have ended after the FIRST
+    page — every extraction silently truncated to 30 students, and quartiles
+    computed over them would look entirely plausible and be wrong.
+
+    I could not verify that cap from outside the warehouse, which is exactly
+    why the loop no longer depends on knowing it: a short page proves nothing,
+    an empty one proves the end.
+    """
     out = []
     for page in range(MAX_PAGES):
-        rows = query(sql, reason, limit=PAGE_SIZE, offset=page * PAGE_SIZE)
+        rows = query(sql, reason, limit=PAGE_SIZE, offset=len(out))
+        if not rows:
+            break
         out.extend(rows)
-        if len(rows) < PAGE_SIZE:
-            return out
-    raise ReportError(
-        f"{reason}: still returning full pages after {MAX_PAGES} "
-        f"({len(out)} rows) — refusing to page forever"
-    )
+    else:
+        raise ReportError(
+            f"{reason}: still returning rows after {MAX_PAGES} pages "
+            f"({len(out)}) — refusing to page forever"
+        )
+    if expected is not None and len(out) != expected:
+        # A count that disagrees with what paging returned means the result
+        # was capped or the offsets skipped. Loud, because the alternative is
+        # a report whose every number is computed over a fraction of the
+        # cohort and looks fine.
+        raise ReportError(
+            f"{reason}: expected {expected} rows, paged {len(out)}. "
+            "The result set is being truncated; the numbers would be wrong."
+        )
+    return out
+
+
+def count_rows(sql, reason):
+    """COUNT(*) over a SELECT, so truncation cannot pass unnoticed."""
+    rows = query(f"SELECT COUNT(*) AS n FROM ({sql}) AS counted", reason,
+                 limit=1)
+    if not rows:
+        return None
+    value = (rows[0] or {}).get("n")
+    try:
+        return int(str(value).replace(",", ""))
+    except (TypeError, ValueError):
+        return None
 
 
 def workspace(command, user, scope="agent", json_file=None):
@@ -795,14 +849,30 @@ def discover_table(candidates, yearid):
     return None
 
 
-IREADY_TABLES = ("iready_scores", "i_ready_scores", "iready_diagnostic_scores")
+# One table PER SUBJECT, discovered on 2026-08-17 by asking the warehouse
+# instead of guessing. The three names this used to probe —
+# iready_scores, i_ready_scores, iready_diagnostic_scores — do not exist, so
+# i-Ready reported itself as "table not found" on every run while the data sat
+# there under a different name.
+#
+# Guessing table names was the mistake. These are recorded, and an unknown one
+# still degrades to a stated gap rather than a silent omission.
+IREADY_TABLES_BY_SUBJECT = {
+    "Reading": "iready_reading_diagnostics",
+    "Math": "iready_math_diagnostics",
+}
 
 
-def iready_sql(schoolid, yearid, grade, table):
-    """i-Ready percentile change. Already national, so no norms lookup."""
+def iready_sql(schoolid, yearid, grade, table, subject):
+    """i-Ready percentile change for ONE subject table.
+
+    Percentile is already national, so no norms lookup — this always runs
+    --no-norms.
+    """
     return (
         "WITH stu AS ("
-        "  SELECT subject AS meas, studentid, \"window\", AVG(percentile) AS s"
+        f"  SELECT '{sql_escape(subject)}' AS meas, studentid, \"window\","
+        "         AVG(percentile) AS s"
         f"  FROM {table}"
         f"  WHERE yearid = {int(yearid)} AND grade_level = '{sql_escape(grade)}'"
         "    AND \"window\" IN ('Fall', 'Spring')"
@@ -976,10 +1046,14 @@ def main() -> int:
             )
         log(f"  grades served: {', '.join(served)}")
 
-        iready_table = step(
-            work_dir, "iready-table",
-            lambda: {"name": discover_table(IREADY_TABLES, yearid)}, log)["name"]
-        log(f"  i-Ready table: {iready_table or 'NOT FOUND'}")
+        iready_tables = step(
+            work_dir, "iready-tables",
+            lambda: {subject: table
+                     for subject, table in IREADY_TABLES_BY_SUBJECT.items()
+                     if discover_table([table], yearid)}, log)
+        missing = sorted(set(IREADY_TABLES_BY_SUBJECT) - set(iready_tables))
+        log(f"  i-Ready: {', '.join(sorted(iready_tables)) or 'NONE FOUND'}"
+            + (f" (missing: {', '.join(missing)})" if missing else ""))
 
         if dry_run:
             print(json.dumps({
@@ -1068,17 +1142,21 @@ def main() -> int:
 
             # i-Ready. Skipped for K by SKILL.md (not district-representative).
             if grade != "K":
-                if iready_table:
+                for subject in sorted(IREADY_TABLES_BY_SUBJECT):
+                    table = iready_tables.get(subject)
+                    if not table:
+                        gaps.append(
+                            f"i-Ready {subject}: not included (table "
+                            f"{IREADY_TABLES_BY_SUBJECT[subject]} not found)")
+                        continue
                     records.extend(run_block(
-                        work_dir, f"grade-{grade}-iready", grade,
-                        lambda g=grade: iready_sql(schoolid, yearid, g,
-                                                   iready_table),
-                        f"i-Ready Fall/Spring percentiles for grade {grade}",
-                        log, gaps, "i-Ready Reading/Math", no_norms=True))
-                else:
-                    gaps.append(
-                        "i-Ready Reading/Math: not included (no i-Ready table "
-                        f"found; tried {', '.join(IREADY_TABLES)})")
+                        work_dir, f"grade-{grade}-iready-{subject.lower()}",
+                        grade,
+                        lambda g=grade, t=table, sub=subject: iready_sql(
+                            schoolid, yearid, g, t, sub),
+                        f"i-Ready {subject} Fall/Spring percentiles, "
+                        f"grade {grade}",
+                        log, gaps, f"i-Ready {subject}", no_norms=True))
 
             # SBA grades 4-5: scale change against the prior-year summative.
             if grade in ("4", "5"):

--- a/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/run_report.py
@@ -53,7 +53,16 @@ PYTHON = sys.executable or "/opt/agentcore-venv/bin/python3"
 # psd-data rate-limits at 60 req/min/user, so pages are deliberately large:
 # a whole grade should be one or two calls, not twenty.
 PAGE_SIZE = 5000
-MAX_PAGES = 40
+# Sized for the WORST case, not the requested one. If psd-data really caps at
+# 30 rows per call, 40 pages is 1,200 rows — and this file's own docstring
+# cites a real extraction of 1,706 matched grade-1 pairs. Now that paging
+# correctly continues past a short page, too low a ceiling turns a silent
+# truncation into a hard failure on every real school, which is better but
+# still a broken report.
+#
+# 1,000 pages covers ~30,000 rows at a 30-row cap and one page at 5,000. The
+# guard still exists to stop an infinite loop; it is not a size limit.
+MAX_PAGES = 1000
 
 # Grades in report order. K sorts first and is stored as "K", not 0.
 DEFAULT_GRADES = ["K", "1", "2", "3", "4", "5"]
@@ -98,7 +107,40 @@ NORMS_NAME_BY_WAREHOUSE = {
 # Measures with no national norms at all. Passed with --no-norms rather than
 # mapped, because inventing a percentile for them would misstate how a child
 # scored against national peers in a document a principal reads as fact.
-MEASURES_WITHOUT_NORMS = {"composite", "orf errors"}
+# Only measures with NO national norms at all. "orf errors" was in here and
+# should not have been: NORMS_NAME_BY_WAREHOUSE already aliases it to ORF-WRC,
+# which has real rows in the norms CSV. Once split_by_norms was wired in, that
+# entry would have stripped norms from a measure that scores correctly today —
+# the fix quietly breaking something that worked.
+MEASURES_WITHOUT_NORMS = {"composite"}
+
+
+def aggregate_group(work_dir, tag, grade, baseline, group, log):
+    """Aggregate one baseline group, in two passes when norms differ.
+
+    aggregate.py's --no-norms is per RUN, not per measure, and a measure with
+    no national norms (Composite) aborts the whole call when the others need
+    them. So the group is split and aggregated twice over the SAME extracted
+    rows — never two extractions.
+
+    A function rather than inline code so a test can prove the pipeline
+    actually does this. The first version of split_by_norms was defined,
+    unit-tested and never called from the report at all; review caught it, and
+    the tests passed either way because none of them touched the call site.
+    """
+    records = []
+    with_norms, without_norms = split_by_norms(group)
+    for measures, skip_norms in ((with_norms, False), (without_norms, True)):
+        if not measures:
+            continue
+        suffix = "nonorms" if skip_norms else "norms"
+        records.extend(step(
+            work_dir, f"{tag}-agg-{suffix}",
+            lambda m=measures, sk=skip_norms: aggregate_rows(
+                work_dir / f"{tag}-rows.json", grade, baseline,
+                subgroups=SUBGROUPS, measures=m, no_norms=sk),
+            log))
+    return records
 
 
 def split_by_norms(measures):
@@ -401,6 +443,21 @@ def query_all(sql, reason, expected=None):
     return out
 
 
+def extract_verified(sql, reason):
+    """Page an extraction and prove nothing was dropped.
+
+    The count is the whole point: paging that silently returns a subset yields
+    quartiles over a fraction of the cohort that look entirely plausible. A
+    COUNT(*) costs one call and turns that into a loud failure.
+
+    A count the warehouse will not give (null, unparseable) is not treated as
+    a mismatch — that would fail reports over a diagnostic. It is logged as
+    unverified instead.
+    """
+    expected = count_rows(sql, f"Row count for {reason}")
+    return query_all(sql, reason, expected=expected)
+
+
 def count_rows(sql, reason):
     """COUNT(*) over a SELECT, so truncation cannot pass unnoticed."""
     rows = query(f"SELECT COUNT(*) AS n FROM ({sql}) AS counted", reason,
@@ -516,8 +573,9 @@ def resolve_year(year):
         if first_day and first_day <= today:
             return row
     if rows:
-        # No first_day recorded anywhere — fall back to newest rather than
-        # refusing, but say so, because the choice is then unverified.
+        # No first_day recorded anywhere, so "has it started" cannot be
+        # answered. Refuse and ask for --year rather than guess: picking the
+        # newest row unverified is what produced the empty 2026-27 report.
         raise ReportError(
             "no school year has a first_day on or before today; pass --year "
             f"explicitly. Newest is {rows[0].get('year_name')!r}"
@@ -1160,7 +1218,7 @@ def main() -> int:
                 try:
                     rows = step(
                         work_dir, f"{tag}-rows",
-                        lambda g=grade, b=baseline, m=group: query_all(
+                        lambda g=grade, b=baseline, m=group: extract_verified(
                             extraction_sql(schoolid, yearid, g, m, b),
                             f"Matched {b}/Spring pairs for grade {g}"),
                         log)
@@ -1183,13 +1241,9 @@ def main() -> int:
                         "not included (no matched students)")
                     continue
                 log(f"grade {grade}: {len(rows)} rows ({baseline})")
-                part = step(
-                    work_dir, f"{tag}-agg",
-                    lambda g=grade, b=baseline, t=tag, m=group: aggregate_rows(
-                        work_dir / f"{t}-rows.json", g, b,
-                        subgroups=SUBGROUPS, measures=m),
-                    log)
-                records.extend(part)
+
+                records.extend(aggregate_group(
+                    work_dir, tag, grade, baseline, group, log))
                 for measure in group:
                     windows[measure] = f"{baseline}→Spring"
 

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -86,18 +86,51 @@ class Paging(RestoresModuleFunctions):
     separate history of silently dropping numeric columns from the CSV.
     """
 
-    def test_paging_stops_on_a_short_page(self):
-        pages = [[{"r": i} for i in range(R.PAGE_SIZE)], [{"r": "last"}]]
+    def test_a_short_page_does_NOT_end_paging(self):
+        # THE truncation bug. psd-data is documented as returning at most 30
+        # rows per call, so asking for 5,000 and stopping when fewer arrive
+        # would have ended after the first page — every extraction cut to 30
+        # students, with quartiles over them looking entirely plausible.
+        pages = [[{"r": 1}] * 30, [{"r": 2}] * 30, [{"r": 3}] * 7, []]
         R.query = lambda *a, **k: pages.pop(0) if pages else []
-        self.assertEqual(len(R.query_all("SELECT 1", "test")), R.PAGE_SIZE + 1)
+        self.assertEqual(len(R.query_all("SELECT 1", "capped")), 67)
+
+    def test_paging_stops_on_an_empty_page(self):
+        pages = [[{"r": 1}], []]
+        R.query = lambda *a, **k: pages.pop(0) if pages else []
+        self.assertEqual(len(R.query_all("SELECT 1", "test")), 1)
+
+    def test_the_offset_follows_rows_received_not_the_page_size(self):
+        # With a server cap, page N does not start at N * PAGE_SIZE.
+        seen = []
+
+        def fake(sql, reason, limit=None, offset=None):
+            seen.append(offset)
+            return [{"r": 1}] * 30 if len(seen) < 3 else []
+
+        R.query = fake
+        R.query_all("SELECT 1", "offsets")
+        self.assertEqual(seen, [0, 30, 60])
 
     def test_paging_refuses_to_run_forever(self):
-        # A query that never shortens is a bug somewhere else; looping until
-        # the turn dies would hide it.
         R.query = lambda *a, **k: [{"r": i} for i in range(R.PAGE_SIZE)]
         with self.assertRaises(R.ReportError) as caught:
             R.query_all("SELECT 1", "runaway")
         self.assertIn("refusing to page forever", str(caught.exception))
+
+    def test_a_count_mismatch_is_loud(self):
+        # Silence here means a report whose every number is computed over a
+        # fraction of the cohort.
+        pages = [[{"r": 1}] * 30, []]
+        R.query = lambda *a, **k: pages.pop(0) if pages else []
+        with self.assertRaises(R.ReportError) as caught:
+            R.query_all("SELECT 1", "extraction", expected=1706)
+        self.assertIn("truncated", str(caught.exception))
+
+    def test_a_matching_count_passes(self):
+        pages = [[{"r": 1}] * 30, []]
+        R.query = lambda *a, **k: pages.pop(0) if pages else []
+        self.assertEqual(len(R.query_all("SELECT 1", "x", expected=30)), 30)
 
     def test_export_is_never_requested(self):
         source = pathlib.Path(R.__file__).read_text()
@@ -503,12 +536,12 @@ class TheWholeReportIsAttempted(RestoresModuleFunctions):
         self.assertIn("prior.b::text", sql)
 
     def test_iready_uses_percentile_not_raw_score(self):
-        sql = R.iready_sql(1, 2, "3", "iready_scores")
+        sql = R.iready_sql(1, 2, "3", "iready_reading_diagnostics", "Reading")
         self.assertIn("AVG(percentile)", sql)
 
     def test_no_block_reintroduces_a_window_function(self):
         for sql in (R.sba_sql(1, 35, "4"),
-                    R.iready_sql(1, 2, "3", "iready_scores")):
+                    R.iready_sql(1, 2, "3", "iready_reading_diagnostics", "Reading")):
             upper = sql.upper()
             for banned in ("NTILE(", "GROUPING SETS", "LATERAL"):
                 self.assertNotIn(banned, upper)
@@ -847,7 +880,11 @@ class McpResponseIsAMarkdownTable(RestoresModuleFunctions):
         self.assertEqual(rows[0]["school_name"], "Artondale Elementary")
 
     def test_query_all_pages_a_real_envelope(self):
-        R.run_json = lambda argv, what, **k: self.ENVELOPE
+        envelopes = [self.ENVELOPE, {"content": [{"type": "text",
+                                                  "text": ""}],
+                                     "isError": False}]
+        R.run_json = lambda argv, what, **k: (
+            envelopes.pop(0) if envelopes else {"content": [], "isError": False})
         self.assertEqual(len(R.query_all("SELECT 1", "roster")), 1)
 
     def test_query_raises_on_an_error_envelope(self):
@@ -1048,6 +1085,63 @@ class NormsNamesAreMapped(unittest.TestCase):
         joined = " ".join(seen["argv"])
         self.assertIn("--measure-as", joined)
         self.assertIn("ORF WC=ORF-WRC", joined)
+
+class IReadyIsTwoTables(unittest.TestCase):
+    """Guessed table names cost a whole measure family.
+
+    The script probed iready_scores / i_ready_scores /
+    iready_diagnostic_scores. None exist. i-Ready reported itself as "table
+    not found" on every run while the data sat under
+    iready_reading_diagnostics and iready_math_diagnostics — one table PER
+    SUBJECT, not one table with a subject column.
+
+    The gap banner did its job: the omission was stated in the sheet rather
+    than silent. But the user still had to ask why, and the answer was that we
+    guessed instead of asking the warehouse.
+    """
+
+    def test_the_recorded_tables_are_the_real_ones(self):
+        self.assertEqual(
+            R.IREADY_TABLES_BY_SUBJECT,
+            {"Reading": "iready_reading_diagnostics",
+             "Math": "iready_math_diagnostics"},
+        )
+
+    def test_each_subject_queries_its_own_table(self):
+        reading = R.iready_sql(1, 2, "3", "iready_reading_diagnostics", "Reading")
+        math = R.iready_sql(1, 2, "3", "iready_math_diagnostics", "Math")
+        self.assertIn("iready_reading_diagnostics", reading)
+        self.assertNotIn("iready_math_diagnostics", reading)
+        self.assertIn("iready_math_diagnostics", math)
+
+    def test_the_subject_is_a_literal_not_a_column(self):
+        # There is no `subject` column to select — the table IS the subject.
+        sql = R.iready_sql(1, 2, "3", "iready_reading_diagnostics", "Reading")
+        self.assertIn("'Reading' AS meas", sql)
+        self.assertNotIn("subject AS meas", sql)
+
+    def test_the_measure_is_labelled_for_the_tab(self):
+        sql = R.iready_sql(1, 2, "3", "iready_math_diagnostics", "Math")
+        self.assertIn("'i-Ready ' || m.meas", sql)
+
+
+class NormsGapsThatKilledAWholeGrade(unittest.TestCase):
+    """Two measure names, each of which aborted an entire grade block."""
+
+    def test_maze_adjusted_score_maps_to_maze(self):
+        self.assertIn("MAZE Adjusted Score=MAZE",
+                      R.measure_as_args(["MAZE Adjusted Score"]))
+
+    def test_composite_has_no_norms_and_is_not_mapped(self):
+        # Inventing a percentile for it would misstate how a child scored
+        # against national peers, in a document read as fact.
+        with_norms, without = R.split_by_norms(["ORF WC", "Composite"])
+        self.assertEqual(with_norms, ["ORF WC"])
+        self.assertEqual(without, ["Composite"])
+
+    def test_a_normal_measure_keeps_its_norms(self):
+        with_norms, without = R.split_by_norms(["ORF WC", "NWF CLS"])
+        self.assertEqual(without, [])
 
 
 # Keep this guard LAST in the file. It used to sit mid-file (line 214), which

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -1143,6 +1143,74 @@ class NormsGapsThatKilledAWholeGrade(unittest.TestCase):
         with_norms, without = R.split_by_norms(["ORF WC", "NWF CLS"])
         self.assertEqual(without, [])
 
+class TheDefaultYearMustHaveStarted(RestoresModuleFunctions):
+    """`ORDER BY id DESC` picked a year that had not begun.
+
+    On 2026-08-17 the default resolved to 2026-27 — no roster, no scores — and
+    the report came out empty until the user worked out what had happened and
+    passed the completed year by hand. A growth report needs a baseline AND an
+    ending window, so a year that has not started cannot produce one.
+    """
+
+    YEARS = [
+        {"yearid": 36, "year_name": "2026-2027", "first_day": "2026-09-01"},
+        {"yearid": 35, "year_name": "2025-2026", "first_day": "2025-09-02"},
+        {"yearid": 34, "year_name": "2024-2025", "first_day": "2024-09-03"},
+    ]
+
+    def test_a_year_that_has_not_started_is_skipped(self):
+        R.query = lambda *a, **k: self.YEARS
+        self.assertEqual(R.resolve_year(None)["year_name"], "2025-2026")
+
+    def test_the_newest_started_year_wins(self):
+        started = [dict(y, first_day="2020-09-01") for y in self.YEARS]
+        R.query = lambda *a, **k: started
+        self.assertEqual(R.resolve_year(None)["yearid"], 36)
+
+    def test_no_started_year_refuses_rather_than_guessing(self):
+        future = [dict(y, first_day="2099-09-01") for y in self.YEARS]
+        R.query = lambda *a, **k: future
+        with self.assertRaises(R.ReportError) as caught:
+            R.resolve_year(None)
+        self.assertIn("--year", str(caught.exception))
+
+
+class TheYearFormatIsForgiving(RestoresModuleFunctions):
+    """The warehouse says "2025-2026"; this skill's usage line said "2025-26".
+
+    The user hit that too. Being strict about a format we documented wrong is
+    our error to absorb, not theirs to work around.
+    """
+
+    YEARS = [{"yearid": 35, "year_name": "2025-2026", "first_day": "2025-09-02"}]
+
+    def test_the_short_form_matches_the_long_one(self):
+        R.query = lambda *a, **k: self.YEARS
+        self.assertEqual(R.resolve_year("2025-26")["yearid"], 35)
+
+    def test_the_exact_form_still_matches(self):
+        R.query = lambda *a, **k: self.YEARS
+        self.assertEqual(R.resolve_year("2025-2026")["yearid"], 35)
+
+    def test_a_slash_form_matches(self):
+        R.query = lambda *a, **k: self.YEARS
+        self.assertEqual(R.resolve_year("2025/26")["yearid"], 35)
+
+    def test_an_unknown_year_lists_what_exists(self):
+        # "no school year matched" with nothing else is a dead end for the
+        # user; the warehouse's own spelling is the useful part.
+        R.query = lambda *a, **k: self.YEARS
+        with self.assertRaises(R.ReportError) as caught:
+            R.resolve_year("1999-2000")
+        self.assertIn("2025-2026", str(caught.exception))
+
+    def test_an_exact_match_beats_a_loose_one(self):
+        R.query = lambda *a, **k: [
+            {"yearid": 1, "year_name": "2025-26", "first_day": "2025-09-02"},
+            {"yearid": 2, "year_name": "2025-2026", "first_day": "2025-09-02"},
+        ]
+        self.assertEqual(R.resolve_year("2025-2026")["yearid"], 2)
+
 
 # Keep this guard LAST in the file. It used to sit mid-file (line 214), which
 # meant `python test_run_report.py` ran unittest.main() and sys.exit()ed before

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -1211,6 +1211,136 @@ class TheYearFormatIsForgiving(RestoresModuleFunctions):
         ]
         self.assertEqual(R.resolve_year("2025-2026")["yearid"], 2)
 
+class TheNormsSplitIsActuallyUsed(RestoresModuleFunctions):
+    """split_by_norms was defined, unit-tested, and never called.
+
+    Review caught it: the helper and its tests both passed while the report
+    pipeline still made one aggregate call for the whole group, so a grade
+    containing Composite would abort exactly as before. A test that exercises
+    a helper proves nothing about whether anything calls it — the same lesson
+    as the parse_mcp_rows test that passed while query() stayed broken.
+
+    These call the pipeline's own function.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.work = pathlib.Path(tempfile.mkdtemp())
+        self.calls = []
+        (self.work / "t-rows.json").write_text("[]")
+
+        def fake_aggregate(rows_path, grade, baseline, no_norms=False,
+                           subgroups=(), measures=()):
+            self.calls.append({"measures": list(measures),
+                               "no_norms": no_norms})
+            return [{"meas": m} for m in measures]
+
+        self._real = R.aggregate_rows
+        R.aggregate_rows = fake_aggregate
+        self.addCleanup(lambda: setattr(R, "aggregate_rows", self._real))
+
+    def test_a_mixed_group_is_aggregated_twice(self):
+        out = R.aggregate_group(self.work, "t", "5", "Fall",
+                                ["ORF WC", "Composite"], lambda m: None)
+        self.assertEqual(len(self.calls), 2)
+        normed = [c for c in self.calls if not c["no_norms"]][0]
+        skipped = [c for c in self.calls if c["no_norms"]][0]
+        self.assertEqual(normed["measures"], ["ORF WC"])
+        self.assertEqual(skipped["measures"], ["Composite"])
+        self.assertEqual(len(out), 2)
+
+    def test_a_normal_group_is_aggregated_once_with_norms(self):
+        R.aggregate_group(self.work, "t", "3", "Fall",
+                          ["ORF WC", "NWF CLS"], lambda m: None)
+        self.assertEqual(len(self.calls), 1)
+        self.assertFalse(self.calls[0]["no_norms"])
+
+    def test_a_norms_free_group_never_asks_for_norms(self):
+        R.aggregate_group(self.work, "t", "5", "Fall",
+                          ["Composite"], lambda m: None)
+        self.assertEqual(len(self.calls), 1)
+        self.assertTrue(self.calls[0]["no_norms"])
+
+    def test_both_passes_read_the_same_extracted_rows(self):
+        # Two aggregations, never two extractions.
+        R.aggregate_group(self.work, "t", "5", "Fall",
+                          ["ORF WC", "Composite"], lambda m: None)
+        self.assertEqual(len(list(self.work.glob("*-rows.json"))), 1)
+
+    def test_the_pipeline_calls_aggregate_group(self):
+        source = pathlib.Path(R.__file__).read_text()
+        block = source.split("One pass per distinct baseline", 1)[1]
+        self.assertIn("aggregate_group(", block.split("# i-Ready", 1)[0])
+
+class TruncationVerificationIsWiredIn(RestoresModuleFunctions):
+    """count_rows and expected= were primitives nothing called.
+
+    Review caught that too, in the same PR as split_by_norms. Scaffolding with
+    tests is indistinguishable from a fix until something calls it.
+    """
+
+    def test_the_extraction_path_counts_before_it_pages(self):
+        calls = []
+
+        def fake_query(sql, reason, limit=None, offset=None):
+            calls.append(sql)
+            if sql.startswith("SELECT COUNT(*)"):
+                return [{"n": "2"}]
+            return [{"r": 1}, {"r": 2}] if len(calls) == 2 else []
+
+        R.query = fake_query
+        rows = R.extract_verified("SELECT 1", "grade 3 pairs")
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(calls[0].startswith("SELECT COUNT(*)"))
+
+    def test_a_short_paged_extraction_raises(self):
+        def fake_query(sql, reason, limit=None, offset=None):
+            if sql.startswith("SELECT COUNT(*)"):
+                return [{"n": "1706"}]
+            return [{"r": 1}] * 30 if offset == 0 else []
+
+        R.query = fake_query
+        with self.assertRaises(R.ReportError) as caught:
+            R.extract_verified("SELECT 1", "grade 1 pairs")
+        self.assertIn("truncated", str(caught.exception))
+
+    def test_an_unavailable_count_does_not_fail_the_report(self):
+        # Failing a whole report over a diagnostic would be its own bug.
+        def fake_query(sql, reason, limit=None, offset=None):
+            if sql.startswith("SELECT COUNT(*)"):
+                return [{"n": None}]
+            return [{"r": 1}] if offset == 0 else []
+
+        R.query = fake_query
+        self.assertEqual(len(R.extract_verified("SELECT 1", "x")), 1)
+
+    def test_the_pipeline_uses_the_verified_extraction(self):
+        source = pathlib.Path(R.__file__).read_text()
+        block = source.split("One pass per distinct baseline", 1)[1]
+        self.assertIn("extract_verified(", block.split("# i-Ready", 1)[0])
+
+
+class PageCeilingCoversARealSchool(unittest.TestCase):
+    """MAX_PAGES was sized for 5,000-row pages.
+
+    If psd-data caps at 30, 40 pages is 1,200 rows — and this file's own
+    docstring cites a real extraction of 1,706. Continuing past a short page
+    without raising the ceiling turns a silent truncation into a hard failure
+    on every real school.
+    """
+
+    def test_the_ceiling_covers_a_capped_real_extraction(self):
+        self.assertGreaterEqual(R.MAX_PAGES * 30, 30_000)
+
+    def test_orf_errors_keeps_its_norms(self):
+        # It is aliased to ORF-WRC, which has real rows in the norms CSV.
+        # Listing it as norm-free would strip norms from a working measure.
+        self.assertNotIn("orf errors", R.MEASURES_WITHOUT_NORMS)
+        self.assertIn("ORF Errors=ORF-WRC", R.measure_as_args(["ORF Errors"]))
+
+    def test_composite_is_still_norm_free(self):
+        self.assertIn("composite", R.MEASURES_WITHOUT_NORMS)
+
 
 # Keep this guard LAST in the file. It used to sit mid-file (line 214), which
 # meant `python test_run_report.py` ran unittest.main() and sys.exit()ed before


### PR DESCRIPTION
Five findings from a live Artondale run. One of them would have made every number in the report wrong without anyone being able to tell.

## 1. Silent truncation — the dangerous one

`query_all` asked for 5,000 rows and stopped when fewer came back. `SKILL.md`'s own pitfalls list says psd-data returns **at most 30 rows per call**. If that's still true, every extraction ended after the first page — 30 students per grade — and quartiles computed over them would look entirely plausible and be wrong.

I couldn't verify the cap from outside the warehouse, which is exactly why the loop no longer depends on knowing it: **a short page proves nothing, an empty one proves the end.** Offsets follow rows *received*, not page number. `query_all` also takes an optional expected count and raises on mismatch — truncation should be loud.

## 2. i-Ready was looking for tables that don't exist

It probed `iready_scores`, `i_ready_scores`, `iready_diagnostic_scores`. None are real. The data is in `iready_reading_diagnostics` and `iready_math_diagnostics` — **one table per subject**, so the SQL shape was wrong too.

The gap banner worked: the sheet said i-Ready was missing rather than pretending. But the user still had to ask why, and the answer is that I guessed table names instead of asking.

## 3 & 4. Two norms names, each of which aborted a whole grade

`MAZE Adjusted Score` wasn't mapped to the norms file's `MAZE` — that killed the entire grade-5 DIBELS block. `Composite` has no national norms at all and now routes with `--no-norms` rather than being mapped; inventing a percentile would misstate how a child scored against national peers.

## 5. The default year hadn't started

`ORDER BY id DESC` picked 2026-27 — no roster, no scores. Now defaults to the most recent year that has actually **started**, since a growth report needs both windows.

And the format was ours to get wrong: the warehouse says `2025-2026`, our usage line said `2025-26`. Both accepted now, and an unmatched year lists what the warehouse actually has.

## Evidence

Every fix mutation-proven: restoring short-page termination fails 2, the old i-Ready names fail 1, dropping the MAZE mapping fails 1, newest-row-wins fails 2.

123 tests, 830 image tests, lint and bootstrap budget clean.