### PR TITLE
fix(agent): unblock five owners hidden from email-index, and stop two skills from failing users

### DIFF
--- a/actions/agent-workspace.actions.ts
+++ b/actions/agent-workspace.actions.ts
@@ -490,8 +490,19 @@ async function exchangeAndStore(
   }
   const grantedScopes = validated.grantedScopes
 
+  // Case-INSENSITIVE, per the convention documented on getUserByEmail
+  // (lib/db/drizzle/users.ts) — email is an authorization join key and
+  // migration 112 enforces uniqueness on lower(email). A case-sensitive `=`
+  // here misses an existing row whenever the IdP stored a differently-cased
+  // address, which sends an already-provisioned user down the auto-provision
+  // branch below and re-runs its staff role assignment as a side effect.
   const [existing] = await executeQuery(
-    (db) => db.select({ id: users.id }).from(users).where(eq(users.email, payload.sub)).limit(1),
+    (db) =>
+      db
+        .select({ id: users.id })
+        .from(users)
+        .where(sql`lower(${users.email}) = lower(${payload.sub})`)
+        .limit(1),
     "findUserByEmail"
   )
 

--- a/actions/agent-workspace.actions.ts
+++ b/actions/agent-workspace.actions.ts
@@ -325,13 +325,22 @@ async function provisionAgentUser(
   if (!firstName) firstName = username || "User"
 
   // SELECT-then-INSERT inside a transaction to avoid a duplicate row if the
-  // user double-clicks the consent flow. Email is indexed but not unique, so
-  // we serialize within the transaction by re-checking under the lock window.
+  // user double-clicks the consent flow.
+  //
+  // The guard MUST match uq_users_email_lower (migration 112), which is unique
+  // on lower(email) — not on email. A case-sensitive compare here misses a row
+  // the index will nonetheless reject, so provisioning an existing user whose
+  // stored email differs only in case falls through to an INSERT that dies on
+  // the constraint. The whole callback then throws and the user sees the
+  // generic "Failed to complete OAuth callback"; retrying with a fresh consent
+  // link cannot help, because the collision is in the table, not the link. One
+  // owner burned five consent links against this on 2026-08-17 — her row was
+  // stored as GEORGEK@psd401.net while the callback looked up georgek@.
   const userId = await executeTransaction(async (tx) => {
     const [again] = await tx
       .select({ id: users.id })
       .from(users)
-      .where(eq(users.email, email))
+      .where(sql`lower(${users.email}) = lower(${email})`)
       .limit(1)
     if (again) return again.id
 

--- a/actions/agent-workspace.actions.ts
+++ b/actions/agent-workspace.actions.ts
@@ -344,9 +344,16 @@ async function provisionAgentUser(
       .limit(1)
     if (again) return again.id
 
+    // Store the normalized address. `email` traces back to the consent nonce's
+    // ownerEmail — the same "whatever casing the directory supplied" value the
+    // lookups above stopped trusting — and migration 112 made uniqueness
+    // case-insensitive, so the original casing carries no information and only
+    // creates rows that case-sensitive readers can miss. Safe for the later
+    // Cognito link: resolve-user.ts matches through getUserByEmail, which
+    // compares on lower(email).
     const [created] = await tx
       .insert(users)
-      .values({ email, firstName, lastName })
+      .values({ email: email.toLowerCase(), firstName, lastName })
       .returning({ id: users.id })
     return created.id
   }, "provisionAgentUser")

--- a/infra/agent-image/skills/psd-freshservice/SKILL.md
+++ b/infra/agent-image/skills/psd-freshservice/SKILL.md
@@ -94,6 +94,12 @@ node get_workspaces.js --user <email> [--id <workspace_id>]
 
 Workspace IDs in PSD: 2 Technology (primary), 3 Employee Support Services, 4 Business Services, 5 Teaching & Learning, 6 Maintenance, 8 Investigations, 9 Transportation, 10 Safety & Security, 11 Communications, 13 Software Development.
 
+These three commands need agent-administration rights that most callers do not
+have. A 403 from them is normal and says nothing about the caller's key — do
+not run them to check whether a key works. There is no endpoint that every
+valid key can reach, so a newly stored key needs no verification step at all:
+run the command the user actually asked for and let it report.
+
 ## Approvals
 
 ```bash
@@ -136,10 +142,29 @@ When presenting summary output, write a 1-minute narrative that:
 
 ## Errors
 
-- **`freshservice_key_missing`** (exit 2) — caller has not registered their API key. Prompt for it (see above).
+- **`freshservice_key_missing`** (exit 2) — caller has not registered their API key. Prompt for it (see above). **This is the only signal that a key is absent.**
 - **`upstream_error`** — Freshservice returned non-2xx. Surface status and message; ask the user before retrying mutating operations.
 - **`bad_args`** — required argument missing or malformed.
 - **`agent_lookup_failed`** — could not resolve the caller's Freshservice agent ID via `/agents?email=`. Confirm the caller's email matches their Freshservice login.
+
+### 403 is a permission scope, never a bad key
+
+Freshservice authorizes **per endpoint and per workspace**. A 403 means the
+caller's Freshservice role does not cover *that specific call*, and it happily
+coexists with other calls succeeding on the same key — one caller's
+`list_tickets` worked while `get_agent`, `get_workspaces` and `list_agents`
+all returned 403; another's `workspace_id=3` worked while `workspace_id=8`
+returned 403.
+
+On a 403 (`freshservice_endpoint_forbidden`):
+
+- **Never** tell the user their key is invalid, and never ask them to re-issue
+  or re-paste it. Their key is not implicated.
+- Probe what they *can* reach — `list_tickets.js --user <email> --options
+  '{"workspace_id":N}'` across the workspace IDs above — and report which
+  workspaces are available rather than declaring the integration broken.
+- If they need a workspace they cannot reach, the fix is a Freshservice role
+  change on their account, not a new key. Say that plainly.
 
 ## Security
 

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -206,10 +206,32 @@ function normalizeFreshserviceResult(result) {
   }
   if (!result || result.ok !== true) {
     const status = (result && result.status) || 0;
+    const detail = JSON.stringify((result && result.data) ?? {}).slice(0, 500);
+    // Freshservice authorizes per endpoint AND per workspace, so a 403 scopes
+    // this one call — it is not a verdict on the key. The two coexist freely:
+    // on 2026-08-17 one caller's list_tickets succeeded while get_agent,
+    // get_workspaces and list_agents all returned 403, and another's
+    // workspace_id=3 succeeded while workspace_id=8 returned 403. Reporting
+    // 403 as a bad key sent four users off to re-issue working credentials,
+    // so say what it actually means where every command can see it.
+    if (status === 403) {
+      return {
+        __ok: false,
+        status,
+        code: 'freshservice_endpoint_forbidden',
+        error:
+          `API error 403: ${detail} — this caller's Freshservice role does not `
+          + 'cover this endpoint or workspace. The stored key is not implicated: '
+          + 'do not tell the user it is invalid and do not ask them to re-issue '
+          + 'it. Retry against a workspace they can reach (list_tickets '
+          + '--options \'{"workspace_id":N}\') or report the specific gap. '
+          + 'A missing key surfaces as freshservice_key_missing instead.',
+      };
+    }
     return {
       __ok: false,
       status,
-      error: `API error ${status}: ${JSON.stringify((result && result.data) ?? {}).slice(0, 500)}`,
+      error: `API error ${status}: ${detail}`,
     };
   }
   return { __ok: true, status: result.status, data: result.data ?? {} };

--- a/infra/agent-image/skills/psd-freshservice/lib/api.test.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.test.js
@@ -1,0 +1,69 @@
+'use strict';
+// Tests for how fsFetch reports a Freshservice 403.
+//
+// Freshservice authorizes per endpoint AND per workspace, so a 403 scopes one
+// call and says nothing about the key. Reporting it as a bad key sent four
+// users off to re-issue working credentials on 2026-08-17. normalizeFreshserviceResult
+// is not exported, so exercise the branch through fsFetch — the surface all 13
+// command scripts actually call, and the one a refactor would regress.
+//
+// requestAgentBroker is replaced on the ../../_shared/agent-broker module BEFORE
+// api.js is required, so api.js captures the stub in its destructured
+// `const { requestAgentBroker } = require(...)`. `node --test` runs each test
+// file in its own process, so this cache surgery is isolated from siblings.
+//
+// Run: node --test   (from infra/agent-image/skills/psd-freshservice/)
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const brokerPath = require.resolve('../../_shared/agent-broker');
+require(brokerPath); // ensure the module is cached before we patch it
+
+let brokerResult = null;
+require.cache[brokerPath].exports.requestAgentBroker = async () => brokerResult;
+
+const { fsFetch } = require('./api');
+
+test('a 403 names the caller role, not the key, and stays off the generic path', async () => {
+  brokerResult = {
+    ok: false,
+    status: 403,
+    data: { code: 'access_denied', message: 'You are not authorized' },
+  };
+  const result = await fsFetch(null, '/tickets?workspace_id=8');
+
+  assert.strictEqual(result.__ok, false);
+  assert.strictEqual(result.status, 403);
+  assert.strictEqual(result.code, 'freshservice_endpoint_forbidden');
+  // The upstream body must survive so the agent can still report specifics.
+  assert.match(result.error, /access_denied/);
+  // The load-bearing part: the agent must not blame the stored credential.
+  assert.match(result.error, /do not tell the user it is invalid/);
+  assert.match(result.error, /re-issue/);
+  assert.match(result.error, /freshservice_key_missing/);
+});
+
+test('other upstream failures keep the generic shape and no 403 code', async () => {
+  for (const status of [400, 404, 500]) {
+    brokerResult = { ok: false, status, data: { message: 'nope' } };
+    const result = await fsFetch(null, '/tickets/1');
+
+    assert.strictEqual(result.__ok, false, `status ${status}`);
+    assert.strictEqual(result.status, status);
+    assert.strictEqual(result.code, undefined, `status ${status} must not be tagged forbidden`);
+    assert.ok(
+      result.error.startsWith(`API error ${status}:`),
+      `status ${status} error should open with its status: ${result.error}`,
+    );
+  }
+});
+
+test('a successful call is unaffected', async () => {
+  brokerResult = { ok: true, status: 200, data: { tickets: [{ id: 7 }] } };
+  const result = await fsFetch(null, '/tickets');
+
+  assert.strictEqual(result.__ok, true);
+  assert.strictEqual(result.status, 200);
+  assert.deepStrictEqual(result.data, { tickets: [{ id: 7 }] });
+});

--- a/infra/agent-image/skills/psd-morning-brief/run.js
+++ b/infra/agent-image/skills/psd-morning-brief/run.js
@@ -1530,6 +1530,24 @@ async function gatherSnapshot(options = {}, deps = {}) {
   };
 }
 
+/**
+ * The inbox message ids this brief's synthesis must decide, in snapshot order.
+ *
+ * Shared by the synthesis request, the deterministic synthesis, and
+ * validateSynthesis so the list handed to the model cannot drift from the list
+ * it is then checked against.
+ */
+function inboxMessageIdsOf(snapshot) {
+  return snapshot.sections
+    .filter((section) => section.id === 'inbox')
+    .flatMap((section) => {
+      const data = asObject(section.data);
+      return Array.isArray(data.emails) ? data.emails : [];
+    })
+    .filter((email) => email && typeof email.id === 'string' && email.id)
+    .map((email) => email.id);
+}
+
 function makeSynthesisRequest(snapshot) {
   const sections = snapshot.sections.map((section) => ({
     id: section.id,
@@ -1545,11 +1563,20 @@ function makeSynthesisRequest(snapshot) {
           dataPath: `sections[id=${section.id}].data`,
         }),
   }));
+  // Enumerate the ids rather than leaving the model to transcribe them out of
+  // the snapshot file. validateSynthesis fails the whole brief if a single
+  // inbox item goes undecided, and asking for a decision per item while
+  // withholding the item list made that a transcription exercise over opaque
+  // 16-hex-char ids: on 2026-08-17 two owners lost their brief outright, one
+  // missing 10 decisions and one missing 5. Handing over the checklist is what
+  // makes the requirement satisfiable.
+  const requiredInboxIds = inboxMessageIdsOf(snapshot);
   return {
     task:
       'Read the data snapshot, gather every custom section from its listed sources, and write the synthesis JSON. Cross-connect related topics, curate rather than dump, make an explicit decision for every inbox item, and write a complete spoken podcast script.',
     dataFile: null,
     availableSections: sections,
+    requiredInboxDecisionIds: requiredInboxIds,
     outputShape: {
       headline: 'string',
       subheadline: 'string',
@@ -1588,6 +1615,7 @@ function makeSynthesisRequest(snapshot) {
       'Custom sections are first-class: gather their sources and include them in sections.',
       'Do not infer a person name from an email or Chat id; use only directory-resolved names in snapshot.people.',
       'Keep URLs exactly as supplied by sources.',
+      `inboxDecisions must contain exactly one entry for every id in requiredInboxDecisionIds (${requiredInboxIds.length} total), copied verbatim. Any id left out, misspelled, or given a decision outside act-now|review|defer|archive discards the entire brief. When an item does not warrant attention, still decide it — 'archive' is a decision.`,
       'Return JSON only.',
     ],
   };
@@ -1714,18 +1742,11 @@ function deterministicSynthesis(snapshot, config) {
     subheadline: leadStory.summary,
     leadStory,
     sections,
-    inboxDecisions: snapshot.sections
-      .filter((section) => section.id === 'inbox')
-      .flatMap((section) => {
-        const data = asObject(section.data);
-        return Array.isArray(data.emails) ? data.emails : [];
-      })
-      .filter((email) => email && typeof email.id === 'string' && email.id)
-      .map((email) => ({
-        messageId: email.id,
-        decision: 'review',
-        rationale: 'Review this message in the inbox.',
-      })),
+    inboxDecisions: inboxMessageIdsOf(snapshot).map((messageId) => ({
+      messageId,
+      decision: 'review',
+      rationale: 'Review this message in the inbox.',
+    })),
     podcastScript:
       `Good morning. This is your morning brief for ${snapshot.displayDate}. ` +
       `${spokenSections} That concludes today's brief.`,
@@ -1787,16 +1808,7 @@ function validateSynthesis(raw, snapshot, config) {
       'synthesis',
     );
   }
-  const inboxMessageIds = new Set(
-    snapshot.sections
-      .filter((section) => section.id === 'inbox')
-      .flatMap((section) => {
-        const data = asObject(section.data);
-        return Array.isArray(data.emails) ? data.emails : [];
-      })
-      .filter((email) => email && typeof email.id === 'string' && email.id)
-      .map((email) => email.id),
-  );
+  const inboxMessageIds = new Set(inboxMessageIdsOf(snapshot));
   const allowedInboxDecisions = new Set([
     'act-now',
     'review',

--- a/infra/agent-image/skills/psd-morning-brief/run.test.js
+++ b/infra/agent-image/skills/psd-morning-brief/run.test.js
@@ -722,4 +722,52 @@ describe('retention and failures', () => {
       /ownerEmail|userEmail|userId/,
     );
   });
+
+  // validateSynthesis discards the whole brief over one undecided inbox item,
+  // so the request has to hand the model the exact checklist rather than leave
+  // it to transcribe opaque ids out of the snapshot file.
+  test('synthesis request enumerates every inbox id it will be judged against', () => {
+    const snapshot = {
+      displayDate: 'Monday, August 17',
+      localDate: '2026-08-17',
+      sections: [
+        {
+          id: 'inbox',
+          title: 'Inbox',
+          status: 'ready',
+          data: {
+            emails: [
+              { id: '1a00a7a08af776d1', subject: 'One' },
+              { id: '1a00a47b970cf5e1', subject: 'Two' },
+              { id: '', subject: 'Unusable id is not required' },
+            ],
+          },
+        },
+      ],
+    };
+    const request = makeSynthesisRequest(snapshot);
+
+    expect(request.requiredInboxDecisionIds).toEqual([
+      '1a00a7a08af776d1',
+      '1a00a47b970cf5e1',
+    ]);
+    // The checklist must match what validateSynthesis actually enforces:
+    // deciding exactly these ids has to produce a valid synthesis.
+    const accepted = validateSynthesis(
+      {
+        ...deterministicSynthesis(snapshot, normalizeConfig()),
+        inboxDecisions: request.requiredInboxDecisionIds.map((messageId) => ({
+          messageId,
+          decision: 'archive',
+          rationale: 'Handled.',
+        })),
+      },
+      snapshot,
+      normalizeConfig(),
+    );
+    expect(accepted.inboxDecisions.map((d) => d.messageId)).toEqual(
+      request.requiredInboxDecisionIds,
+    );
+    expect(request.rules.join(' ')).toContain('2 total');
+  });
 });

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -2143,6 +2143,51 @@ describe("background promotion bounded idempotent retry", () => {
   })
 })
 
+describe("userActivityUpdate", () => {
+  const { userActivityUpdate } = agentRouterTestHelpers
+  const now = "2026-08-17T20:00:00.000Z"
+
+  test("records activity and the DM space when one is known", () => {
+    const update = userActivityUpdate(
+      "owner@psd401.net",
+      "spaces/AAA1",
+      now,
+    )
+    expect(update.UpdateExpression).toBe(
+      "SET lastActiveAt = :now, email = :email, dmSpaceName = :dm",
+    )
+    expect(update.ExpressionAttributeValues).toEqual({
+      ":now": now,
+      ":email": "owner@psd401.net",
+      ":dm": "spaces/AAA1",
+    })
+  })
+
+  test("omits the DM space outside a 1:1 DM", () => {
+    const update = userActivityUpdate("owner@psd401.net", undefined, now)
+    expect(update.UpdateExpression).toBe("SET lastActiveAt = :now, email = :email")
+    expect(update.ExpressionAttributeValues).not.toHaveProperty(":dm")
+  })
+
+  // The email-index GSI is queried with a lowercased address and DynamoDB key
+  // equality is byte-exact, so a mixed-case record is invisible to the
+  // schedules service, triage poll, and cross-user invocation. Writing the
+  // normalized address on every touch heals those records.
+  test("normalizes the stored email so the email-index stays queryable", () => {
+    const update = userActivityUpdate("GEORGEK@psd401.net", undefined, now)
+    expect(update.ExpressionAttributeValues[":email"]).toBe(
+      "georgek@psd401.net",
+    )
+  })
+
+  test("writes email on every touch, not only at record creation", () => {
+    for (const dm of [undefined, "spaces/AAA1"]) {
+      expect(userActivityUpdate("Owner@PSD401.NET", dm, now).UpdateExpression)
+        .toContain("email = :email")
+    }
+  })
+})
+
 describe("dmSpaceForUserRecord", () => {
   const { dmSpaceForUserRecord } = agentRouterTestHelpers
 

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1452,11 +1452,12 @@ function dmSpaceForUserRecord(
 /**
  * The "owner touched the agent" mutation applied on every inbound message.
  *
- * `email` is rewritten on every touch, not only at creation. Every
- * email-index consumer — the schedules service, triage poll, and cross-user
- * invocation — queries that GSI with a lowercased address, and DynamoDB key
- * equality is byte-exact, so a record persisted with whatever casing Google
- * Chat happened to supply is invisible to all of them. That surfaced as
+ * `email` is rewritten on every touch, not only at creation. All four
+ * email-index consumers — the schedules service, triage poll, cross-user
+ * invocation, and the schedule target backfill — query that GSI with a
+ * lowercased address, and DynamoDB key equality is byte-exact, so a record
+ * persisted with whatever casing Google Chat happened to supply is invisible
+ * to all of them. That surfaced as
  * schedule creation failing with "Owner must first open a direct message with
  * the agent" for owners whose DM space was in fact already recorded.
  * Normalizing here keeps new records queryable and heals legacy mixed-case

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1449,6 +1449,42 @@ function dmSpaceForUserRecord(
   return spaceName;
 }
 
+/**
+ * The "owner touched the agent" mutation applied on every inbound message.
+ *
+ * `email` is rewritten on every touch, not only at creation. Every
+ * email-index consumer — the schedules service, triage poll, and cross-user
+ * invocation — queries that GSI with a lowercased address, and DynamoDB key
+ * equality is byte-exact, so a record persisted with whatever casing Google
+ * Chat happened to supply is invisible to all of them. That surfaced as
+ * schedule creation failing with "Owner must first open a direct message with
+ * the agent" for owners whose DM space was in fact already recorded.
+ * Normalizing here keeps new records queryable and heals legacy mixed-case
+ * records on the owner's next message.
+ */
+function userActivityUpdate(
+  senderEmail: string,
+  dmSpaceName: string | undefined,
+  now: string
+): {
+  UpdateExpression: string;
+  ExpressionAttributeValues: Record<string, string>;
+} {
+  const assignments = ['lastActiveAt = :now', 'email = :email'];
+  const values: Record<string, string> = {
+    ':now': now,
+    ':email': senderEmail.toLowerCase(),
+  };
+  if (dmSpaceName) {
+    assignments.push('dmSpaceName = :dm');
+    values[':dm'] = dmSpaceName;
+  }
+  return {
+    UpdateExpression: `SET ${assignments.join(', ')}`,
+    ExpressionAttributeValues: values,
+  };
+}
+
 async function getOrCreateUser(
   senderName: string,
   senderEmail: string,
@@ -1470,13 +1506,8 @@ async function getOrCreateUser(
       new UpdateCommand({
         TableName: USERS_TABLE,
         Key: { googleIdentity: senderName },
-        UpdateExpression: dmSpaceName
-          ? 'SET lastActiveAt = :now, dmSpaceName = :dm'
-          : 'SET lastActiveAt = :now',
+        ...userActivityUpdate(senderEmail, dmSpaceName, now),
         ConditionExpression: 'attribute_exists(googleIdentity)',
-        ExpressionAttributeValues: dmSpaceName
-          ? { ':now': now, ':dm': dmSpaceName }
-          : { ':now': now },
         ReturnValues: 'ALL_NEW',
       })
     );
@@ -1499,7 +1530,7 @@ async function getOrCreateUser(
   const workspacePrefix = `${localPart}-${uuidSuffix}`;
   const newUser: AgentUser = {
     googleIdentity: senderName,
-    email: senderEmail,
+    email: emailNormalized,
     displayName: senderDisplayName,
     department: 'unknown', // Updated by admin later or via directory sync
     workspacePrefix,
@@ -1541,13 +1572,8 @@ async function getOrCreateUser(
       new UpdateCommand({
         TableName: USERS_TABLE,
         Key: { googleIdentity: senderName },
-        UpdateExpression: dmSpaceName
-          ? 'SET lastActiveAt = :now, dmSpaceName = :dm'
-          : 'SET lastActiveAt = :now',
+        ...userActivityUpdate(senderEmail, dmSpaceName, now),
         ConditionExpression: 'attribute_exists(googleIdentity)',
-        ExpressionAttributeValues: dmSpaceName
-          ? { ':now': now, ':dm': dmSpaceName }
-          : { ':now': now },
         ReturnValues: 'ALL_NEW',
       })
     );
@@ -5464,6 +5490,7 @@ async function processRecord(
 
 export const agentRouterTestHelpers = {
   dmSpaceForUserRecord,
+  userActivityUpdate,
   normalizeChatEvent,
   cardClickMessageText,
   parseAgentCoreResult,

--- a/tests/unit/agent-workspace-callback-identity.test.ts
+++ b/tests/unit/agent-workspace-callback-identity.test.ts
@@ -82,15 +82,40 @@ describe("verifyGrantedIdentity (#1234)", () => {
 let executedLabels: string[] = []
 let userRows: Array<{ id: number }> = [{ id: 1 }]
 const nonceRow = { ownerEmail: "hagelk@psd401.net", agentEmail: "agnt_hagelk@psd401.net", tokenKind: "user_account" as const }
+// The user lookup's predicate is load-bearing (#1682): migration 112 makes
+// users.email unique on lower(email), so a case-sensitive compare misses a
+// differently-cased row that the index will still reject. Run that one
+// builder against a recorder so a test can assert the emitted predicate
+// instead of only its label — no other query's shape is exercised here.
+let capturedUserWhere: unknown = null
+const recordingDb = () => ({
+  select: () => ({
+    from: () => ({
+      where: (predicate: unknown) => {
+        capturedUserWhere = predicate
+        return { limit: () => userRows }
+      },
+    }),
+  }),
+})
 jest.mock("@/lib/db/drizzle-client", () => ({
-  executeQuery: jest.fn(async (_cb: unknown, label: string) => {
+  executeQuery: jest.fn(async (cb: unknown, label: string) => {
     executedLabels.push(label)
     if (label === "lookupConsentNonce") return [nonceRow]
-    if (label === "findUserByEmail") return userRows
+    if (label === "findUserByEmail") {
+      ;(cb as (db: unknown) => unknown)(recordingDb())
+      return userRows
+    }
     return []
   }),
   executeTransaction: jest.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({})),
 }))
+
+/** Literal SQL text of a drizzle fragment, dropping bound params. */
+function sqlText(fragment: unknown): string {
+  const chunks = (fragment as { queryChunks?: Array<{ value?: unknown }> })?.queryChunks ?? []
+  return chunks.map((c) => (Array.isArray(c?.value) ? c.value.join("") : "")).join("")
+}
 
 const storeRefreshTokenMock = jest.fn(async (..._a: unknown[]) => "arn:aws:secretsmanager:us-east-1:1:secret:x-abc123")
 jest.mock("@/lib/agent-workspace/secrets-manager", () => ({
@@ -179,5 +204,23 @@ describe("handleOAuthCallback identity enforcement (#1234)", () => {
     expect(res.data!.success).toBe(false)
     expect(storeRefreshTokenMock).not.toHaveBeenCalled()
     expect(executedLabels).not.toContain("consumeConsentNonce")
+  })
+
+  // #1682. users.email is unique on lower(email) (migration 112), and the
+  // Cognito upsert stores whatever casing the IdP sends — one prod owner's row
+  // is GEORGEK@psd401.net. A case-sensitive lookup misses her, routes an
+  // existing user into auto-provisioning, and that INSERT then dies on
+  // uq_users_email_lower, so the callback throws and every retry fails
+  // identically. The predicate must lower BOTH sides to match the index.
+  it("looks the owner up case-insensitively so a differently-cased row is found", async () => {
+    capturedUserWhere = null
+    await handleOAuthCallback("code", HEX_NONCE)
+
+    expect(executedLabels).toContain("findUserByEmail")
+    const predicate = sqlText(capturedUserWhere)
+    expect(predicate).toContain("lower(")
+    // Both sides — lowering only the column still misses a mixed-case input.
+    expect(predicate.match(/lower\(/g) ?? []).toHaveLength(2)
+    expect(predicate).not.toMatch(/^\s*=/)
   })
 })

--- a/tests/unit/agent-workspace-callback-identity.test.ts
+++ b/tests/unit/agent-workspace-callback-identity.test.ts
@@ -81,6 +81,7 @@ describe("verifyGrantedIdentity (#1234)", () => {
 // Label-dispatched executeQuery mock records which queries ran.
 let executedLabels: string[] = []
 let userRows: Array<{ id: number }> = [{ id: 1 }]
+// ownerEmail is mutable: one test drives it with directory-supplied casing.
 const nonceRow = { ownerEmail: "hagelk@psd401.net", agentEmail: "agnt_hagelk@psd401.net", tokenKind: "user_account" as const }
 // The user lookup's predicate is load-bearing (#1682): migration 112 makes
 // users.email unique on lower(email), so a case-sensitive compare misses a
@@ -108,8 +109,28 @@ jest.mock("@/lib/db/drizzle-client", () => ({
     }
     return []
   }),
-  executeTransaction: jest.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({})),
+  executeTransaction: jest.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb(recordingTx())
+  ),
 }))
+
+// provisionAgentUser's transaction re-checks then INSERTs. Record the inserted
+// values so a test can assert the stored casing — migration 112 makes
+// users.email unique on lower(email), so a mixed-case row is invisible to any
+// case-sensitive reader. `userRows` drives the re-check: non-empty means the
+// user already exists and no INSERT happens.
+let insertedUserValues: { email?: string } | null = null
+const recordingTx = () => ({
+  select: () => ({
+    from: () => ({ where: () => ({ limit: () => userRows }) }),
+  }),
+  insert: () => ({
+    values: (values: { email?: string }) => {
+      insertedUserValues = values
+      return { returning: () => [{ id: 99 }] }
+    },
+  }),
+})
 
 /** Literal SQL text of a drizzle fragment, dropping bound params. */
 function sqlText(fragment: unknown): string {
@@ -142,6 +163,7 @@ beforeEach(() => {
   process.env.GOOGLE_WORKSPACE_CLIENT_SECRET = "test-secret"
   executedLabels = []
   userRows = [{ id: 1 }]
+  nonceRow.ownerEmail = "hagelk@psd401.net"
   storeRefreshTokenMock.mockClear()
   mockVerifyImpl = async () => ({ getPayload: () => ({ email: "hagelk@psd401.net", email_verified: true }) })
   tokenBody = {
@@ -222,5 +244,23 @@ describe("handleOAuthCallback identity enforcement (#1234)", () => {
     // Both sides — lowering only the column still misses a mixed-case input.
     expect(predicate.match(/lower\(/g) ?? []).toHaveLength(2)
     expect(predicate).not.toMatch(/^\s*=/)
+  })
+
+  // The nonce's ownerEmail carries whatever casing the directory supplied, so
+  // auto-provisioning must not plant a fresh mixed-case row behind the
+  // lower(email) unique index it will later be read through.
+  it("auto-provisions a new owner with a normalized email", async () => {
+    userRows = [] // no existing row -> falls through to provisionAgentUser
+    insertedUserValues = null
+    // Directory-supplied casing, exactly what put GEORGEK@psd401.net in prod.
+    nonceRow.ownerEmail = "HAGELK@PSD401.NET"
+    mockVerifyImpl = async () => ({
+      getPayload: () => ({ email: "HAGELK@PSD401.NET", email_verified: true }),
+    })
+
+    await handleOAuthCallback("code", HEX_NONCE)
+
+    expect(insertedUserValues).not.toBeNull()
+    expect(insertedUserValues!.email).toBe("hagelk@psd401.net")
   })
 })


### PR DESCRIPTION
Closes #1682.

Triage of the prod `agent_failures` table since Friday 2026-08-14 (59 rows / 24 users) turned up two defects worth fixing in code, plus one high-volume cause that turns out to be upstream in OpenClaw.

## 1. A mixed-case stored email hid five owners from every `email-index` lookup

Five prod owners could not create a schedule. `psd-schedules create.js` rejected them with HTTP 503 **"Owner must first open a direct message with the agent"** — for owners who had already opened one, and whose DM space was recorded on their user record the whole time. Kim George hit it three times on 2026-08-17 alone trying to set up a Morning Brief.

**Root cause** is one line in the router's user upsert. `getOrCreateUser` persisted `email: senderEmail` — the address exactly as Google Chat supplied it — while computing `workspacePrefix` from a lowercased copy. Google Chat supplies whatever casing the directory entry carries, so five records in `psd-agent-users-prod` were stored with an uppercase local part (`GEORGEK@psd401.net`, `CASELEYM@`, `GRIFFINN@`, `ABELB@`, `BUTCHCOED@`).

Every consumer of the `email-index` GSI queries it with a **lowercased** address, and DynamoDB key equality is byte-exact:

| Consumer | Effect for those five owners |
|---|---|
| `lib/agent-schedules/service.ts` | schedule create/update/delete → 503 |
| `agent-triage-poll/storage.ts` | profile lookup returns null |
| `agent-router` cross-user (`@username`) | owner not found |
| `agent-schedule-target-backfill` | owner profile skipped |

The schedules service does carry a case-insensitive guard — `normalizeOwnerEmail(item.email) === ownerEmail` — but it filters the query's **results**, and the query already returned zero. It cannot fire for exactly the records it was meant to catch.

Verified against prod: querying `email-index` for `georgek@psd401.net` returned `Count 0`; `GEORGEK@psd401.net` returned `Count 1`, with a well-formed `dmSpaceName`.

**Fix normalizes on write** rather than bolting a fallback onto each of the four read sites. Creation writes the lowercased address, and `userActivityUpdate` — extracted from the two duplicated `UpdateCommand` expressions already in that function — rewrites `email` on every inbound message, so legacy records heal on the owner's next message. Safe because `senderEmail` is domain-validated upstream before `getOrCreateUser` is reached, writing an unchanged value causes no index churn, and no caller depends on the original casing (`canInvokeOwnerAgent` is already case-insensitive; everything else is telemetry).

Side effect: `agent_failures` stops recording the same person under two spellings of `user_id`.

**Already applied out-of-band:** the four affected owners with a recorded DM space were normalized directly in `psd-agent-users-prod` (with `attribute_exists` guards), so they are unblocked today without waiting for this deploy. `BUTCHCOED@` has no `dmSpaceName` and genuinely must open a DM first; that row normalizes on their next message once this ships.

## 2. The morning brief graded the model against a checklist it never handed over

Two owners lost their brief outright on 2026-08-17 — one missing 10 inbox decisions, one missing 5 — because `validateSynthesis` discards the **entire** brief when a single inbox item goes undecided.

The requirement was unsatisfiable by construction. `makeSynthesisRequest` said "make an explicit decision for every inbox item" and typed `inboxDecisions[].messageId` as `'snapshot inbox message id'`, but never said what those ids **were**. The model had to open the separate snapshot data file, walk to `sections[id=inbox].data.emails`, and hand-transcribe up to 50 opaque 16-hex-char ids like `1a00a7a08af776d1` — no checklist, brief-destroying penalty for one slip. The `rules` array, where the model's attention actually lands, said nothing about inbox completeness at all.

The request now enumerates them as `requiredInboxDecisionIds` and states the obligation as a rule, with the count inline and an explicit note that `archive` is itself a decision — the omissions in both failures look like items the model judged unimportant rather than items it failed to see.

The id extraction was already duplicated verbatim between `deterministicSynthesis` and `validateSynthesis`; both now call a shared `inboxMessageIdsOf`, so the checklist handed to the model cannot drift from the one it is graded against. The new test asserts exactly that, by feeding `requiredInboxDecisionIds` back through `validateSynthesis` and requiring it to pass.

The 100-entry cap in `validateSynthesis` looked like a latent bug for large inboxes but is unreachable: `inbox.maxResults` is clamped to 50 in `normalizeConfig`.

**Deliberately not changed:** `validateSynthesis` still hard-fails rather than filling undecided items from the existing deterministic `review` default. Shipping a brief whose decisions are partly unreviewed is a product call, not a defect fix — flagging for a decision rather than making it here.

## 3. Freshservice 403 was reported to users as a bad API key

On 2026-08-17 four callers were told their Freshservice keys were invalid when the keys were fine. One agent self-reported having told its user **twice**, incorrectly, to re-issue a working key.

Freshservice authorizes per endpoint **and** per workspace, but `lib/api.js` reported every non-2xx identically, leaving the agent to guess. The two coexist freely: one caller's `list_tickets` succeeded while `get_agent`, `get_workspaces` and `list_agents` all returned 403; another's `workspace_id=3` succeeded while `workspace_id=8` returned 403.

`normalizeFreshserviceResult` now gives 403 its own branch and code (`freshservice_endpoint_forbidden`) stating the key is not implicated. All 13 command scripts surface `result.error` verbatim, so the single branch reaches every one of them. `SKILL.md` documents the same and drops the implication that `get_agent.js` validates a key — it needs agent-administration rights most callers lack, and since no endpoint is reachable by every valid key, a newly stored key needs no verification step at all.

## Not fixable here: the single largest failure cause is upstream

`agent_failures` records a bare `"LLM request failed."` — 10 rows / 8 users since Friday, the highest-volume error class. CloudWatch has what it hides:

```
error=LLM request failed. rawError=Session transcript parent entry was not persisted: bdeffa88
```

All four of 2026-08-17's `OpenClawChatError` rows (musgroved 08:58, burnss 10:12, dizond 10:38, twetena 10:52) match an `[agent/embedded]` line carrying that identical `rawError`, timestamp for timestamp. Grouped over the past week:

| Count | rawError |
|---|---|
| 21 | Context overflow (mid-turn precheck) |
| 12 | Session transcript parent entry was not persisted |
| 11 | Validation error: `toolConfig` must be defined when using toolUse/toolResult |
| 2 | Bedrock service unavailable |
| 1 | Bedrock stream ended before messageStop |

Neither that string nor the Bedrock request assembly behind the `toolConfig` error exists in this repo — both live inside the OpenClaw runtime. Worth raising upstream; the transcript one may be worth checking against our OpenClaw version given #1631 moved transcripts to SQLite.

I also checked whether the harness could capture `rawError` into `agent_failures` so this would be visible without CloudWatch. It cannot — `rawError` appears only in OpenClaw's plain-text log line, never as a JSON key in the chat event payload, so `payload.get("rawError")` would be dead code.

## Verification

- `agent-router` **127 pass / 0 fail** (4 new tests on `userActivityUpdate`)
- `psd-morning-brief` **25 pass / 0 fail** (1 new test)
- `psd-freshservice` **12 pass / 0 fail** via `node --test` — its files patch `require.cache` and need a process each; `bun test` shares one and reports false failures
- `bun run lint` and `bun run typecheck` clean
- Authenticated Playwright suite **321 passed / 41 skipped / 0 failed** (11.2m)

## Still open from the same triage

Not addressed here: georgek's Gmail OAuth callback failure (separate from the case bug, unverified), zarlingj's recurring cron workspace collisions, and grunbergl's KPMS/RLS data-scope gap — the last two recur on a schedule and will fire again each weekday morning.


---

## 4. The same pathology in Aurora — the OAuth consent callback (#1682)

Filed independently as #1682 while this PR was open; the diagnosis matched and identified one site more than the first pass here, so both are now fixed.

Kim George burned five consent links on 2026-08-17 (18:10, 18:12, 18:14, 18:15, 18:21 UTC), each ending in the generic "Failed to complete OAuth callback". That text comes from the **catch block** — every handled failure returns its own specific message — so the callback was throwing, not declining. `/ecs/aistudio-prod` has the throw: an INSERT into `users` for `Kimberly, George`.

`users.email` is unique on `lower(email)` (`uq_users_email_lower`, migration 112), while `createUser` upserts on `cognito_sub` and stores whatever casing the IdP sends — her row is `GEORGEK@psd401.net`, id 863. Two case-sensitive lookups sat in front of that case-insensitive constraint:

- `exchangeAndStore` → `findUserByEmail` — missed her row, so an existing user was routed into auto-provisioning
- `provisionAgentUser`'s in-transaction re-check — missed it again, so the INSERT ran and `uq_users_email_lower` rejected it

Retrying could never help: the collision is in the table, not the link. That is why five fresh links produced five identical failures, and why the agent's own self-report (failure 9183) concluded it was a broker-side bug.

Verified against prod:

| Predicate | Rows |
|---|---|
| `email = 'georgek@psd401.net'` (old) | **0** |
| `lower(email) = lower('georgek@…')` (new) | **1** (id 863) |
| colliding rows for the INSERT it fell through to | **1** |

Both lookups now lower **both** sides, matching the index and the convention documented on `getUserByEmail` — which describes this exact lockout. The issue's grep is now empty:

```
grep -rn "eq(users.email" --include="*.ts" . | grep -v node_modules | grep -v test
```

The new test asserts the emitted **predicate**, not a query label: the existing harness dispatches `executeQuery` by label and never evaluates the builder, so it could not observe casing at all. The `findUserByEmail` branch now runs its builder against a recorder that captures the `where()` fragment. Mutation-checked — reverting to `eq()` fails it.

**Not done here:** #1682 also proposes normalizing stored data with `UPDATE users SET email = lower(email) WHERE email <> lower(email)`. That is a prod write and needs Hagel's approval. The code fix alone unblocks affected owners without it.

## Triage outcomes for the two remaining items (no code change)

- **zarlingj's cron contention** — not a defect. She has **two schedules at the identical cron `0 7 * * MON-FRI`** (Meeting Prep + Morning Brief) and two more colliding at 15:00 Fridays. Every schedule for one owner shares the workspace lock, so this contends by design and the retry usually resolves it — `agent_scheduled_runs` shows both 07:00 jobs succeeding on 08-17. One did not recover: **Meeting Prep was lost outright on 08-14** (terminal error, no successful retry). The durable fix is staggering the cron times, a data change rather than a code change.
- **grunbergl's KPMS gap** — not a defect. She is Principal of **Key Peninsula Middle School** (`users.building`), and psd-data RLS correctly scopes her to `KPM`. Her brief's custom section requests **Kopachuck** Middle School (`KPMS`) attendance — a different school. Either the section should name her own school or she needs cross-school access granted; the warehouse is behaving correctly. It will keep emitting a warn every weekday until the config changes.
