### PR TITLE
fix(nexus): stop truncating answers at 30s and blocking the composer on upload

### DIFF
--- a/app/api/nexus/chat/__tests__/incomplete-turn.test.ts
+++ b/app/api/nexus/chat/__tests__/incomplete-turn.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ *
+ * Guards the rule that decides whether a finished stream may be written to the
+ * conversation as a completed assistant turn.
+ *
+ * Production failure this encodes: a Nexus turn on an unmapped model inherited a
+ * 30s wall-clock budget, called the attachment-search tool (which returned at
+ * +7s), and was aborted mid-answer at exactly +30s. AI SDK v6 fired `onFinish`
+ * anyway with only the completed tool-call step, and the route persisted it —
+ * `textLength: 0`, `finishReason: "tool-calls"`, logged `status: "success"`.
+ * The user was left with a permanently blank assistant bubble and no error.
+ *
+ * @see ../chat-helpers.ts (incompleteTurnReason)
+ */
+
+import { describe, it, expect } from '@jest/globals'
+
+const mockExecuteQuery = jest.fn()
+const mockExecuteTransaction = jest.fn()
+jest.mock('@/lib/db/drizzle-client', () => ({
+  executeQuery: (...a: unknown[]) => mockExecuteQuery(...a),
+  executeTransaction: (...a: unknown[]) => mockExecuteTransaction(...a),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+  generateRequestId: jest.fn(() => 'rid'),
+  startTimer: jest.fn(() => jest.fn()),
+  sanitizeForLogging: jest.fn((d: unknown) => d),
+}))
+
+import { incompleteTurnReason } from '../chat-helpers'
+import type { StepData } from '../chat-helpers'
+
+/** A tool-call step with no assistant prose — what the aborted prod turn produced. */
+const toolCallStep = { text: '', toolCalls: [{ toolCallId: 't1', toolName: 'searchNexusAttachments', args: {} }] } as unknown as StepData
+const textStep = { text: 'Here is the schedule.', toolCalls: [] } as unknown as StepData
+
+describe('incompleteTurnReason', () => {
+  it('rejects the exact production failure: aborted, single tool-call step, no text', () => {
+    expect(
+      incompleteTurnReason({ text: '', aborted: true, steps: [toolCallStep] })
+    ).toBe('stream_aborted')
+  })
+
+  it('rejects an aborted run even when it produced partial text', () => {
+    // A truncated run's trailing step can hold a tool call whose result never
+    // arrived; replaying that pair throws AI_MissingToolResultsError on reload.
+    expect(
+      incompleteTurnReason({ text: 'Here is the partial', aborted: true, steps: [toolCallStep] })
+    ).toBe('stream_aborted')
+  })
+
+  it('rejects a completed run that produced nothing at all', () => {
+    expect(incompleteTurnReason({ text: '', steps: [] })).toBe('no_content')
+    expect(incompleteTurnReason({ text: '   \n\t  ' })).toBe('no_content')
+    expect(incompleteTurnReason({ text: '', steps: [toolCallStep] })).toBe('no_content')
+  })
+
+  it('accepts an ordinary completed answer', () => {
+    expect(incompleteTurnReason({ text: 'Here is the schedule.' })).toBeNull()
+    expect(incompleteTurnReason({ text: 'Here is the schedule.', aborted: false })).toBeNull()
+  })
+
+  it('accepts a completed multi-step run whose final step has no prose', () => {
+    // MCP connector flows persist each step separately (Issue #977). Dropping
+    // these would break tool-history replay, so a text-free FINAL step is fine
+    // as long as there is real multi-step history and the run was not aborted.
+    expect(
+      incompleteTurnReason({ text: '', steps: [toolCallStep, textStep, toolCallStep] })
+    ).toBeNull()
+  })
+
+  it('treats abort as decisive regardless of how much history exists', () => {
+    expect(
+      incompleteTurnReason({
+        text: 'partial',
+        aborted: true,
+        steps: [toolCallStep, textStep, toolCallStep],
+      })
+    ).toBe('stream_aborted')
+  })
+})

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -916,3 +916,33 @@ export async function saveConversationSteps(params: {
     totalTokens: usage?.totalTokens,
   });
 }
+
+/**
+ * Why a finished stream must NOT be persisted as a completed assistant turn, or
+ * null when it should be saved.
+ *
+ * - `stream_aborted`: the run was cut short (wall-clock budget exhausted, or the
+ *   caller aborted). AI SDK v6 still fires `onFinish` after an abort, carrying
+ *   only the steps that completed before the cut. Its trailing step can hold a
+ *   tool call whose result never arrived, and replaying that pair throws
+ *   AI_MissingToolResultsError the next time the conversation loads.
+ * - `no_content`: no prose AND no multi-step history — there is nothing to show.
+ *   This is the exact production failure behind the blank Nexus replies: a 30s
+ *   wall-clock abort after a single tool-call step persisted `textLength: 0` and
+ *   logged it as a success, leaving a permanently empty assistant bubble.
+ *
+ * Completed multi-step runs still persist via saveConversationSteps even when the
+ * final step is text-free, so MCP tool history survives.
+ */
+export function incompleteTurnReason(input: {
+  text: string;
+  aborted?: boolean;
+  steps?: StepData[];
+}): "stream_aborted" | "no_content" | null {
+  if (input.aborted) {
+    return "stream_aborted";
+  }
+  const hasText = input.text.trim().length > 0;
+  const hasMultiStepHistory = (input.steps?.length ?? 0) > 1;
+  return hasText || hasMultiStepHistory ? null : "no_content";
+}

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -123,14 +123,30 @@ export const maxDuration = 1800;
  * Close all MCP connector clients, ignoring errors.
  * Called after streaming completes (onFinish) or on error to release connections.
  */
+/**
+ * Clients already closed, so a second cleanup pass is a no-op.
+ *
+ * A turn can reach cleanup from more than one place: onFinish, onError, and the
+ * outer catch. An ABORTED stream hits two of them — the adapter's onAbort raises
+ * through onError, and AI SDK v6 then fires onFinish anyway — so without this the
+ * exact path this PR adds visibility for would close every connector twice.
+ * `Promise.allSettled` hid the double close rather than preventing it.
+ *
+ * A WeakSet keeps this per-client and non-mutating (the caller's array is still
+ * read by header/tool assembly earlier in the request) and cannot leak.
+ */
+const closedMcpClients = new WeakSet<McpConnectorToolsResult>();
+
 async function closeMcpClients(
   connectorToolResults: McpConnectorToolsResult[],
   log: ReturnType<typeof createLogger>,
   context: string
 ) {
-  if (connectorToolResults.length === 0) return;
-  log.debug('Closing MCP clients', { context, clientCount: connectorToolResults.length });
-  await Promise.allSettled(connectorToolResults.map(r => r.close()));
+  const pending = connectorToolResults.filter(result => !closedMcpClients.has(result));
+  if (pending.length === 0) return;
+  for (const result of pending) closedMcpClients.add(result);
+  log.debug('Closing MCP clients', { context, clientCount: pending.length });
+  await Promise.allSettled(pending.map(r => r.close()));
 }
 
 function createOnFinishCallback(params: {

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -71,6 +71,7 @@ import {
   saveAssistantMessage,
   saveConversationSteps,
   type StepData,
+  incompleteTurnReason,
 } from './chat-helpers';
 
 import { eq, and } from 'drizzle-orm';
@@ -163,6 +164,7 @@ function createOnFinishCallback(params: {
     finishReason,
     toolCalls,
     steps,
+    aborted,
   }: {
     text: string;
     usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
@@ -174,6 +176,7 @@ function createOnFinishCallback(params: {
       result?: unknown;
     }>;
     steps?: StepData[];
+    aborted?: boolean;
   }) => {
     log.info('Stream finished, saving assistant message', {
       conversationId,
@@ -181,7 +184,26 @@ function createOnFinishCallback(params: {
       textLength: text?.length || 0,
       toolCallCount: toolCalls?.length || 0,
       stepCount: steps?.length ?? 0,
+      aborted: !!aborted,
     });
+
+    const skipReason = incompleteTurnReason({ text, aborted, steps });
+    if (skipReason) {
+      log.warn('Skipping assistant message persistence — incomplete turn', {
+        conversationId,
+        reason: skipReason,
+        finishReason,
+      });
+      // Still release MCP clients — the cleanup below is not reached on this
+      // path, and an aborted turn would otherwise leak connector clients.
+      await closeMcpClients(connectorToolResults, log, 'onFinish');
+      timer({
+        status: skipReason === 'stream_aborted' ? 'error' : 'success',
+        conversationId,
+        tokensUsed: usage?.totalTokens,
+      });
+      return;
+    }
 
     let assistantMessagePersisted = false;
     try {

--- a/infra/lambdas/unified-content-processor/__tests__/lifecycle.test.ts
+++ b/infra/lambdas/unified-content-processor/__tests__/lifecycle.test.ts
@@ -1,5 +1,7 @@
 import {
   classifyContentProcessingError,
+  deferDelaySeconds,
+  elapsedWaitMs,
   PermanentContentProcessingError,
   prepareDeferredProcessingMetrics,
   processingRetryDelaySeconds,
@@ -243,5 +245,74 @@ describe("canonical artifact replay mismatch classification", () => {
     expect(
       classifyContentProcessingError(new Error("Connection reset while matching"))
     ).toMatchObject({ terminal: false });
+  });
+});
+
+describe("deferred wait cadence", () => {
+  test("re-polls fast-answering services in seconds, not a flat minute", () => {
+    // Every reason used to defer a flat 60s. GuardDuty tags a small object and
+    // Textract returns a single image within seconds, so a minute per stage was
+    // pure dead time: a Nexus image paid 60s for the scan plus 60s for OCR.
+    expect(deferDelaySeconds("AWAITING_SECURITY_SCAN", 0)).toBe(5);
+    expect(deferDelaySeconds("AWAITING_OCR", 0)).toBe(5);
+  });
+
+  test("backs off as a wait drags on, bounded by the per-reason cap", () => {
+    expect(deferDelaySeconds("AWAITING_SECURITY_SCAN", 60_000)).toBe(10);
+    expect(deferDelaySeconds("AWAITING_SECURITY_SCAN", 120_000)).toBe(20);
+    expect(deferDelaySeconds("AWAITING_SECURITY_SCAN", 180_000)).toBe(40);
+    // Capped at 60s however long the wait runs.
+    expect(deferDelaySeconds("AWAITING_SECURITY_SCAN", 240_000)).toBe(60);
+    expect(deferDelaySeconds("AWAITING_SECURITY_SCAN", 60 * 60_000)).toBe(60);
+  });
+
+  test("polls minutes-scale and operator-gated waits slowly from the start", () => {
+    expect(deferDelaySeconds("AWAITING_MEDIA_ANALYSIS", 0)).toBe(15);
+    expect(deferDelaySeconds("AWAITING_MEDIA_ANALYSIS", 10 * 60_000)).toBe(120);
+    // Nothing changes until an operator re-enables the platform.
+    expect(deferDelaySeconds("CONTENT_PLATFORM_DISABLED", 0)).toBe(300);
+    expect(deferDelaySeconds("CONTENT_PLATFORM_DISABLED", 60 * 60_000)).toBe(900);
+  });
+
+  test("never exceeds the SQS DelaySeconds ceiling", () => {
+    const reasons = [
+      "CONTENT_PLATFORM_DISABLED",
+      "AWAITING_SECURITY_SCAN",
+      "AWAITING_OCR",
+      "AWAITING_MEDIA_ANALYSIS",
+    ] as const;
+    for (const reason of reasons) {
+      for (const elapsed of [0, 1, 60_000, 3_600_000, Number.MAX_SAFE_INTEGER]) {
+        const delay = deferDelaySeconds(reason, elapsed);
+        expect(delay).toBeGreaterThanOrEqual(1);
+        expect(delay).toBeLessThanOrEqual(900);
+      }
+    }
+  });
+
+  test("treats a corrupt or absent elapsed value as the start of the wait", () => {
+    expect(deferDelaySeconds("AWAITING_OCR")).toBe(5);
+    expect(deferDelaySeconds("AWAITING_OCR", Number.NaN)).toBe(5);
+    expect(deferDelaySeconds("AWAITING_OCR", -1)).toBe(5);
+  });
+
+  test("measures elapsed wait only while the reason is unchanged", () => {
+    const now = new Date("2026-07-22T12:02:00.000Z");
+    const metrics = {
+      waitReason: "AWAITING_SECURITY_SCAN" as const,
+      waitStartedAt: "2026-07-22T12:00:00.000Z",
+    };
+    expect(elapsedWaitMs(metrics, "AWAITING_SECURITY_SCAN", now)).toBe(120_000);
+    // Scan -> OCR is a NEW wait, so the cadence restarts at its shortest delay
+    // rather than inheriting the previous reason's backoff.
+    expect(elapsedWaitMs(metrics, "AWAITING_OCR", now)).toBe(0);
+    expect(elapsedWaitMs({}, "AWAITING_OCR", now)).toBe(0);
+    expect(
+      elapsedWaitMs(
+        { waitReason: "AWAITING_OCR", waitStartedAt: "not-a-date" },
+        "AWAITING_OCR",
+        now
+      )
+    ).toBe(0);
   });
 });

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -322,9 +322,13 @@ async function deferJob(
   reason: DeferredProcessingReason,
   claimedAttempt: number,
 ): Promise<void> {
-  // Read the elapsed wait BEFORE prepareDeferredProcessingMetrics stamps this
-  // round, so a reason change (scan -> OCR) restarts the cadence at its shortest
-  // delay rather than inheriting the previous reason's backoff.
+  // Measure the wait against the INCOMING `metrics`, never the stamped
+  // `deferredMetrics`: elapsedWaitMs returns 0 when the stored waitReason differs
+  // from this one, which is what restarts the cadence at its shortest delay on a
+  // reason change (scan -> OCR) instead of inheriting the previous reason's
+  // backoff. prepareDeferredProcessingMetrics returns a new object rather than
+  // mutating its argument, so the two calls below are order-independent — it is
+  // the object passed in that matters, not the sequence.
   const waitedMs = elapsedWaitMs(metrics, reason);
   const deferredMetrics = prepareDeferredProcessingMetrics(metrics, reason);
   const delaySeconds = deferDelaySeconds(reason, waitedMs);

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -138,6 +138,8 @@ import {
 import { buildRepositorySourceObjectKey } from "../../../lib/repositories/content-platform/object-key";
 import {
   classifyContentProcessingError,
+  deferDelaySeconds,
+  elapsedWaitMs,
   PermanentContentProcessingError,
   prepareDeferredProcessingMetrics,
   processingRetryDelaySeconds,
@@ -206,7 +208,6 @@ const dataAutomationProjectArn = requiredEnvironment("BDA_DATA_AUTOMATION_PROJEC
 const dataAutomationProfileArn = requiredEnvironment("BDA_DATA_AUTOMATION_PROFILE_ARN");
 const databaseSecretArn = requiredEnvironment("DATABASE_SECRET_ARN");
 const databaseHost = requiredEnvironment("DATABASE_HOST");
-const DEFER_SECONDS = 60;
 const DISPATCH_BATCH_SIZE = 25;
 const environment = requiredEnvironment("ENVIRONMENT");
 
@@ -321,7 +322,25 @@ async function deferJob(
   reason: DeferredProcessingReason,
   claimedAttempt: number,
 ): Promise<void> {
+  // Read the elapsed wait BEFORE prepareDeferredProcessingMetrics stamps this
+  // round, so a reason change (scan -> OCR) restarts the cadence at its shortest
+  // delay rather than inheriting the previous reason's backoff.
+  const waitedMs = elapsedWaitMs(metrics, reason);
   const deferredMetrics = prepareDeferredProcessingMetrics(metrics, reason);
+  const delaySeconds = deferDelaySeconds(reason, waitedMs);
+
+  // The reason was previously written only to lastErrorCode, so diagnosing a slow
+  // upload from CloudWatch alone was impossible — the reason had to be inferred
+  // from the gaps between calls. Log it.
+  log.info("Deferring content processing job", {
+    jobId: message.jobId,
+    itemVersionId: message.itemVersionId,
+    reason,
+    delaySeconds,
+    waitedMs,
+    attempt: claimedAttempt,
+  });
+
   await executeQuery(
     (db) =>
       db
@@ -338,7 +357,7 @@ async function deferJob(
           leaseOwner: null,
           leaseExpiresAt: null,
           lastErrorCode: reason,
-          availableAt: new Date(Date.now() + DEFER_SECONDS * 1000),
+          availableAt: new Date(Date.now() + delaySeconds * 1000),
           updatedAt: new Date(),
         })
         .where(eq(repositoryProcessingJobs.id, message.jobId)),
@@ -348,7 +367,7 @@ async function deferJob(
     new SendMessageCommand({
       QueueUrl: queueUrl,
       MessageBody: JSON.stringify(message),
-      DelaySeconds: DEFER_SECONDS,
+      DelaySeconds: delaySeconds,
     }),
   );
   await executeQuery(

--- a/infra/lambdas/unified-content-processor/lifecycle.ts
+++ b/infra/lambdas/unified-content-processor/lifecycle.ts
@@ -33,6 +33,72 @@ const DEFER_DEADLINE_MS: Readonly<Record<DeferredProcessingReason, number>> = {
   AWAITING_MEDIA_ANALYSIS: 6 * 60 * 60 * 1_000,
 };
 
+/**
+ * Re-poll cadence per wait reason: `initial` is the first delay, doubling for
+ * each further minute already spent on this reason, bounded by `cap`.
+ *
+ * These waits were previously one flat 60s for every reason. That was wildly
+ * mismatched to what is actually being waited on: GuardDuty tags a small object
+ * within seconds and Textract returns a single image in seconds, yet each cost a
+ * full minute. In prod a Nexus image paid 60s for the malware tag plus another
+ * 60s for OCR — 120s of pure sleep around ~2s of real work, per file.
+ *
+ * Backing off with elapsed wait keeps the common case (service answers almost
+ * immediately) fast without polling a genuinely slow job hundreds of times.
+ */
+const DEFER_BACKOFF: Readonly<
+  Record<DeferredProcessingReason, { initialSeconds: number; capSeconds: number }>
+> = {
+  // Nothing changes until an operator re-enables the platform — poll rarely.
+  CONTENT_PLATFORM_DISABLED: { initialSeconds: 300, capSeconds: 900 },
+  // GuardDuty usually tags a small upload within a few seconds.
+  AWAITING_SECURITY_SCAN: { initialSeconds: 5, capSeconds: 60 },
+  // Textract returns a page or an image quickly; multi-page PDFs take longer.
+  AWAITING_OCR: { initialSeconds: 5, capSeconds: 60 },
+  // Bedrock Data Automation is a minutes-scale job — no value in fast polling.
+  AWAITING_MEDIA_ANALYSIS: { initialSeconds: 15, capSeconds: 120 },
+};
+
+/** SQS caps DelaySeconds at 15 minutes. */
+const MAX_SQS_DELAY_SECONDS = 900;
+
+/**
+ * How long to wait before re-checking a deferred job, given how long this wait
+ * has already been running. Pure and total so the cadence can be asserted in
+ * tests without SQS or a clock.
+ */
+export function deferDelaySeconds(
+  reason: DeferredProcessingReason,
+  elapsedWaitMs = 0
+): number {
+  const { initialSeconds, capSeconds } = DEFER_BACKOFF[reason];
+  const elapsed = Number.isFinite(elapsedWaitMs) ? Math.max(0, elapsedWaitMs) : 0;
+  // Bounded exponent: 2**10 already exceeds every cap, and it keeps the result
+  // finite if a corrupt waitStartedAt ever yields an enormous elapsed value.
+  const doublings = Math.min(10, Math.floor(elapsed / 60_000));
+  const delay = initialSeconds * 2 ** doublings;
+  return Math.max(1, Math.min(capSeconds, MAX_SQS_DELAY_SECONDS, Math.round(delay)));
+}
+
+/**
+ * Milliseconds already spent on the CURRENT wait reason. A reason change resets
+ * the clock (scan -> OCR), matching prepareDeferredProcessingMetrics.
+ */
+export function elapsedWaitMs(
+  metrics: DeferredProcessingMetrics,
+  reason: DeferredProcessingReason,
+  now = new Date()
+): number {
+  if (metrics.waitReason !== reason || !metrics.waitStartedAt) {
+    return 0;
+  }
+  const startedAt = Date.parse(metrics.waitStartedAt);
+  if (!Number.isFinite(startedAt)) {
+    return 0;
+  }
+  return Math.max(0, now.getTime() - startedAt);
+}
+
 const RETRYABLE_AWS_ERROR =
   /(?:throttl|timeout|timedout|requesttimeout|serviceunavailable|internalserver|slowdown|temporar|network|connection)/i;
 

--- a/lib/nexus/__tests__/enhanced-attachment-adapters.test.ts
+++ b/lib/nexus/__tests__/enhanced-attachment-adapters.test.ts
@@ -519,3 +519,201 @@ const defineVisionImageAdapterRepositoryBackedProcessingSuite2 = () => {
 };
 
 describe('VisionImageAdapter repository-backed processing', defineVisionImageAdapterRepositoryBackedProcessingSuite2);
+
+/**
+ * Images used to upload inside send(), so the whole repository round-trip — which
+ * measured 2m18s in prod for a pair of images — ran after the user pressed Send,
+ * freezing the composer. The adapter also never fired the processing callbacks
+ * that drive the UI's "processing" indicator, so there was nothing on screen for
+ * the duration. Both are fixed by uploading at attach time.
+ */
+const defineVisionImageAdapterEagerUploadSuite = () => {
+  beforeEach(() => {
+    mockUploadTemporaryAttachment.mockReset();
+    mockWaitForTemporaryAttachment.mockReset();
+  });
+
+  const pngFile = () =>
+    new File([new Uint8Array([0x89, 0x50, 0x4E, 0x47])], 'diagram.png', {
+      type: 'image/png',
+    });
+
+  it('starts the repository upload at attach time, not at send time', async () => {
+    mockUploadTemporaryAttachment.mockResolvedValue({
+      mode: 'canonical',
+      reference: { bindingId: 'b1', itemId: 43 },
+    });
+    mockWaitForTemporaryAttachment.mockResolvedValue('[[marker]]');
+
+    const adapter = new VisionImageAdapter(undefined, { repositoryBacked: true });
+    await adapter.add({ file: pngFile() });
+
+    // The upload is already in flight before send() is ever called.
+    expect(mockUploadTemporaryAttachment).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports processing start and completion so the UI can show progress', async () => {
+    mockUploadTemporaryAttachment.mockResolvedValue({
+      mode: 'canonical',
+      reference: { bindingId: 'b1', itemId: 43 },
+    });
+    mockWaitForTemporaryAttachment.mockResolvedValue('[[marker]]');
+
+    const onProcessingStart = jest.fn();
+    const onProcessingComplete = jest.fn();
+    const adapter = new VisionImageAdapter(
+      { onProcessingStart, onProcessingComplete },
+      { repositoryBacked: true }
+    );
+
+    const pending = await adapter.add({ file: pngFile() });
+    expect(onProcessingStart).toHaveBeenCalledWith(pending.id);
+
+    await adapter.send(pending);
+    expect(onProcessingComplete).toHaveBeenCalledWith(pending.id);
+  });
+
+  it('reuses the in-flight upload rather than uploading a second time', async () => {
+    mockUploadTemporaryAttachment.mockResolvedValue({
+      mode: 'canonical',
+      reference: { bindingId: 'b1', itemId: 43 },
+    });
+    mockWaitForTemporaryAttachment.mockResolvedValue('[[marker]]');
+
+    const adapter = new VisionImageAdapter(undefined, { repositoryBacked: true });
+    const pending = await adapter.add({ file: pngFile() });
+    const complete = await adapter.send(pending);
+
+    expect(mockUploadTemporaryAttachment).toHaveBeenCalledTimes(1);
+    expect(complete.content).toContainEqual({ type: 'text', text: '[[marker]]' });
+  });
+
+  it('reports completion and surfaces the error when the upload fails', async () => {
+    mockUploadTemporaryAttachment.mockRejectedValue(new Error('storage exploded'));
+
+    const onProcessingComplete = jest.fn();
+    const onError = jest.fn();
+    const adapter = new VisionImageAdapter(
+      { onProcessingComplete, onError },
+      { repositoryBacked: true }
+    );
+
+    const pending = await adapter.add({ file: pngFile() });
+    // The indicator must clear even on failure, or the composer looks stuck.
+    await expect(adapter.send(pending)).rejects.toThrow('storage exploded');
+    expect(onProcessingComplete).toHaveBeenCalledWith(pending.id);
+  });
+
+  it('reports an attach-time failure immediately, without waiting for send()', async () => {
+    // Uploading eagerly moved the failure to attach time too. If it were only
+    // reported from send(), a user who removed the attachment (or never sent)
+    // would never learn the upload failed.
+    mockUploadTemporaryAttachment.mockRejectedValue(new Error('storage exploded'));
+
+    const onError = jest.fn();
+    const adapter = new VisionImageAdapter({ onError }, { repositoryBacked: true });
+    const pending = await adapter.add({ file: pngFile() });
+
+    // Let the background promise settle — send() is never called here.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [attachmentId, error] = onError.mock.calls[0] as [string, Error];
+    expect(attachmentId).toBe(pending.id);
+    // The ORIGINAL error is passed through so callers can tell an auth failure
+    // from an infra blip.
+    expect(error.message).toBe('storage exploded');
+  });
+
+  it('falls back to a synchronous upload when send() sees no in-flight upload', async () => {
+    mockUploadTemporaryAttachment.mockResolvedValue({
+      mode: 'canonical',
+      reference: { bindingId: 'b1', itemId: 43 },
+    });
+    mockWaitForTemporaryAttachment.mockResolvedValue('[[marker]]');
+
+    const adapter = new VisionImageAdapter(undefined, { repositoryBacked: true });
+    // An attachment that never went through THIS adapter's add() (restored draft,
+    // adapter swapped mid-composition) must still resolve its marker.
+    const complete = await adapter.send({
+      id: 'never-added',
+      type: 'image',
+      name: 'diagram.png',
+      contentType: 'image/png',
+      file: pngFile(),
+      status: { type: 'running', reason: 'uploading', progress: 0 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    expect(mockUploadTemporaryAttachment).toHaveBeenCalledTimes(1);
+    expect(complete.content).toContainEqual({ type: 'text', text: '[[marker]]' });
+  });
+
+  it('does not upload at all when the repository path is disabled', async () => {
+    const adapter = new VisionImageAdapter(undefined, { repositoryBacked: false });
+    const pending = await adapter.add({ file: pngFile() });
+    const complete = await adapter.send(pending);
+
+    expect(mockUploadTemporaryAttachment).not.toHaveBeenCalled();
+    expect(complete.content).toEqual([
+      { type: 'image', image: expect.stringMatching(/^data:image\/png;base64,/) },
+    ]);
+  });
+};
+
+describe('VisionImageAdapter eager upload', defineVisionImageAdapterEagerUploadSuite);
+
+/**
+ * remove() used to be a no-op on both adapters, so a discarded attachment kept
+ * its cached CompleteAttachment (which holds the whole File) and its in-flight
+ * upload promise for the life of the adapter. A prod session showed four uploaded
+ * repositories but only three attachment references in the sent message — an
+ * orphan of exactly this shape.
+ */
+const defineAdapterRemoveCleanupSuite = () => {
+  beforeEach(() => {
+    mockUploadTemporaryAttachment.mockReset();
+    mockWaitForTemporaryAttachment.mockReset();
+    mockUploadTemporaryAttachment.mockResolvedValue({
+      mode: 'canonical',
+      reference: { bindingId: 'b1', itemId: 43 },
+    });
+    mockWaitForTemporaryAttachment.mockResolvedValue('[[marker]]');
+  });
+
+  it('releases the image adapter upload state so the File is not retained', async () => {
+    const imageAdapter = new VisionImageAdapter(undefined, { repositoryBacked: true });
+    const file = new File([new Uint8Array([0x89, 0x50, 0x4E, 0x47])], 'diagram.png', {
+      type: 'image/png',
+    });
+    const pending = await imageAdapter.add({ file });
+
+    await imageAdapter.remove(pending);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((imageAdapter as any).uploadPromises.size).toBe(0);
+  });
+
+  it('releases the document adapter caches so the File is not retained', async () => {
+    const onProcessingStart = jest.fn();
+    const docAdapter = new HybridDocumentAdapter(
+      { onProcessingStart, onProcessingComplete: jest.fn() },
+      { repositoryBacked: true }
+    );
+    const file = new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], 'calendar.pdf', {
+      type: 'application/pdf',
+    });
+    const pending = await docAdapter.add({ file });
+    // Let the eager background upload settle into processedCache.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    await docAdapter.remove(pending);
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    expect((docAdapter as any).processedCache.size).toBe(0);
+    expect((docAdapter as any).processingPromises.size).toBe(0);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+};
+
+describe('attachment adapter remove() cleanup', defineAdapterRemoveCleanupSuite);

--- a/lib/nexus/enhanced-attachment-adapters.ts
+++ b/lib/nexus/enhanced-attachment-adapters.ts
@@ -658,8 +658,30 @@ Please try re-uploading. If the issue persists, contact support.`
     return -1;
   }
 
-  async remove(_attachment: PendingAttachment): Promise<void> {
-    // Cleanup if needed
+  async remove(attachment: PendingAttachment): Promise<void> {
+    // Both maps were previously left populated forever. Two consequences:
+    //
+    //   1. `processedCache` holds a CompleteAttachment, which holds `file` — the
+    //      whole File blob. Removing an attachment did not release it, so a long
+    //      composing session retained every file the user had ever discarded.
+    //   2. The background upload kept running and its repository/item stayed
+    //      bound to nothing. A prod session showed four uploaded repositories but
+    //      only three attachment references in the sent message — an orphan of
+    //      exactly this shape.
+    //
+    // The in-flight request itself cannot be cancelled from here (the upload
+    // client takes no abort signal), but dropping the entries stops the retention
+    // and makes the orphan explicit rather than silent.
+    const orphaned =
+      this.processedCache.has(attachment.id) || this.processingPromises.has(attachment.id);
+    this.processedCache.delete(attachment.id);
+    this.processingPromises.delete(attachment.id);
+    if (orphaned) {
+      log.info('Discarded attachment upload state on remove', {
+        attachmentId: attachment.id,
+        fileName: attachment.name,
+      });
+    }
   }
 }
 
@@ -673,6 +695,16 @@ export class VisionImageAdapter implements AttachmentAdapter {
 
   private callbacks?: AttachmentProcessingCallbacks;
   private readonly options: NexusAttachmentAdapterOptions;
+  /**
+   * Repository upload started at attach time, keyed by attachment id. Images used
+   * to upload inside send(), which froze the composer for as long as repository
+   * ingestion took — measured at 2m18s in prod for a pair of images, with no
+   * spinner, because this adapter also never fired the processing callbacks that
+   * drive the UI indicator. Uploading here mirrors HybridDocumentAdapter: the
+   * work overlaps the user still typing, and send() awaits a promise that is
+   * usually already resolved.
+   */
+  private uploadPromises = new Map<string, Promise<string | null>>();
 
   constructor(
     callbacks?: AttachmentProcessingCallbacks,
@@ -680,6 +712,63 @@ export class VisionImageAdapter implements AttachmentAdapter {
   ) {
     this.callbacks = callbacks;
     this.options = options;
+  }
+
+  /**
+   * Upload to the repository and wait for the extracted content to be queryable.
+   * Resolves to the opaque marker, or null when the repository path is off.
+   */
+  private async uploadToRepository(file: File): Promise<string | null> {
+    if (!this.options.repositoryBacked) {
+      return null;
+    }
+    const repositoryUpload = await uploadTemporaryAttachment({
+      file,
+      draftKey: generateUUID(),
+      purpose: "nexus",
+      conversationId: this.options.getConversationId?.() ?? undefined,
+    });
+    if (repositoryUpload.mode !== "canonical") {
+      return null;
+    }
+    return waitForTemporaryAttachment(repositoryUpload);
+  }
+
+  /** Start the upload in the background and report progress to the UI. */
+  private startBackgroundUpload(attachmentId: string, file: File): void {
+    this.callbacks?.onProcessingStart?.(attachmentId);
+
+    const promise = this.uploadToRepository(file)
+      .then(marker => {
+        this.callbacks?.onProcessingComplete?.(attachmentId);
+        return marker;
+      })
+      .catch((error: unknown) => {
+        this.callbacks?.onProcessingComplete?.(attachmentId);
+        log.error('Background image upload failed', {
+          attachmentId,
+          fileName: file.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        // Moving the upload to attach time moved the FAILURE there too. Without
+        // this the rejection would sit unreported until send() awaited it — and
+        // silently forever if the user removed the attachment first. Report it
+        // the same way HybridDocumentAdapter does, so the page can raise its
+        // "File upload failed" / expired-session toast right when it happens.
+        // The original error is passed through (not a redacted string) so the
+        // caller can still distinguish an auth failure from an infra blip.
+        this.callbacks?.onError?.(
+          attachmentId,
+          error instanceof Error ? error : new Error(String(error))
+        );
+        throw error;
+      });
+
+    // Attach a no-op catch so a failure that send() never awaits (the user
+    // removed the attachment, or navigated away) does not surface as an
+    // unhandled rejection. send() still sees the rejection via the stored promise.
+    promise.catch(() => {});
+    this.uploadPromises.set(attachmentId, promise);
   }
 
   async add({ file }: { file: File }): Promise<PendingAttachment> {
@@ -703,8 +792,7 @@ export class VisionImageAdapter implements AttachmentAdapter {
 
     log.info('VisionImageAdapter.add() validation passed');
 
-    // Return pending attachment while processing
-    return {
+    const attachment: PendingAttachment = {
       id: generateUUID(),
       type: "image",
       name: this.sanitizeFileName(file.name),
@@ -716,24 +804,30 @@ export class VisionImageAdapter implements AttachmentAdapter {
         progress: 0
       },
     };
+
+    // Start the repository upload now rather than at send time.
+    this.startBackgroundUpload(attachment.id, file);
+
+    return attachment;
   }
 
   async send(attachment: PendingAttachment): Promise<CompleteAttachment> {
     // Convert image to base64 data URL
     const base64 = await this.fileToBase64DataURL(attachment.file);
-    let repositoryMarker: string | null = null;
 
-    if (this.options.repositoryBacked) {
-      const repositoryUpload = await uploadTemporaryAttachment({
-        file: attachment.file,
-        draftKey: generateUUID(),
-        purpose: "nexus",
-        conversationId: this.options.getConversationId?.() ?? undefined,
+    // Normally already resolved — add() kicked this off when the file was picked.
+    // The fallback covers an attachment that reached send() without going through
+    // this adapter's add() (restored draft, adapter swap mid-composition).
+    const pending = this.uploadPromises.get(attachment.id);
+    this.uploadPromises.delete(attachment.id);
+    if (!pending) {
+      log.info('No background image upload found — uploading synchronously', {
+        attachmentId: attachment.id,
+        fileName: attachment.name,
       });
-      if (repositoryUpload.mode === "canonical") {
-        repositoryMarker = await waitForTemporaryAttachment(repositoryUpload);
-      }
     }
+    // `??` short-circuits, so the synchronous upload only runs without a pending one.
+    const repositoryMarker = await (pending ?? this.uploadToRepository(attachment.file));
 
     log.info('VisionImageAdapter.send() called', {
       attachmentId: attachment.id,
@@ -764,8 +858,11 @@ export class VisionImageAdapter implements AttachmentAdapter {
   }
 
 
-  async remove(_attachment: PendingAttachment): Promise<void> {
-    // Cleanup if needed (e.g., revoke object URLs if you created any)
+  async remove(attachment: PendingAttachment): Promise<void> {
+    // Drop the in-flight upload's entry so a long composing session that adds and
+    // removes images repeatedly does not retain every File through its promise.
+    // The request itself is already detached (see startBackgroundUpload).
+    this.uploadPromises.delete(attachment.id);
   }
 
   private async fileToBase64DataURL(file: File): Promise<string> {

--- a/lib/streaming/__tests__/model-capability-coverage.test.ts
+++ b/lib/streaming/__tests__/model-capability-coverage.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Guards the model-capability tables against the failure that produced empty
+ * Nexus answers in production.
+ *
+ * `getAdaptiveTimeout` derives a stream's wall-clock budget from the capability
+ * entry a provider adapter returns for a model ID. Those entries are matched by
+ * hard-coded glob patterns, and the patterns had fallen a full generation behind
+ * the model catalogue: `gemini-3-flash-preview`, `us.anthropic.claude-sonnet-4-6`
+ * and `us.anthropic.claude-opus-4-6-v1` matched nothing, fell through to
+ * `getDefaultCapabilities()`, and inherited a 30s abort. A Nexus turn that
+ * searched an attachment then tried to write a long answer was cut off at
+ * exactly 30s with `textLength: 0`.
+ *
+ * Two things are asserted here:
+ *   1. Current production model IDs resolve to a workable budget.
+ *   2. The DEFAULT entry is itself workable — pattern tables will always lag the
+ *      catalogue, so the fallback has to fail safe rather than fail tight.
+ *
+ * @see ../provider-adapters/claude-adapter.ts
+ * @see ../provider-adapters/gemini-adapter.ts
+ * @see ../unified-streaming-service.ts (getAdaptiveTimeout)
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { ClaudeAdapter } from '../provider-adapters/claude-adapter';
+import { GeminiAdapter } from '../provider-adapters/gemini-adapter';
+import { OpenAIAdapter } from '../provider-adapters/openai-adapter';
+
+/**
+ * Shortest budget in which a model can realistically produce a long answer —
+ * a multi-paragraph schedule, a document summary. The prod incident aborted at
+ * 30s, so anything at or below that is a regression of this exact bug.
+ */
+const MIN_WORKABLE_TIMEOUT_MS = 60_000;
+
+const claude = new ClaudeAdapter();
+const gemini = new GeminiAdapter();
+const openai = new OpenAIAdapter();
+
+/**
+ * Model IDs the production router actually selects, observed in the
+ * /ecs/aistudio-prod logs. Add to this list when a model is added to the
+ * catalogue — a new entry failing here means its capabilities are unmapped.
+ */
+const PRODUCTION_MODELS: ReadonlyArray<{
+  label: string;
+  modelId: string;
+  adapter: { getCapabilities(modelId: string): { maxTimeoutMs: number } };
+}> = [
+  { label: 'Claude Sonnet 4.6 (Bedrock)', modelId: 'us.anthropic.claude-sonnet-4-6', adapter: claude },
+  { label: 'Claude Opus 4.6 (Bedrock)', modelId: 'us.anthropic.claude-opus-4-6-v1', adapter: claude },
+  { label: 'Claude Sonnet 5', modelId: 'anthropic.claude-sonnet-5', adapter: claude },
+  { label: 'Claude Haiku 4.5', modelId: 'claude-haiku-4.5', adapter: claude },
+  { label: 'Gemini 3 Flash', modelId: 'gemini-3-flash-preview', adapter: gemini },
+  { label: 'Gemini 3 Pro', modelId: 'gemini-3-pro-preview', adapter: gemini },
+  { label: 'Gemini 3.1 Pro', modelId: 'gemini-3.1-pro-preview', adapter: gemini },
+  { label: 'GPT-5', modelId: 'gpt-5', adapter: openai },
+];
+
+describe('model capability coverage', () => {
+  describe.each(PRODUCTION_MODELS)('$label', ({ modelId, adapter }) => {
+    it('resolves a budget long enough to finish a long answer', () => {
+      expect(adapter.getCapabilities(modelId).maxTimeoutMs).toBeGreaterThanOrEqual(
+        MIN_WORKABLE_TIMEOUT_MS
+      );
+    });
+  });
+
+  it('gives an UNRECOGNISED model a workable budget, not the tightest one', () => {
+    // Reaching the default means the model is newer than the pattern table, not
+    // smaller — and new models are the ones most likely to write long answers.
+    for (const adapter of [claude, gemini, openai]) {
+      expect(
+        adapter.getCapabilities('some-model-released-after-this-test-was-written')
+          .maxTimeoutMs
+      ).toBeGreaterThanOrEqual(MIN_WORKABLE_TIMEOUT_MS);
+    }
+  });
+});
+
+describe('capability pattern precedence', () => {
+  it('does not let family-first Claude patterns swallow legacy version-first IDs', () => {
+    // Legacy IDs put the version BEFORE the family (claude-3-5-haiku-*), so they
+    // must keep resolving to their own entries rather than the Claude 4.x one.
+    const legacyHaiku = claude.getCapabilities('us.anthropic.claude-3-5-haiku-20241022-v1');
+    expect(legacyHaiku.supportsThinking).toBe(false);
+
+    const legacySonnet = claude.getCapabilities('anthropic.claude-3-5-sonnet-20241022-v2');
+    expect(legacySonnet.supportsThinking).toBe(false);
+
+    const claude3Opus = claude.getCapabilities('anthropic.claude-3-opus-20240229-v1');
+    expect(claude3Opus.supportsReasoning).toBe(false);
+  });
+
+  it('does not let the Gemini 3 pattern swallow Gemini 2.5 or 1.5', () => {
+    expect(gemini.getCapabilities('gemini-2.5-flash').maxTimeoutMs).toBe(90000);
+    expect(gemini.getCapabilities('gemini-1.5-flash-latest').maxTimeoutMs).toBe(30000);
+  });
+
+  it('distinguishes Claude families for cost estimation', () => {
+    const opus = claude.getCapabilities('us.anthropic.claude-opus-4-6-v1');
+    const sonnet = claude.getCapabilities('us.anthropic.claude-sonnet-4-6');
+    const haiku = claude.getCapabilities('claude-haiku-4.5');
+
+    expect(opus.costPerOutputToken).toBeGreaterThan(sonnet.costPerOutputToken!);
+    expect(sonnet.costPerOutputToken).toBeGreaterThan(haiku.costPerOutputToken!);
+  });
+});

--- a/lib/streaming/__tests__/model-capability-coverage.test.ts
+++ b/lib/streaming/__tests__/model-capability-coverage.test.ts
@@ -25,6 +25,8 @@ import { describe, it, expect } from '@jest/globals';
 import { ClaudeAdapter } from '../provider-adapters/claude-adapter';
 import { GeminiAdapter } from '../provider-adapters/gemini-adapter';
 import { OpenAIAdapter } from '../provider-adapters/openai-adapter';
+import type { ProviderCapabilities } from '../types';
+import { resolveStreamTimeout } from '../unified-streaming-service';
 
 /**
  * Shortest budget in which a model can realistically produce a long answer —
@@ -45,7 +47,7 @@ const openai = new OpenAIAdapter();
 const PRODUCTION_MODELS: ReadonlyArray<{
   label: string;
   modelId: string;
-  adapter: { getCapabilities(modelId: string): { maxTimeoutMs: number } };
+  adapter: { getCapabilities(modelId: string): ProviderCapabilities };
 }> = [
   { label: 'Claude Sonnet 4.6 (Bedrock)', modelId: 'us.anthropic.claude-sonnet-4-6', adapter: claude },
   { label: 'Claude Opus 4.6 (Bedrock)', modelId: 'us.anthropic.claude-opus-4-6-v1', adapter: claude },
@@ -78,6 +80,43 @@ describe('model capability coverage', () => {
   });
 });
 
+describe('declared budget is the one actually used', () => {
+  // The first version of this suite only asserted `>= 60_000`, which a HALF-fixed
+  // getAdaptiveTimeout passed: it honoured maxTimeoutMs for non-reasoning models
+  // but let a ladder of hard-coded conditionals override it for reasoning ones,
+  // so a declared 180s silently became 120s (Claude 4.x) or 60s (Gemini 3).
+  //
+  // This calls the REAL resolveStreamTimeout rather than restating the ladder —
+  // a test that reimplements the rule it checks cannot catch the rule being wrong.
+  // (PR #1686 review.)
+
+  it.each(PRODUCTION_MODELS)('$label uses its declared budget verbatim', ({ modelId, adapter }) => {
+    const caps = adapter.getCapabilities(modelId);
+    expect(resolveStreamTimeout(caps)).toBe(caps.maxTimeoutMs);
+  });
+});
+
+describe('advertised capabilities match actual behaviour', () => {
+  // supportsThinking is served to the browser by /api/models/capabilities and
+  // scores model selection in nexus-provider-factory. Advertising it while the
+  // adapter's private gate never attaches thinking config to the Bedrock request
+  // would show a toggle that does nothing and bias routing. (PR #1686 review.)
+  const thinkingGate = (modelId: string): boolean =>
+    [/^claude-4/i, /^anthropic\.claude-4/i].some(re =>
+      re.test(modelId) || re.test(modelId.replace(/^us\./, ''))
+    );
+
+  it.each([
+    'us.anthropic.claude-sonnet-4-6',
+    'us.anthropic.claude-opus-4-6-v1',
+    'anthropic.claude-sonnet-5',
+    'claude-haiku-4.5',
+    'us.anthropic.claude-3-5-haiku-20241022-v1',
+  ])('%s advertises supportsThinking only when the gate would fire', modelId => {
+    expect(claude.getCapabilities(modelId).supportsThinking).toBe(thinkingGate(modelId));
+  });
+});
+
 describe('capability pattern precedence', () => {
   it('does not let family-first Claude patterns swallow legacy version-first IDs', () => {
     // Legacy IDs put the version BEFORE the family (claude-3-5-haiku-*), so they
@@ -104,5 +143,46 @@ describe('capability pattern precedence', () => {
 
     expect(opus.costPerOutputToken).toBeGreaterThan(sonnet.costPerOutputToken!);
     expect(sonnet.costPerOutputToken).toBeGreaterThan(haiku.costPerOutputToken!);
+  });
+});
+
+describe('resolveStreamTimeout precedence', () => {
+  const caps = (over: Partial<ProviderCapabilities> = {}): ProviderCapabilities =>
+    ({
+      supportsReasoning: false,
+      supportsThinking: false,
+      supportedResponseModes: ['standard'],
+      supportsBackgroundMode: false,
+      supportedTools: [],
+      typicalLatencyMs: 1000,
+      maxTimeoutMs: 90_000,
+      ...over,
+    }) as ProviderCapabilities;
+
+  it('lets an explicit caller timeout win over the table (agentic per-run limit)', () => {
+    expect(resolveStreamTimeout(caps({ maxTimeoutMs: 90_000 }), 15_000)).toBe(15_000);
+  });
+
+  it('ignores a non-positive or non-finite caller timeout', () => {
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(resolveStreamTimeout(caps(), bad)).toBe(90_000);
+    }
+  });
+
+  it('prefers the declared budget over the reasoning heuristics', () => {
+    // The bug this guards: a reasoning model's declared 180s was overridden to
+    // 120s (thinking) or 60s (not thinking) by the old conditional ladder.
+    expect(
+      resolveStreamTimeout(caps({ supportsReasoning: true, supportsThinking: true, maxTimeoutMs: 180_000 }))
+    ).toBe(180_000);
+    expect(
+      resolveStreamTimeout(caps({ supportsReasoning: true, supportsThinking: false, maxTimeoutMs: 180_000 }))
+    ).toBe(180_000);
+  });
+
+  it('falls back to the heuristics only when no budget is declared', () => {
+    expect(resolveStreamTimeout(caps({ supportsReasoning: true, supportsThinking: true, maxTimeoutMs: 0 }))).toBe(120_000);
+    expect(resolveStreamTimeout(caps({ supportsReasoning: true, supportsThinking: false, maxTimeoutMs: 0 }))).toBe(60_000);
+    expect(resolveStreamTimeout(caps({ maxTimeoutMs: 0 }))).toBe(120_000);
   });
 });

--- a/lib/streaming/__tests__/sse-equivalence.test.ts
+++ b/lib/streaming/__tests__/sse-equivalence.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment node
+ *
+ * Proves the passthrough transform that `buildAbortAwareResponse` wraps the chunk
+ * stream in emits byte-identical SSE to an unwrapped stream — i.e. a NON-aborted
+ * run (the overwhelmingly common case) is unaffected by appending the abort path.
+ *
+ * Scope: this asserts the transform/encoding equivalence, not the method itself;
+ * `buildAbortAwareResponse` is exercised directly in stream-deadline.test.ts.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { createUIMessageStreamResponse } from 'ai';
+
+function chunkStream(chunks: unknown[]) {
+  return new ReadableStream({
+    start(c) { for (const x of chunks) c.enqueue(x); c.close(); },
+  });
+}
+
+describe('SSE equivalence', () => {
+  const chunks = [
+    { type: 'start' },
+    { type: 'text-start', id: 't' },
+    { type: 'text-delta', id: 't', delta: 'hello' },
+    { type: 'text-end', id: 't' },
+    { type: 'finish' },
+  ];
+
+  it('passthrough transform does not alter the SSE bytes', async () => {
+    const direct = await createUIMessageStreamResponse({
+      stream: chunkStream(chunks) as never,
+    }).text();
+
+    const piped = await createUIMessageStreamResponse({
+      stream: chunkStream(chunks).pipeThrough(
+        new TransformStream({
+          transform(chunk, controller) { controller.enqueue(chunk); },
+          flush() { /* not aborted → append nothing */ },
+        })
+      ) as never,
+    }).text();
+
+    expect(piped).toBe(direct);
+    expect(piped).toContain('data: [DONE]');
+  });
+});

--- a/lib/streaming/__tests__/stream-deadline.test.ts
+++ b/lib/streaming/__tests__/stream-deadline.test.ts
@@ -267,6 +267,24 @@ describe('buildAbortAwareResponse', () => {
     expect(chunks.some(c => c.type === 'error')).toBe(false);
   });
 
+  it('stays silent for a turn that rendered only a file, a source, or a data part', async () => {
+    // Text and tool chunks are not the only things the thread renders. Calling
+    // one of these turns "empty" would tell someone their visible answer wasn't
+    // there, so the check errs towards "visible". (PR #1686 review.)
+    const rendered: Array<Record<string, unknown>> = [
+      { type: 'file', url: 'https://example.test/a.png', mediaType: 'image/png' },
+      { type: 'source-url', sourceId: 's1', url: 'https://example.test' },
+      { type: 'data-schedule', data: { rows: 1 } },
+    ];
+
+    for (const part of rendered) {
+      const chunks = await readChunks(
+        responder.respond([{ type: 'start' }, part, { type: 'finish' }], false, false)
+      );
+      expect(chunks.some(c => c.type === 'error')).toBe(false);
+    }
+  });
+
   it('leaves already-streamed content intact and only appends', async () => {
     const chunks = await readChunks(responder.respond(okChunks, true, true));
     // Everything the model produced still arrives, in order, ahead of the notice.

--- a/lib/streaming/__tests__/stream-deadline.test.ts
+++ b/lib/streaming/__tests__/stream-deadline.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the step-aware stream wall-clock budget.
+ *
+ * Runs in the node environment: `buildAbortAwareResponse` pipes through a
+ * `TransformStream`, and jsdom's `ReadableStream` is a different class from the
+ * one Node's `TransformStream` accepts ("transform.readable must be an instance
+ * of ReadableStream"). Production runs on the Node globals, so node is the
+ * faithful environment here.
+ *
+ * The previous implementation was a plain `AbortSignal.timeout(timeoutMs)` over
+ * the whole `streamText` call. That clock covered tool execution as well as model
+ * calls, so with multi-step tool use a slow tool silently spent the model's time
+ * to answer. In production a Nexus attachment turn called a retrieval tool that
+ * returned at +7s, and the run was aborted at exactly +30s having produced no
+ * text at all.
+ *
+ * `buildStreamDeadline` gives each step its own budget, pushed forward at every
+ * step boundary, with an absolute ceiling still bounding a runaway loop.
+ *
+ * @see ../provider-adapters/base-adapter.ts
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { BaseProviderAdapter, type StreamDeadline } from '../provider-adapters/base-adapter';
+import { createLogger } from '@/lib/logger';
+
+/** Minimal concrete adapter exposing the protected budget builder. */
+class TestAdapter extends BaseProviderAdapter {
+  protected providerName = 'test';
+  async createModel(): Promise<never> {
+    throw new Error('not used — these tests never stream');
+  }
+  getCapabilities() {
+    return this.getDefaultCapabilities();
+  }
+  getSupportedTools(): string[] {
+    return [];
+  }
+  supportsModel() {
+    return true;
+  }
+  build(timeoutMs: number | undefined, maxSteps?: number): StreamDeadline {
+    return this.buildStreamDeadline(timeoutMs, maxSteps, createLogger({ module: 'test' }));
+  }
+}
+
+const adapter = new TestAdapter();
+
+describe('buildStreamDeadline', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('is inert when no timeout is configured', () => {
+    for (const value of [undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const deadline = adapter.build(value as number | undefined);
+      expect(deadline.signal).toBeUndefined();
+      expect(deadline.timedOut()).toBe(false);
+      // extend()/dispose() must be safe to call on the inert handle.
+      deadline.extend();
+      deadline.dispose();
+    }
+  });
+
+  it('aborts a single-step run once its budget elapses', () => {
+    const deadline = adapter.build(30_000);
+    expect(deadline.signal?.aborted).toBe(false);
+
+    jest.advanceTimersByTime(29_999);
+    expect(deadline.signal?.aborted).toBe(false);
+    expect(deadline.timedOut()).toBe(false);
+
+    jest.advanceTimersByTime(2);
+    expect(deadline.signal?.aborted).toBe(true);
+    expect(deadline.timedOut()).toBe(true);
+
+    deadline.dispose();
+  });
+
+  it('does NOT charge tool-execution time to the next step — the prod bug', () => {
+    // Reproduces the incident's shape: a 30s budget, a tool round-trip that
+    // finishes at +7s, then the model writing its answer. Under the old
+    // single-clock behaviour the answer was cut off 23s later at exactly +30s.
+    const deadline = adapter.build(30_000, 10);
+
+    jest.advanceTimersByTime(7_000); // tool call + tool execution
+    deadline.extend(); // step boundary
+
+    // The old clock would fire here (T0+30s). The step-aware one must not.
+    jest.advanceTimersByTime(23_001);
+    expect(deadline.signal?.aborted).toBe(false);
+    expect(deadline.timedOut()).toBe(false);
+
+    // The answering step still gets its own full 30s from the boundary at T0+7s,
+    // so the budget now runs to T0+37s rather than T0+30s.
+    jest.advanceTimersByTime(6_998); // T0+36_999
+    expect(deadline.signal?.aborted).toBe(false);
+
+    jest.advanceTimersByTime(2); // T0+37_001
+    expect(deadline.signal?.aborted).toBe(true);
+
+    deadline.dispose();
+  });
+
+  it('still bounds a runaway loop at timeout x maxSteps', () => {
+    const deadline = adapter.build(10_000, 3); // ceiling 30s
+
+    // A loop that keeps producing step boundaries cannot extend forever.
+    for (let i = 0; i < 10; i += 1) {
+      jest.advanceTimersByTime(5_000);
+      deadline.extend();
+    }
+
+    expect(deadline.signal?.aborted).toBe(true);
+    expect(deadline.timedOut()).toBe(true);
+    deadline.dispose();
+  });
+
+  it('caps the ceiling regardless of how large maxSteps is', () => {
+    const deadline = adapter.build(120_000, 1000); // would be 120000s uncapped
+
+    // ABSOLUTE_STREAM_CEILING_MS is 10 minutes.
+    for (let i = 0; i < 200; i += 1) {
+      jest.advanceTimersByTime(60_000);
+      deadline.extend();
+    }
+    expect(deadline.signal?.aborted).toBe(true);
+    deadline.dispose();
+  });
+
+  it('ignores extend() after it has already fired', () => {
+    const deadline = adapter.build(1_000);
+    jest.advanceTimersByTime(1_001);
+    expect(deadline.timedOut()).toBe(true);
+
+    deadline.extend();
+    jest.advanceTimersByTime(10_000);
+    // Still aborted — a late step boundary must not resurrect the run.
+    expect(deadline.signal?.aborted).toBe(true);
+    expect(deadline.timedOut()).toBe(true);
+    deadline.dispose();
+  });
+
+  it('stops the timer on dispose so a finished stream leaves nothing pending', () => {
+    const deadline = adapter.build(5_000);
+    deadline.dispose();
+    jest.advanceTimersByTime(60_000);
+    expect(deadline.signal?.aborted).toBe(false);
+    expect(deadline.timedOut()).toBe(false);
+    // Repeated dispose is safe.
+    deadline.dispose();
+  });
+
+  it('carries an explanatory abort reason', () => {
+    const deadline = adapter.build(1_000);
+    jest.advanceTimersByTime(1_001);
+    expect(String((deadline.signal as AbortSignal).reason)).toContain('budget');
+    deadline.dispose();
+  });
+});
+
+/**
+ * An aborted run must become VISIBLE to the person watching the thread.
+ *
+ * ai@6.0.208 enqueues an `abort` UI chunk on abort but raises no client-side
+ * error, so the browser just sees the stream stop — the "it died mid-response"
+ * symptom. An `error` chunk DOES reach the client and renders through
+ * `MessagePrimitive.Error`, so the adapter appends one when the run was cut short.
+ */
+describe('buildAbortAwareResponse', () => {
+  class ResponseAdapter extends TestAdapter {
+    build(): StreamDeadline {
+      throw new Error('unused in this suite');
+    }
+    respond(chunks: unknown[], aborted: boolean, timedOut: boolean): Response {
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const c of chunks) controller.enqueue(c);
+          controller.close();
+        },
+      });
+      return this.buildAbortAwareResponse(
+        {
+          toUIMessageStream: () => stream as ReadableStream<never>,
+          toTextStreamResponse: () => new Response('unused'),
+        },
+        () => aborted,
+        () => timedOut
+      );
+    }
+  }
+
+  const responder = new ResponseAdapter();
+  const okChunks = [
+    { type: 'start' },
+    { type: 'text-delta', id: 't', delta: 'Here is the schedule.' },
+    { type: 'finish' },
+  ];
+
+  /** Decode the SSE body back into UI message chunks. */
+  async function readChunks(res: Response): Promise<Array<Record<string, unknown>>> {
+    const body = await res.text();
+    return body
+      .split('\n\n')
+      .map(frame => frame.replace(/^data: /, '').trim())
+      .filter(payload => payload.length > 0 && payload !== '[DONE]')
+      .map(payload => JSON.parse(payload) as Record<string, unknown>);
+  }
+
+  it('adds nothing to a run that completed normally', async () => {
+    const chunks = await readChunks(responder.respond(okChunks, false, false));
+    expect(chunks.some(c => c.type === 'error')).toBe(false);
+    expect(chunks.map(c => c.type)).toEqual(['start', 'text-delta', 'finish']);
+  });
+
+  it('appends a terminal error chunk explaining a timed-out run', async () => {
+    const chunks = await readChunks(responder.respond(okChunks, true, true));
+    const error = chunks.at(-1) as { type: string; errorText: string };
+
+    expect(error.type).toBe('error');
+    // The client renders errorText verbatim, so it must read as an explanation,
+    // not a stack trace or an error code.
+    expect(error.errorText).toContain('cut off');
+    expect(error.errorText).toContain('ran out of time');
+  });
+
+  it('distinguishes an interruption from a timeout', async () => {
+    const chunks = await readChunks(responder.respond(okChunks, true, false));
+    const error = chunks.at(-1) as { type: string; errorText: string };
+
+    expect(error.type).toBe('error');
+    expect(error.errorText).toContain('interrupted');
+    expect(error.errorText).not.toContain('ran out of time');
+  });
+
+  it('leaves already-streamed content intact and only appends', async () => {
+    const chunks = await readChunks(responder.respond(okChunks, true, true));
+    // Everything the model produced still arrives, in order, ahead of the notice.
+    expect(chunks.slice(0, 3).map(c => c.type)).toEqual(['start', 'text-delta', 'finish']);
+    expect(chunks).toHaveLength(4);
+  });
+});

--- a/lib/streaming/__tests__/stream-deadline.test.ts
+++ b/lib/streaming/__tests__/stream-deadline.test.ts
@@ -239,6 +239,34 @@ describe('buildAbortAwareResponse', () => {
     expect(error.errorText).not.toContain('ran out of time');
   });
 
+  it('explains an empty response even when the run was NOT aborted', async () => {
+    // A run that ends cleanly having emitted nothing is still a dead end: the
+    // route refuses to persist it, so without a notice the stream would simply
+    // stop and reload as though the turn never happened. (PR #1686 review.)
+    const chunks = await readChunks(
+      responder.respond([{ type: 'start' }, { type: 'finish' }], false, false)
+    );
+    const last = chunks.at(-1) as { type: string; errorText: string };
+    expect(last.type).toBe('error');
+    expect(last.errorText).toContain('empty response');
+  });
+
+  it('stays silent for a tool-only turn, which the thread still renders', async () => {
+    const chunks = await readChunks(
+      responder.respond(
+        [
+          { type: 'start' },
+          { type: 'tool-input-start', toolCallId: 'c1', toolName: 'searchNexusAttachments' },
+          { type: 'tool-output-available', toolCallId: 'c1', output: { ok: true } },
+          { type: 'finish' },
+        ],
+        false,
+        false
+      )
+    );
+    expect(chunks.some(c => c.type === 'error')).toBe(false);
+  });
+
   it('leaves already-streamed content intact and only appends', async () => {
     const chunks = await readChunks(responder.respond(okChunks, true, true));
     // Everything the model produced still arrives, in order, ahead of the notice.

--- a/lib/streaming/provider-adapters/base-adapter.ts
+++ b/lib/streaming/provider-adapters/base-adapter.ts
@@ -594,6 +594,15 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
    * own — tool activity (`tool-input-start`, `tool-output-available`, … — MCP
    * tools stream through these same types with a `dynamic` flag), generated
    * files, retrieved sources, and custom `data-*` parts. (PR #1686 review.)
+   *
+   * Paired with `incompleteTurnReason` (`app/api/nexus/chat/chat-helpers.ts`),
+   * which decides whether the turn is persisted from text and step history
+   * alone. The two answer different questions and are allowed to disagree, but
+   * a turn this method calls visible while that one calls `no_content` renders
+   * and then vanishes on reload with nothing said. No such turn is reachable
+   * today (Nexus streams generated images through `image-generation-handler`,
+   * not this path, and no `data-*` part is emitted through an adapter), so if a
+   * chunk type is ever added on one side, check the other.
    */
   protected static isVisibleChunkType(type: string): boolean {
     return (

--- a/lib/streaming/provider-adapters/base-adapter.ts
+++ b/lib/streaming/provider-adapters/base-adapter.ts
@@ -617,9 +617,18 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
         : result.toTextStreamResponse(options);
     }
 
+    // Track whether the turn produced anything the user can actually see. A
+    // tool-only turn still renders (the thread shows tool output), so only a
+    // stream with neither text nor tool activity is genuinely blank.
+    let producedVisibleOutput = false;
+
     const stream = result.toUIMessageStream().pipeThrough(
       new TransformStream<UIMessageChunk, UIMessageChunk>({
         transform(chunk, controller) {
+          const type = (chunk as { type?: string }).type ?? '';
+          if (type === 'text-delta' || type.startsWith('tool-') || type === 'reasoning-delta') {
+            producedVisibleOutput = true;
+          }
           controller.enqueue(chunk);
         },
         flush(controller) {
@@ -627,6 +636,18 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
             controller.enqueue({
               type: 'error',
               errorText: BaseProviderAdapter.abortNotice(didTimeOut()),
+            });
+            return;
+          }
+          // A run that ended cleanly having emitted nothing at all is still a
+          // dead end for the user: the route now refuses to persist it, so
+          // without this the stream would simply stop and reload as if the turn
+          // never happened. Say so instead. (PR #1686 review.)
+          if (!producedVisibleOutput) {
+            controller.enqueue({
+              type: 'error',
+              errorText:
+                'The model returned an empty response. Please try again, or rephrase your request.',
             });
           }
         },

--- a/lib/streaming/provider-adapters/base-adapter.ts
+++ b/lib/streaming/provider-adapters/base-adapter.ts
@@ -1,4 +1,12 @@
-import { streamText, stepCountIs, type LanguageModel, type ModelMessage, type ToolSet } from 'ai';
+import {
+  streamText,
+  stepCountIs,
+  createUIMessageStreamResponse,
+  type LanguageModel,
+  type ModelMessage,
+  type ToolSet,
+  type UIMessageChunk
+} from 'ai';
 import { createLogger } from '@/lib/logger';
 import { createUniversalTools } from '@/lib/tools/provider-native-tools';
 import type {
@@ -23,6 +31,45 @@ type CostStopPredicate = (opts: {
 
 /** A single AI SDK `stopWhen` condition: a step-count guard or a cost predicate. */
 type StopCondition = ReturnType<typeof stepCountIs> | CostStopPredicate;
+
+/**
+ * Hard ceiling for any single streaming run, regardless of per-step budget and
+ * step count. Bounds a wedged model/tool loop that keeps producing step
+ * boundaries; the route/platform ceiling (`maxDuration`) is the backstop above it.
+ */
+const ABSOLUTE_STREAM_CEILING_MS = 600_000; // 10 minutes
+
+/**
+ * A step-aware wall-clock budget for one streaming run.
+ *
+ * A plain `AbortSignal.timeout()` bounds the ENTIRE `streamText` call — every
+ * model call AND every tool execution — against one fixed clock. With multi-step
+ * tool use that is actively wrong: a retrieval tool that takes 7s silently steals
+ * 7s from the model's budget to write the answer. In prod this aborted a Nexus
+ * attachment turn at exactly 30s with `textLength: 0` — the tool returned at +7s
+ * and the model never got enough clock to produce a token.
+ *
+ * This grants each step its own `stepBudgetMs`, pushed forward at every step
+ * boundary, while an absolute ceiling still bounds a runaway loop.
+ */
+export interface StreamDeadline {
+  /** Abort signal for `streamText`; undefined when no budget is configured. */
+  readonly signal?: AbortSignal;
+  /** Push the per-step clock forward. Call at each step boundary. */
+  extend(): void;
+  /** True once THIS deadline aborted the run (vs. a caller-initiated abort). */
+  timedOut(): boolean;
+  /** Release the timer. Safe to call more than once. */
+  dispose(): void;
+}
+
+/** Shared handle for "no timeout configured" — nothing to arm or release. */
+const NO_STREAM_DEADLINE: StreamDeadline = {
+  signal: undefined,
+  extend: () => {},
+  timedOut: () => false,
+  dispose: () => {},
+};
 
 /**
  * Standalone transient error classifier used by both the streaming adapters
@@ -260,6 +307,9 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
       maxSteps: config.maxSteps || 'not set'
     });
     
+    // Hoisted so a synchronous streamText failure still releases the timer.
+    let deadline: StreamDeadline = NO_STREAM_DEADLINE;
+
     try {
       // Create enhanced configuration
       const enhancedConfig = this.enhanceStreamConfig(config);
@@ -273,7 +323,19 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
       // accumulated usage cost reaches the per-run cap. AI SDK `stopWhen` accepts
       // an array — ANY condition stops the loop.
       const stopConditions = this.buildStopConditions(enhancedConfig, logger);
-      const abortSignal = this.buildTimeoutSignal(enhancedConfig.timeout, logger); // #926
+      deadline = this.buildStreamDeadline( // #926
+        enhancedConfig.timeout,
+        enhancedConfig.maxSteps,
+        logger
+      );
+      const abortSignal = deadline.signal;
+
+      // Set when the run is cut short (budget exhausted or caller abort) so
+      // onFinish can tell a completed answer from a truncated one. AI SDK v6
+      // still fires onFinish after an abort, carrying only the steps that had
+      // already completed — persisting that as-is is what wrote empty assistant
+      // messages to prod conversations.
+      let streamAborted = false;
 
       // Start streaming with AI SDK
       const result = streamText({
@@ -295,6 +357,11 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
         }),
         // Capture tool calls as each step finishes (AI SDK v6)
         onStepFinish: (event) => {
+          // Reaching a step boundary buys the next step a fresh budget, so the
+          // time a tool spent executing is not deducted from the model's time to
+          // write the answer.
+          deadline.extend();
+
           logger.info('onStepFinish called', {
             provider: this.providerName,
             hasToolCalls: !!event.toolCalls,
@@ -305,25 +372,7 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
           });
 
           // Capture tool calls
-          if (event.toolCalls && Array.isArray(event.toolCalls)) {
-            for (const tc of event.toolCalls) {
-              // AI SDK v6 uses "input" for tool arguments, not "args"
-              const toolCall = tc as { toolCallId: string; toolName: string; args?: unknown; input?: unknown };
-              const toolArgs = (toolCall.input || toolCall.args || {}) as Record<string, unknown>;
-
-              accumulatedToolCalls.push({
-                toolCallId: toolCall.toolCallId,
-                toolName: toolCall.toolName,
-                args: toolArgs
-              });
-              logger.debug('Tool call captured from step', {
-                provider: this.providerName,
-                toolCallId: toolCall.toolCallId,
-                toolName: toolCall.toolName,
-                hasArgs: Object.keys(toolArgs).length > 0
-              });
-            }
-          }
+          this.captureStepToolCalls(event.toolCalls, accumulatedToolCalls, logger);
 
           // NOTE: Tool results are NOT available in onStepFinish — AI SDK v4+ fires this
           // callback when the LLM call finishes, before tool execution completes.
@@ -331,6 +380,9 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
           // See: https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text#on-step-finish
         },
         onFinish: async (event) => {
+          deadline.dispose();
+          const aborted = streamAborted || deadline.timedOut();
+
           logger.info('streamText onFinish triggered', {
             provider: this.providerName,
             hasText: !!event.text,
@@ -338,32 +390,18 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
             finishReason: event.finishReason,
             textLength: event.text?.length || 0,
             toolCallCount: accumulatedToolCalls.length,
-            toolNames: accumulatedToolCalls.map(tc => tc.toolName)
+            toolNames: accumulatedToolCalls.map(tc => tc.toolName),
+            aborted
           });
 
           // Extract tool results from event.steps (shared method handles runtime validation)
           this.extractToolResultsFromSteps(event, accumulatedToolCalls, logger);
 
-          // Build per-step breakdown for multi-step tool-use persistence
-          // (transformFinishStep, Issue #977). AI SDK v6 TypeScript types don't
-          // declare `steps` on the onFinish event object, but the runtime value
-          // includes it for multi-step tool-use flows. Cast to access the field
-          // until the SDK's types are updated.
-          const rawSteps = (event as Record<string, unknown>).steps;
-          const steps = Array.isArray(rawSteps)
-            ? rawSteps.map(transformFinishStep)
-            : undefined;
-
-          const transformedData = {
-            text: event.text || '',
-            usage: transformFinishUsage(event.usage),
-            finishReason: event.finishReason || 'stop',
-            toolCalls: accumulatedToolCalls.length > 0 ? accumulatedToolCalls : undefined,
-            // Pass steps whenever any exist (not only > 1): a single-step agentic
-            // run that calls one tool still needs its step data so onFinish can
-            // count tool calls. `> 1` dropped single-step tool data. (Correctness review.)
-            steps: steps && steps.length > 0 ? steps : undefined,
-          };
+          const transformedData = this.buildFinishPayload(
+            event,
+            accumulatedToolCalls,
+            aborted
+          );
 
           // Call provider-specific finish handler
           await this.handleFinish(transformedData, callbacks);
@@ -378,17 +416,38 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
             await callbacks.onFinish(transformedData);
           }
         },
+        // An aborted run reaches NEITHER onError NOR onFinish's error path in AI
+        // SDK v6 — without this handler a wall-clock abort was silent server-side:
+        // no log, no metric, no onError, and onFinish then persisted the partial
+        // (often empty) result as if the turn had succeeded.
+        //
+        // NOTE (verified against ai@6.0.208): the SDK enqueues an `abort` UI part
+        // and sets its internal isAborted flag, but does NOT raise a client-side
+        // error, so the browser still just sees the stream stop. Making the cut-off
+        // visible in the UI needs a separate client-side change; this handler only
+        // guarantees the SERVER notices, records, and refuses to persist it.
+        onAbort: ({ steps }) => {
+          streamAborted = true;
+          this.reportStreamAbort({
+            deadline,
+            completedSteps: steps.length,
+            toolCallCount: accumulatedToolCalls.length,
+            callbacks,
+            logger
+          });
+        },
         onError: (event) => {
+          deadline.dispose();
           const error = event.error instanceof Error ? event.error : new Error(String(event.error));
-          
+
           logger.error('Stream error', {
             provider: this.providerName,
             error: error.message
           });
-          
+
           // Call provider-specific error handler
           this.handleError(error, callbacks);
-          
+
           // Call user's error callback
           if (callbacks.onError) {
             callbacks.onError(error);
@@ -399,15 +458,22 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
       // Handle streaming chunks for progress tracking
       this.handleStreamProgress(result, callbacks);
       
+      const buildResponse = (options?: { headers?: Record<string, string> }) =>
+        this.buildAbortAwareResponse(
+          result,
+          () => streamAborted || deadline.timedOut(),
+          () => deadline.timedOut(),
+          options
+        );
+
       return {
-        toDataStreamResponse: (options?: { headers?: Record<string, string> }) =>
-          result.toUIMessageStreamResponse ? result.toUIMessageStreamResponse(options) : result.toTextStreamResponse(options),
-        toUIMessageStreamResponse: (options?: { headers?: Record<string, string> }) =>
-          result.toUIMessageStreamResponse ? result.toUIMessageStreamResponse(options) : result.toTextStreamResponse(options),
+        toDataStreamResponse: buildResponse,
+        toUIMessageStreamResponse: buildResponse,
         usage: Promise.resolve(result.usage)
       };
-      
+
     } catch (error) {
+      deadline.dispose();
       logger.error('Failed to start stream', {
         provider: this.providerName,
         error: error instanceof Error ? error.message : String(error)
@@ -415,7 +481,7 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
       throw error;
     }
   }
-  
+
   /**
    * Validate if this adapter supports the given model
    * Must be implemented by each provider
@@ -448,25 +514,250 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
   }
 
   /**
-   * Build a wall-clock abort signal for the per-run timeout (#926). Without it the
-   * configured `timeout` was inert: a hung model/tool loop ran until the
-   * route/platform ceiling (up to 900s). `AbortSignal.timeout` aborts the whole
-   * streamText call (model calls + tool loop) once the limit elapses. Returns
-   * undefined when no positive, finite timeout is configured. Shared by all
-   * adapters (base + provider overrides) so every path enforces the timeout.
+   * Accumulate a step's tool calls. AI SDK v6 names tool arguments `input`;
+   * `args` is the pre-v6 name, kept as a fallback.
    */
-  protected buildTimeoutSignal(
-    timeoutMs: number | undefined,
+  protected captureStepToolCalls(
+    toolCalls: unknown,
+    accumulatedToolCalls: AccumulatedToolCall[],
     logger: ReturnType<typeof createLogger>
-  ): AbortSignal | undefined {
-    if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-      return undefined;
+  ): void {
+    if (!Array.isArray(toolCalls)) {
+      return;
     }
-    logger.debug('Applying stream wall-clock timeout', {
-      provider: this.providerName,
-      timeoutMs,
+    for (const tc of toolCalls) {
+      const toolCall = tc as { toolCallId: string; toolName: string; args?: unknown; input?: unknown };
+      const toolArgs = (toolCall.input || toolCall.args || {}) as Record<string, unknown>;
+
+      accumulatedToolCalls.push({
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        args: toolArgs
+      });
+      logger.debug('Tool call captured from step', {
+        provider: this.providerName,
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        hasArgs: Object.keys(toolArgs).length > 0
+      });
+    }
+  }
+
+  /**
+   * Shape the AI SDK finish event into the callback payload used across adapters.
+   *
+   * Per-step breakdown feeds multi-step tool-use persistence (transformFinishStep,
+   * Issue #977). AI SDK v6's TypeScript types don't declare `steps` on the finish
+   * event, but the runtime value carries it for multi-step flows — hence the cast,
+   * which can go once the SDK's types catch up.
+   */
+  protected buildFinishPayload(
+    event: { text?: string; usage?: unknown; finishReason?: string },
+    accumulatedToolCalls: AccumulatedToolCall[],
+    aborted: boolean
+  ) {
+    const rawSteps = (event as Record<string, unknown>).steps;
+    const steps = Array.isArray(rawSteps) ? rawSteps.map(transformFinishStep) : undefined;
+
+    return {
+      text: event.text || '',
+      usage: transformFinishUsage(event.usage as Parameters<typeof transformFinishUsage>[0]),
+      finishReason: event.finishReason || 'stop',
+      toolCalls: accumulatedToolCalls.length > 0 ? accumulatedToolCalls : undefined,
+      // Pass steps whenever any exist (not only > 1): a single-step agentic run
+      // that calls one tool still needs its step data so onFinish can count tool
+      // calls. `> 1` dropped single-step tool data. (Correctness review.)
+      steps: steps && steps.length > 0 ? steps : undefined,
+      // Truncated run — callers must not persist this as a completed turn.
+      aborted,
+    };
+  }
+
+  /**
+   * User-facing text for a run that ended early. Shared by the server-side error
+   * (`reportStreamAbort`) and the terminal chunk sent to the browser, so the log
+   * and the thread say the same thing.
+   */
+  protected static abortNotice(timedOut: boolean): string {
+    return timedOut
+      ? 'The response was cut off before it finished — the model ran out of time. Try asking again, or break the request into smaller parts.'
+      : 'The response was interrupted before it finished. Please try again.';
+  }
+
+  /**
+   * Build the HTTP response, appending a terminal `error` chunk when the run was
+   * cut short.
+   *
+   * Verified against ai@6.0.208: an abort enqueues an `abort` UI chunk and sets an
+   * internal flag, but raises NO client-side error — the browser simply sees the
+   * stream stop, which is exactly the "it just died mid-response" symptom users
+   * reported. An `error` chunk DOES reach the client (`onError(new
+   * Error(chunk.errorText))`), and the Thread renders it through
+   * `MessagePrimitive.Error`. Appending one on flush turns a silent truncation
+   * into a visible, explained one.
+   *
+   * The chunk is appended at end-of-stream, so it neither reorders nor rewrites
+   * any content the model already produced.
+   */
+  protected buildAbortAwareResponse(
+    result: {
+      toUIMessageStream?: () => ReadableStream<UIMessageChunk>;
+      toUIMessageStreamResponse?: (options?: { headers?: Record<string, string> }) => Response;
+      toTextStreamResponse: (options?: { headers?: Record<string, string> }) => Response;
+    },
+    wasAborted: () => boolean,
+    didTimeOut: () => boolean,
+    options?: { headers?: Record<string, string> }
+  ): Response {
+    // Providers without the UI-message stream (plain text responses) keep the
+    // previous behaviour — there is no chunk protocol to append to.
+    if (typeof result.toUIMessageStream !== 'function') {
+      return result.toUIMessageStreamResponse
+        ? result.toUIMessageStreamResponse(options)
+        : result.toTextStreamResponse(options);
+    }
+
+    const stream = result.toUIMessageStream().pipeThrough(
+      new TransformStream<UIMessageChunk, UIMessageChunk>({
+        transform(chunk, controller) {
+          controller.enqueue(chunk);
+        },
+        flush(controller) {
+          if (wasAborted()) {
+            controller.enqueue({
+              type: 'error',
+              errorText: BaseProviderAdapter.abortNotice(didTimeOut()),
+            });
+          }
+        },
+      })
+    );
+
+    return createUIMessageStreamResponse({
+      stream,
+      ...(options?.headers ? { headers: options.headers } : {}),
     });
-    return AbortSignal.timeout(timeoutMs);
+  }
+
+  /**
+   * Surface an aborted run: release the timer, log it, and raise a real error to
+   * the caller. Shared by every adapter so no path can abort silently again.
+   */
+  protected reportStreamAbort(input: {
+    deadline: StreamDeadline;
+    completedSteps: number;
+    toolCallCount: number;
+    callbacks: StreamingCallbacks;
+    logger: ReturnType<typeof createLogger>;
+  }): void {
+    const { deadline, completedSteps, toolCallCount, callbacks, logger } = input;
+    deadline.dispose();
+    const timedOut = deadline.timedOut();
+
+    const error = new Error(BaseProviderAdapter.abortNotice(timedOut));
+    logger.error('Stream aborted before completion', {
+      provider: this.providerName,
+      timedOut,
+      completedSteps,
+      toolCallCount
+    });
+
+    this.handleError(error, callbacks);
+    if (callbacks.onError) {
+      callbacks.onError(error);
+    }
+  }
+
+  /**
+   * Build the wall-clock budget for the per-run timeout (#926). Without it the
+   * configured `timeout` was inert: a hung model/tool loop ran until the
+   * route/platform ceiling (up to 900s).
+   *
+   * `timeoutMs` is the budget for a SINGLE step, not for the whole run: the clock
+   * is pushed forward each time a step boundary is reached (see `StreamDeadline`),
+   * so tool-execution time no longer eats the model's time to answer. The total
+   * run is still bounded by `timeoutMs × maxSteps`, capped at
+   * `ABSOLUTE_STREAM_CEILING_MS`. Single-step runs (no `maxSteps`) keep exactly
+   * the previous semantics.
+   *
+   * Returns a no-op handle when no positive, finite timeout is configured. Shared
+   * by all adapters (base + provider overrides) so every path enforces it.
+   */
+  protected buildStreamDeadline(
+    timeoutMs: number | undefined,
+    maxSteps: number | undefined,
+    logger: ReturnType<typeof createLogger>
+  ): StreamDeadline {
+    if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return NO_STREAM_DEADLINE;
+    }
+
+    const steps =
+      typeof maxSteps === 'number' && Number.isFinite(maxSteps) && maxSteps > 0
+        ? Math.floor(maxSteps)
+        : 1;
+    const ceilingMs = Math.min(timeoutMs * steps, ABSOLUTE_STREAM_CEILING_MS);
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    const hardStopAt = startedAt + ceilingMs;
+    let deadlineAt = startedAt + timeoutMs;
+    let expired = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    logger.debug('Applying stream wall-clock budget', {
+      provider: this.providerName,
+      stepBudgetMs: timeoutMs,
+      maxSteps: steps,
+      ceilingMs,
+    });
+
+    const clear = () => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    };
+
+    const arm = () => {
+      clear();
+      const firesAt = Math.min(deadlineAt, hardStopAt);
+      timer = setTimeout(() => {
+        timer = undefined;
+        // `deadlineAt` may have moved while this timer was pending (a step
+        // finished). Re-arm for the remainder rather than aborting early.
+        if (Date.now() < Math.min(deadlineAt, hardStopAt)) {
+          arm();
+          return;
+        }
+        expired = true;
+        logger.warn('Stream wall-clock budget exhausted — aborting run', {
+          provider: this.providerName,
+          stepBudgetMs: timeoutMs,
+          ceilingMs,
+          elapsedMs: Date.now() - startedAt,
+        });
+        controller.abort(
+          new Error(
+            `Stream exceeded its wall-clock budget (${Math.round(ceilingMs / 1000)}s)`
+          )
+        );
+      }, Math.max(0, firesAt - Date.now()));
+    };
+
+    arm();
+
+    return {
+      signal: controller.signal,
+      extend: () => {
+        if (expired) {
+          return;
+        }
+        deadlineAt = Date.now() + timeoutMs;
+        arm();
+      },
+      timedOut: () => expired,
+      dispose: clear,
+    };
   }
 
   /**
@@ -647,7 +938,13 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
       supportsBackgroundMode: false,
       supportedTools: [],
       typicalLatencyMs: 2000,
-      maxTimeoutMs: 30000
+      // Deliberately generous. Reaching this default means the model is NEWER
+      // than its provider's pattern table, not smaller — new models are the ones
+      // most likely to be slow, capable, and used for long answers. The old 30s
+      // here silently truncated every Claude 4.x / Gemini 3 / Nova response in
+      // Nexus. Pattern tables will always lag the model catalogue, so the
+      // fallback must fail safe.
+      maxTimeoutMs: 120000
     };
   }
   

--- a/lib/streaming/provider-adapters/base-adapter.ts
+++ b/lib/streaming/provider-adapters/base-adapter.ts
@@ -585,6 +585,28 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
   }
 
   /**
+   * Does this UI chunk type put something in front of the user?
+   *
+   * Used only to decide whether a cleanly-finished run was genuinely blank, so it
+   * errs towards "visible": a false positive merely withholds the empty-response
+   * notice, while a false negative tells someone their rendered answer was empty.
+   * Beyond text and reasoning it covers every part type the thread renders on its
+   * own — tool activity (`tool-input-start`, `tool-output-available`, … — MCP
+   * tools stream through these same types with a `dynamic` flag), generated
+   * files, retrieved sources, and custom `data-*` parts. (PR #1686 review.)
+   */
+  protected static isVisibleChunkType(type: string): boolean {
+    return (
+      type === 'text-delta' ||
+      type === 'reasoning-delta' ||
+      type === 'file' ||
+      type.startsWith('tool-') ||
+      type.startsWith('source-') ||
+      type.startsWith('data-')
+    );
+  }
+
+  /**
    * Build the HTTP response, appending a terminal `error` chunk when the run was
    * cut short.
    *
@@ -626,7 +648,7 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
       new TransformStream<UIMessageChunk, UIMessageChunk>({
         transform(chunk, controller) {
           const type = (chunk as { type?: string }).type ?? '';
-          if (type === 'text-delta' || type.startsWith('tool-') || type === 'reasoning-delta') {
+          if (BaseProviderAdapter.isVisibleChunkType(type)) {
             producedVisibleOutput = true;
           }
           controller.enqueue(chunk);

--- a/lib/streaming/provider-adapters/claude-adapter.ts
+++ b/lib/streaming/provider-adapters/claude-adapter.ts
@@ -108,8 +108,20 @@ export class ClaudeAdapter extends BaseProviderAdapter {
 
     return {
       supportsReasoning: true,
-      supportsThinking: true,
-      maxThinkingTokens: 6553,
+      // Deliberately false, and it must stay in lockstep with the private
+      // `supportsThinking()` gate below — that gate is what actually attaches
+      // thinking config to the Bedrock request, and it still matches only
+      // `claude-4*`. Advertising `true` here while the gate never fires would be
+      // a live lie: `supportsThinking` is served to the browser by
+      // /api/models/capabilities (driving UI affordances) and scores model
+      // selection in nexus-provider-factory, so the UI could offer an Extended
+      // Thinking toggle that does nothing and routing could prefer a model that
+      // never returns reasoning traces.
+      //
+      // Turning thinking ON for these models changes the Bedrock request payload
+      // for every Nexus turn, which is a behaviour change beyond this incident
+      // fix. Flip BOTH together in that follow-up. (PR #1686 review.)
+      supportsThinking: false,
       supportedResponseModes: ['standard'],
       supportsBackgroundMode: false,
       supportedTools: [],

--- a/lib/streaming/provider-adapters/claude-adapter.ts
+++ b/lib/streaming/provider-adapters/claude-adapter.ts
@@ -86,7 +86,52 @@ export class ClaudeAdapter extends BaseProviderAdapter {
     return [];
   }
 
+  /**
+   * Model IDs that put the family BEFORE the version (`claude-sonnet-4-6`,
+   * `claude-opus-4-6-v1`, `claude-haiku-4.5`, `claude-sonnet-5`), with or without
+   * an `anthropic.` / `us.anthropic.` Bedrock prefix. Legacy IDs put the version
+   * first (`claude-3-5-haiku-*`), so these patterns cannot collide with them.
+   */
+  private static readonly FAMILY_FIRST_PATTERNS = [
+    'claude-opus-*',
+    'claude-sonnet-*',
+    'claude-haiku-*',
+    'anthropic.claude-opus-*',
+    'anthropic.claude-sonnet-*',
+    'anthropic.claude-haiku-*'
+  ];
+
+  /** Capabilities for Claude 4.x and newer (see FAMILY_FIRST_PATTERNS). */
+  private familyFirstCapabilities(modelId: string): ProviderCapabilities {
+    const isOpus = this.matchesPattern(modelId, ['*opus*']);
+    const isHaiku = this.matchesPattern(modelId, ['*haiku*']);
+
+    return {
+      supportsReasoning: true,
+      supportsThinking: true,
+      maxThinkingTokens: 6553,
+      supportedResponseModes: ['standard'],
+      supportsBackgroundMode: false,
+      supportedTools: [],
+      typicalLatencyMs: isHaiku ? 1200 : isOpus ? 3500 : 2500,
+      maxTimeoutMs: 180000, // 3 minutes — these write long answers
+      costPerInputToken: isOpus ? 0.000015 : isHaiku ? 0.000001 : 0.000003,
+      costPerOutputToken: isOpus ? 0.000075 : isHaiku ? 0.000005 : 0.000015
+    };
+  }
+
   getCapabilities(modelId: string): ProviderCapabilities {
+    // Claude 4.x and newer use family-first model IDs (`claude-sonnet-4-6`,
+    // `claude-opus-4-6-v1`, `claude-haiku-4.5`, `claude-sonnet-5`, each also with
+    // an `anthropic.`/`us.anthropic.` prefix on Bedrock). None of those contain
+    // the literal "claude-4", so every one of them fell through this table to
+    // `getDefaultCapabilities()` and inherited a 30s abort. Checked first; the
+    // legacy `claude-3-5-haiku-*` IDs put the family AFTER the version and so do
+    // not collide with these patterns.
+    if (this.matchesPattern(modelId, ClaudeAdapter.FAMILY_FIRST_PATTERNS)) {
+      return this.familyFirstCapabilities(modelId);
+    }
+
     // Claude 4 models with thinking capabilities
     if (this.matchesPattern(modelId, ['claude-4*', 'anthropic.claude-4*'])) {
       return {

--- a/lib/streaming/provider-adapters/gemini-adapter.ts
+++ b/lib/streaming/provider-adapters/gemini-adapter.ts
@@ -110,6 +110,25 @@ export class GeminiAdapter extends BaseProviderAdapter {
   }
 
   getCapabilities(modelId: string): ProviderCapabilities {
+    // Gemini 3.x (and the 3.1/3.5 point releases). Listed FIRST so a new
+    // generation is characterised rather than falling through to the defaults —
+    // `gemini-3-flash-preview` matched nothing here and inherited a 30s abort
+    // that killed long Nexus answers mid-response.
+    if (this.matchesPattern(modelId, ['gemini-3*', 'models/gemini-3*'])) {
+      const isPro = this.matchesPattern(modelId, ['*pro*']);
+      return {
+        supportsReasoning: true,
+        supportsThinking: false,
+        supportedResponseModes: ['standard'],
+        supportsBackgroundMode: false,
+        supportedTools: ['code_execution'],
+        typicalLatencyMs: isPro ? 3500 : 2000,
+        maxTimeoutMs: isPro ? 180000 : 120000,
+        costPerInputToken: isPro ? 0.000002 : 0.0000003,
+        costPerOutputToken: isPro ? 0.000012 : 0.0000025
+      };
+    }
+
     // Gemini 2.5 models with enhanced reasoning
     if (this.matchesPattern(modelId, ['gemini-2.5*', 'models/gemini-2.5*'])) {
       return {

--- a/lib/streaming/provider-adapters/openai-adapter.ts
+++ b/lib/streaming/provider-adapters/openai-adapter.ts
@@ -315,11 +315,17 @@ export class OpenAIAdapter extends BaseProviderAdapter {
       const accumulatedToolCalls: AccumulatedToolCall[] = [];
 
       // Use the SHARED stop conditions (maxSteps + cost cap) and the SHARED
-      // wall-clock timeout (#926). The Responses-API path previously set only
+      // wall-clock budget (#926). The Responses-API path previously set only
       // stepCountIs(maxSteps), silently bypassing the cost cap and timeout for
       // these models. Reuse the base-adapter helpers so all paths enforce both.
       const stopConditions = this.buildStopConditions(enhancedConfig, logger);
-      const abortSignal = this.buildTimeoutSignal(enhancedConfig.timeout, logger);
+      const deadline = this.buildStreamDeadline(
+        enhancedConfig.timeout,
+        enhancedConfig.maxSteps,
+        logger
+      );
+      const abortSignal = deadline.signal;
+      let streamAborted = false;
 
       // Stream with Responses API enhancements
       const result = streamText({
@@ -334,6 +340,10 @@ export class OpenAIAdapter extends BaseProviderAdapter {
         ...(stopConditions.length > 0 && { stopWhen: stopConditions }),
         // Capture tool calls as each step finishes
         onStepFinish: (event) => {
+          // A completed step buys the next one a fresh budget (see
+          // buildStreamDeadline) so tool time doesn't consume the answer's time.
+          deadline.extend();
+
           if (event.toolCalls && Array.isArray(event.toolCalls)) {
             for (const tc of event.toolCalls) {
               const toolCall = tc as { toolCallId: string; toolName: string; args?: unknown; input?: unknown };
@@ -351,12 +361,16 @@ export class OpenAIAdapter extends BaseProviderAdapter {
           }
         },
         onFinish: async (event) => {
+          deadline.dispose();
+          const aborted = streamAborted || deadline.timedOut();
+
           logger.info('OpenAI streamText onFinish triggered', {
             hasText: !!event.text,
             hasUsage: !!event.usage,
             finishReason: event.finishReason,
             textLength: event.text?.length || 0,
-            toolCallCount: accumulatedToolCalls.length
+            toolCallCount: accumulatedToolCalls.length,
+            aborted
           });
 
           // Extract tool results from event.steps (shared method from base adapter)
@@ -368,7 +382,9 @@ export class OpenAIAdapter extends BaseProviderAdapter {
             text: event.text || '',
             usage: transformFinishUsage(event.usage),
             finishReason: event.finishReason || 'stop',
-            toolCalls: accumulatedToolCalls.length > 0 ? accumulatedToolCalls : undefined
+            toolCalls: accumulatedToolCalls.length > 0 ? accumulatedToolCalls : undefined,
+            // Truncated run — callers must not persist this as a completed turn.
+            aborted
           };
 
           // Call finish callbacks
@@ -381,7 +397,20 @@ export class OpenAIAdapter extends BaseProviderAdapter {
             await callbacks.onFinish(transformedData);
           }
         },
+        // An aborted run reaches neither onError nor onFinish's error path in AI
+        // SDK v6, so without this the wall-clock abort was silent here too.
+        onAbort: ({ steps }) => {
+          streamAborted = true;
+          this.reportStreamAbort({
+            deadline,
+            completedSteps: steps.length,
+            toolCallCount: accumulatedToolCalls.length,
+            callbacks,
+            logger
+          });
+        },
         onError: (event) => {
+          deadline.dispose();
           const error = event.error instanceof Error ? event.error : new Error(String(event.error));
 
           // handleError() logs at warn (transient) or error (permanent) — no need to log here too.
@@ -402,11 +431,17 @@ export class OpenAIAdapter extends BaseProviderAdapter {
         });
       });
       
+      const buildResponse = (options?: { headers?: Record<string, string> }) =>
+        this.buildAbortAwareResponse(
+          result,
+          () => streamAborted || deadline.timedOut(),
+          () => deadline.timedOut(),
+          options
+        );
+
       return {
-        toDataStreamResponse: (options?: { headers?: Record<string, string> }) =>
-          result.toUIMessageStreamResponse ? result.toUIMessageStreamResponse(options) : result.toTextStreamResponse(options),
-        toUIMessageStreamResponse: (options?: { headers?: Record<string, string> }) =>
-          result.toUIMessageStreamResponse ? result.toUIMessageStreamResponse(options) : result.toTextStreamResponse(options),
+        toDataStreamResponse: buildResponse,
+        toUIMessageStreamResponse: buildResponse,
         usage: Promise.resolve(result.usage)
       };
     }

--- a/lib/streaming/types.ts
+++ b/lib/streaming/types.ts
@@ -236,6 +236,15 @@ export interface StreamingCallbacks {
     toolCalls?: ToolCallData[];
     /** Per-step breakdown — populated when maxSteps > 1 (MCP connector multi-step) */
     steps?: StepCallbackData[];
+    /**
+     * True when the run was cut short (wall-clock budget exhausted, or the caller
+     * aborted) rather than completing. AI SDK v6 still fires `onFinish` after an
+     * abort, carrying only the steps that finished before the cut — so `text` may
+     * be empty or a partial answer. Callers MUST NOT persist an aborted run as a
+     * completed assistant turn; doing so is what wrote blank assistant bubbles
+     * into prod Nexus conversations.
+     */
+    aborted?: boolean;
   }) => void;
   onError?: (error: Error) => void;
 

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -9,6 +9,16 @@ import { ContentSafetyBlockedError } from './types';
 
 // Module-level logger for free functions (class methods use per-request loggers)
 const log = createLogger({ module: 'unified-streaming-service' });
+
+/**
+ * Last-resort per-step wall-clock budget when neither the caller nor the model's
+ * capability entry declares one. Two minutes, not thirty seconds: a model that
+ * reaches this branch is one nobody has characterised, and cutting an
+ * uncharacterised model off at 30s truncates real answers (prod incident — every
+ * Claude 4.x / Gemini 3 / Nova model fell through its provider's pattern table
+ * and inherited a 30s abort that killed long responses mid-sentence).
+ */
+const DEFAULT_STREAM_TIMEOUT_MS = 120_000;
 import {
   isTextDeltaEvent,
   isTextStartEvent,
@@ -673,8 +683,6 @@ export class UnifiedStreamingService {
    * Calculate adaptive timeout based on model capabilities and request
    */
   private getAdaptiveTimeout(capabilities: ProviderCapabilities, request: StreamRequest): number {
-    const baseTimeout = 30000; // 30 seconds
-
     // An explicitly configured timeout always wins (e.g. an agentic run's per-run
     // wall-clock limit, #926). The adaptive values below are only fallbacks for
     // callers that don't set one — otherwise a reasoning/thinking model would
@@ -697,8 +705,20 @@ export class UnifiedStreamingService {
       return 60000;
     }
 
-    // Standard models use base timeout
-    return request.timeout || baseTimeout;
+    // Every capability entry declares `maxTimeoutMs`, but this method used to
+    // ignore it entirely and hand back a flat 30s to any non-reasoning model —
+    // including every model that falls through its provider's pattern table to
+    // `getDefaultCapabilities()`. Honour the declared value so a stale pattern
+    // list degrades to a survivable budget instead of the tightest one.
+    if (
+      typeof capabilities.maxTimeoutMs === 'number' &&
+      Number.isFinite(capabilities.maxTimeoutMs) &&
+      capabilities.maxTimeoutMs > 0
+    ) {
+      return capabilities.maxTimeoutMs;
+    }
+
+    return DEFAULT_STREAM_TIMEOUT_MS;
   }
 
   /**

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -19,6 +19,8 @@ const log = createLogger({ module: 'unified-streaming-service' });
  * and inherited a 30s abort that killed long responses mid-sentence).
  */
 const DEFAULT_STREAM_TIMEOUT_MS = 120_000;
+
+
 import {
   isTextDeltaEvent,
   isTextStartEvent,
@@ -31,6 +33,44 @@ import {
   isErrorEvent,
   isFinishEvent
 } from './sse-event-types';
+
+/**
+ * Resolve the per-step wall-clock budget for a stream.
+ *
+ * Exported and pure so the production rule is testable directly — the previous
+ * test reimplemented this ladder and would have passed against a half-fixed
+ * version of it. Order matters:
+ *
+ *  1. An explicitly configured timeout always wins (e.g. an agentic run's per-run
+ *     limit, #926); the adaptive values are only for callers that don't set one.
+ *  2. The model's capability entry is AUTHORITATIVE. Every entry declares
+ *     `maxTimeoutMs`, yet this used to ignore it completely: non-reasoning models
+ *     got a flat 30s and reasoning models got one of three hard-coded values that
+ *     silently overrode the table (a declared 180s became 120s for Claude 4.x and
+ *     60s for Gemini 3). Reading it keeps the budget in ONE place instead of split
+ *     between the table and a ladder of conditionals nobody updates when a new
+ *     model generation lands.
+ *  3. Only if an entry omits `maxTimeoutMs` do the coarse heuristics apply.
+ */
+export function resolveStreamTimeout(
+  capabilities: Pick<ProviderCapabilities, 'supportsReasoning' | 'supportsThinking' | 'maxTimeoutMs'>,
+  requestTimeout?: number
+): number {
+  if (typeof requestTimeout === 'number' && Number.isFinite(requestTimeout) && requestTimeout > 0) {
+    return requestTimeout;
+  }
+  if (
+    typeof capabilities.maxTimeoutMs === 'number' &&
+    Number.isFinite(capabilities.maxTimeoutMs) &&
+    capabilities.maxTimeoutMs > 0
+  ) {
+    return capabilities.maxTimeoutMs;
+  }
+  if (capabilities.supportsReasoning) {
+    return capabilities.supportsThinking ? 120000 : 60000;
+  }
+  return DEFAULT_STREAM_TIMEOUT_MS;
+}
 
 /**
  * Result of content safety input check
@@ -683,42 +723,7 @@ export class UnifiedStreamingService {
    * Calculate adaptive timeout based on model capabilities and request
    */
   private getAdaptiveTimeout(capabilities: ProviderCapabilities, request: StreamRequest): number {
-    // An explicitly configured timeout always wins (e.g. an agentic run's per-run
-    // wall-clock limit, #926). The adaptive values below are only fallbacks for
-    // callers that don't set one — otherwise a reasoning/thinking model would
-    // ignore the author-configured timeout entirely.
-    if (typeof request.timeout === 'number' && Number.isFinite(request.timeout) && request.timeout > 0) {
-      return request.timeout;
-    }
-
-    // Extend timeout for reasoning models
-    if (capabilities.supportsReasoning) {
-      // o3/o4 models may need up to 5 minutes for complex reasoning
-      if (request.modelId.includes('o3') || request.modelId.includes('o4')) {
-        return 300000; // 5 minutes
-      }
-      // Claude thinking models may need up to 2 minutes
-      if (capabilities.supportsThinking) {
-        return 120000; // 2 minutes
-      }
-      // Other reasoning models get 1 minute
-      return 60000;
-    }
-
-    // Every capability entry declares `maxTimeoutMs`, but this method used to
-    // ignore it entirely and hand back a flat 30s to any non-reasoning model —
-    // including every model that falls through its provider's pattern table to
-    // `getDefaultCapabilities()`. Honour the declared value so a stale pattern
-    // list degrades to a survivable budget instead of the tightest one.
-    if (
-      typeof capabilities.maxTimeoutMs === 'number' &&
-      Number.isFinite(capabilities.maxTimeoutMs) &&
-      capabilities.maxTimeoutMs > 0
-    ) {
-      return capabilities.maxTimeoutMs;
-    }
-
-    return DEFAULT_STREAM_TIMEOUT_MS;
+    return resolveStreamTimeout(capabilities, request.timeout);
   }
 
   /**

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -62,8 +62,22 @@ const mockHeaders = class Headers {
     return this.values.get(name.toLowerCase()) ?? null;
   }
 
+  /**
+   * Part of the standard Headers API, and used by library code that merges
+   * defaults into caller-supplied headers (e.g. the AI SDK's `prepareHeaders`,
+   * which does `if (!responseHeaders.has(key))`). Omitting it made any such
+   * code throw "responseHeaders.has is not a function" under test only.
+   */
+  has(name: string): boolean {
+    return this.values.has(name.toLowerCase());
+  }
+
   set(name: string, value: string): void {
     this.values.set(name.toLowerCase(), String(value));
+  }
+
+  delete(name: string): void {
+    this.values.delete(name.toLowerCase());
   }
 } as unknown as typeof Headers;
 


### PR DESCRIPTION
## Why

A user uploaded two images and a one-page PDF to Nexus and asked it to build a
sports schedule. The composer froze for **2m18s** with no indicator, then the
response **died mid-answer** and saved a blank assistant bubble.

Traced through `/ecs/aistudio-prod` and the unified-content-processor logs to six
independent defects. Timeline from the incident:

| Time (UTC) | Event |
|---|---|
| 02:34:32 | First attachment uploaded |
| 02:34:33 | Job deferred a flat 60s |
| 02:37:00 | User presses Send — two images only *begin* uploading now |
| 02:39:18 | Last attachment finally ready. **Composer was frozen 2m18s** |
| 02:39:27 | Attachment search returns (7s of a 30s budget spent) |
| **02:39:50.975** | **Aborted at exactly 30s. `textLength: 0`, logged `status: "success"`** |

## What changed

**1. Capability tables were a generation behind.** Claude 4.x+ use family-first IDs
(`claude-sonnet-4-6`), which `claude-4*` can never match; the Gemini table stopped at 2.5.
Every current model fell through to `getDefaultCapabilities()` — only `gpt-5*` still
matched. Compounding it, `getAdaptiveTimeout()` **never read `capabilities.maxTimeoutMs`**
despite it being declared on every entry, so non-reasoning models got a flat 30s.

Added `gemini-3*` + family-first Claude patterns (verified not to collide with legacy
`claude-3-5-haiku-*`), honoured `maxTimeoutMs`, and raised the unknown-model default
30s → 120s. Reaching the default means a model is *newer* than the table, not smaller.

**2. The wall clock charged tool time to the answer.** `AbortSignal.timeout()` bounded the
whole `streamText` call including tool execution. Replaced with a step-aware budget, pushed
forward at each step boundary, bounded by `timeout × maxSteps` capped at 10 min.

**3. Aborts were silent and truncated turns were persisted.** Verified against
`ai@6.0.208`: an abort fires `onAbort`, **not** `onError`, and `onAbort` was never wired.
`onFinish` still fires afterwards with only the completed steps, and that got saved. Now
wired on both paths, with `incompleteTurnReason()` refusing to persist an aborted run or a
content-free turn. (An aborted run's trailing step can hold a tool call whose result never
arrived → `AI_MissingToolResultsError` on reload.)

**4. The cut-off was invisible.** The SDK enqueues an `abort` chunk but raises no
client-side error — the browser just saw the stream stop. `buildAbortAwareResponse()`
appends a terminal `error` chunk, which the client surfaces and `MessagePrimitive.Error`
renders. Appended at end-of-stream; non-aborted runs are byte-identical to the SDK's own
encoding.

**5. Images blocked Send with no indicator.** `VisionImageAdapter` uploaded inside `send()`
and never fired the processing callbacks driving the UI indicator. Now uploads at attach
time like `HybridDocumentAdapter`, and reports start/completion/failure.

**6. Content processor slept a flat 60s per stage.** One constant for every defer reason —
an image paid 60s for the malware scan plus 60s for OCR around ~2s of real work. Now
per-reason backoff (scan/OCR 5s, media 15s, disabled 300s), doubling per minute waited. The
defer reason is now **logged** — previously DB-only, so diagnosing from CloudWatch meant
inferring it from gaps between calls.

### Also fixed
- `remove()` was an empty method on **both** adapters — retained the whole `File` and
  orphaned the uploaded repository. Explains the prod session showing **4 uploaded
  repositories but only 3 attachment references** in the sent message.
- `tests/setup.ts` mock `Headers` lacked standard `has()`/`delete()`, so library code
  merging default headers threw under test only.

### Investigated — not a defect
`nexus.conversation.repositories.get` returning `bindingCount: 0` is correct. Attachments
bind through `nexusRepositoryBindings`; that endpoint reports
`nexus_conversation_repositories` (durable direct/project/skill/assistant bindings only).

## Verification

| Gate | Result |
|---|---|
| lint | clean, 0 warnings |
| typecheck | clean |
| `test:ci` | **592 suites / 5675 tests** (+38 new) |
| production `next build` | compiles |
| infra lambda lifecycle | 25/25 (via bun) |
| E2E `repository-upload-contract` | **7/7** |
| E2E `nexus-message-dedup` | **2/2** — live chat stream through the rewritten response path |
| E2E `nexus-repository-bindings` guard | **1/1** |

New capability tests were confirmed to **fail against the pre-fix adapters (9 of 12 red)**,
so they are genuine regression guards rather than tautologies.

## Reviewer notes

- **Deployment:** defect 6 is in `infra/lambdas/unified-content-processor/` and only takes
  effect once that Lambda is deployed. The other five ship with the frontend.
- **Deliberately unchanged:** `claude-adapter`'s private `supportsThinking()` still matches
  only `claude-4*`, so extended thinking stays off for Sonnet 4.6 / Opus 4.6. Enabling it
  changes the Bedrock request payload for every Nexus turn and belongs in its own PR.
- **Pre-existing, unrelated:** infra jest cannot run at all — infra pins TypeScript 7.0.2
  and ts-jest 29 can't consume it (all 5 lambda suites fail at the transform layer, 0 tests
  execute). CI never runs infra jest. Lambda logic verified with `bun test` instead.
