### PR TITLE
fix(ci): remove expiring smoke fixture and OpenWiki self-trigger

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   push:
     branches: [dev]
+    paths-ignore:
+      - "openwiki/**"
   schedule:
     - cron: "0 8 * * 1"
 jobs:

--- a/tests/smoke/nexus-ephemeral-repositories.smoke.ts
+++ b/tests/smoke/nexus-ephemeral-repositories.smoke.ts
@@ -36,7 +36,9 @@ import {
 } from "@/lib/nexus/ephemeral-repository-service";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const NOW = new Date("2026-07-23T12:00:00.000Z");
+// Access checks compare expiry against the database wall clock, so a fixed
+// fixture date eventually turns this active-repository smoke into a time bomb.
+const NOW = new Date();
 const policy = {
   nexusAttachmentRetentionDays: 30,
   deletionGraceDays: 7,


### PR DESCRIPTION
## Summary

- anchor the Nexus ephemeral-repository smoke to runtime instead of a fixed date that expired on 2026-08-23
- ignore dev pushes that change only generated openwiki files, preventing auto-merged docs PRs from starting a redundant OpenWiki generation cycle

## Root cause

The smoke refreshed its test repository to a fixed expiry of 2026-08-23 12:00 UTC while the production access query compares against PostgreSQL now(). It passed before that cutoff and then failed deterministically on two consecutive dev pushes afterward.

The migrated OpenWiki caller auto-merged docs PRs. Those openwiki-only merge commits retriggered the dev-push workflow, requiring a second convergence pass.

## Verification

- Nexus real-database smoke: passed against local Docker PostgreSQL
- full-repository lint: passed
- full-repository typecheck: passed
- authenticated Playwright pre-push gate: 320 passed, 41 configured skips, 1 flaky test passed on retry
- workflow YAML parse and git diff check: passed

No UI behavior changes; screenshots are not applicable.
