### PR TITLE
fix(agent): the four defects behind a week of prod agent failures

### DIFF
--- a/actions/agent-workspace.actions.ts
+++ b/actions/agent-workspace.actions.ts
@@ -38,6 +38,23 @@ const SCOPES_BY_KIND: Record<"user_account", string[]> = {
     // requires a fresh consent click — existing refresh tokens retain
     // only the original scope set until re-issued.
     "https://www.googleapis.com/auth/gmail.modify",
+    // Inbox FILTERS (approved 2026-08-28). Google does not fold filter
+    // management into gmail.modify — settings.filters needs
+    // gmail.settings.basic specifically — so three users asking for
+    // skip-inbox-and-label rules, or for existing rules to be removed, had no
+    // route at all (agent_failures 12909, 13866, 14559).
+    //
+    // `.basic` is the narrow half of the settings surface: filters, labels,
+    // vacation and IMAP/POP. It does NOT cover forwarding addresses, send-as
+    // aliases or delegates — those need gmail.settings.sharing, which is
+    // deliberately not requested. The broker allowlist independently confines
+    // this to the filters resource (command-executor ALLOWED_WRITES).
+    //
+    // Existing refresh tokens keep the scope set they were issued with, so
+    // every current user must re-consent before filter calls work; until they
+    // do, requiredWorkspaceScopeGap turns the call into a re-authorize prompt
+    // rather than a Google 403.
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     // Full calendar so the agent can write events with markers (per user
     // direction 2026-04-26: "the way it is working right now is fine").
     "https://www.googleapis.com/auth/calendar",

--- a/app/api/v1/content/[id]/route.ts
+++ b/app/api/v1/content/[id]/route.ts
@@ -25,7 +25,7 @@ import {
 import { contentErrorToResponse, resolveRestRequester } from "@/lib/content/rest";
 import {
   assertContentAuthoringCapability,
-  contentDeepLink,
+  contentSurfaceLink,
   resolveCollectionId,
 } from "@/lib/content/surface-helpers";
 import { createLogger } from "@/lib/logger";
@@ -58,7 +58,7 @@ export const GET = withApiAuth(async (request: NextRequest, auth, requestId, par
     const req = await requesterFromApiAuth(auth);
     const obj = await contentService.get(req, id);
     const response = createApiResponse(
-      { data: { ...obj, url: contentDeepLink(obj.slug) }, meta: { requestId } },
+      { data: { ...obj, url: contentSurfaceLink(obj) }, meta: { requestId } },
       requestId
     );
     response.headers.set("ETag", contentHeadEtag(obj.currentVersionId));

--- a/app/api/v1/content/route.ts
+++ b/app/api/v1/content/route.ts
@@ -33,7 +33,7 @@ import {
 } from "@/lib/content/rest";
 import {
   assertContentAuthoringCapability,
-  contentDeepLink,
+  contentSurfaceLink,
   resolveCollectionId,
 } from "@/lib/content/surface-helpers";
 import { decodeContentBody } from "@/lib/content/code-encoding";
@@ -75,7 +75,7 @@ function createContentResponse(
 ) {
   return createApiResponse(
     {
-      data: { ...created, url: contentDeepLink(created.slug) },
+      data: { ...created, url: contentSurfaceLink(created) },
       meta: { requestId },
     },
     requestId,

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -1649,12 +1649,57 @@ def main():
                         ),
                         require_generation=True,
                     )
-                    await asyncio.get_running_loop().run_in_executor(
-                        None,
-                        retry_push,
-                    )
-                    _workspace_local_clean = True
-                    _workspace_turn_writable = False
+                    try:
+                        await asyncio.get_running_loop().run_in_executor(
+                            None,
+                            retry_push,
+                        )
+                    except Exception as retry_exc:  # noqa: BLE001
+                        # The prior turn's fenced batch could not be replayed.
+                        # It used to take the whole invocation down with it:
+                        # the exception escaped to the outer handler, which
+                        # disabled push and answered the user with a workspace
+                        # error — and the NEXT invocation then did the exact
+                        # committed restore anyway. The user lost a turn to
+                        # reach a recovery we can perform right here.
+                        #
+                        # Those local changes are unreconcilable either way, so
+                        # quarantine them (invalidate the local generation so
+                        # the refresh below is a full, pruning restore from the
+                        # committed manifest) and let the turn continue. This
+                        # is a recovered outcome, so it records at warn and
+                        # does NOT page — the failure that matters is a restore
+                        # that could not be completed, which still raises.
+                        _fail_closed_workspace_after_restore_error(
+                            workspace_prefix
+                        )
+                        logger.warning(
+                            "pending workspace checkpoint could not be "
+                            "replayed (%s) — discarding unpushable local "
+                            "changes and restoring the committed generation",
+                            retry_exc,
+                        )
+                        record_failure(
+                            source="harness",
+                            severity="warn",
+                            error_class="WorkspaceCheckpointRetryAbandoned",
+                            error_message=(
+                                "pending checkpoint replay failed; local "
+                                f"changes discarded: {str(retry_exc)[:500]}"
+                            ),
+                            user_id=user_email,
+                            session_id=session_id,
+                            context={
+                                "phase": "workspace_checkpoint_retry",
+                                "workspace_prefix": workspace_prefix,
+                                # The turn continues on an exact committed
+                                # restore, so this is telemetry, not an outage.
+                                "recovered": True,
+                            },
+                        )
+                    else:
+                        _workspace_local_clean = True
+                        _workspace_turn_writable = False
                 pulled = await asyncio.get_running_loop().run_in_executor(
                     None,
                     workspace_sync.refresh_workspace,

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -204,6 +204,20 @@ class TurnResult:
     # the dashboard can trend nudge-fire rate. A recovered-after-nudge turn
     # writes no agent_failures row, so this flag is its only persisted signal.
     nudged: bool = False
+    # A failure this ATTEMPT hit that has not been written to agent_failures
+    # yet, because `process()` may still recover the turn by retrying it (see
+    # `_should_retry_upstream`). `process()` is the only reader: it flushes the
+    # row via `_flush_deferred_failure` when the turn ends failed, and drops it
+    # when the retry succeeds — the same policy `nudged` already documents,
+    # that a recovered turn writes no agent_failures row.
+    #
+    # Deferring is why this exists at all. Recording at the attempt meant every
+    # recovered turn still left a severity=error row and still ticked the
+    # AgentFailuresHarness metric behind the failure alarm: in the week of
+    # 2026-08-21, 8 of 10 OpenClawChatError rows in prod had ALREADY been
+    # recovered by the retry below (7 clean, 1 via job promotion), so the
+    # Failures tab read as 10 broken turns when 2 were.
+    deferred_failure: Optional[Dict[str, Any]] = None
 
 
 def _shape_of(value: object) -> str:
@@ -1401,7 +1415,7 @@ class OpenClawAdapter(HarnessAdapter):
             message, session_id, model_override, deadline_s, _is_nudge
         )
         if not self._should_retry_upstream(attempt):
-            return attempt
+            return self._flush_deferred_failure(attempt)
         # Wall clock, not attempt.latency_ms: latency is measured from
         # chat.send and so misses connection setup, which the retry must also
         # pay for a second time.
@@ -1416,7 +1430,7 @@ class OpenClawAdapter(HarnessAdapter):
                 remaining_s,
                 attempt.error_class,
             )
-            return attempt
+            return self._flush_deferred_failure(attempt)
         logger.warning(
             "retrying turn after a clean upstream failure: error_class=%s "
             "latency_ms=%d retry_deadline_s=%d",
@@ -1431,15 +1445,40 @@ class OpenClawAdapter(HarnessAdapter):
         if retried.failed:
             # Keep the retry's result — it is the more recent evidence — but
             # say plainly that a retry happened, so a two-failure turn is not
-            # read as a single blip.
+            # read as a single blip. Both attempts' rows are written: the turn
+            # really did fail twice, and the first attempt is the evidence that
+            # says so.
             logger.error(
                 "upstream retry also failed: first=%s second=%s",
                 attempt.error_class,
                 retried.error_class,
             )
-            return retried
+            self._flush_deferred_failure(attempt)
+            return self._flush_deferred_failure(retried)
+        # The turn was recovered, so no agent_failures row is written for the
+        # attempt that failed — the same policy a recovered-after-nudge turn
+        # follows. The two log lines above remain the record that it happened.
+        if attempt.deferred_failure:
+            logger.info(
+                "dropping the failed attempt's agent_failures row — the "
+                "retry recovered the turn: error_class=%s",
+                attempt.error_class,
+            )
         logger.info("upstream retry recovered the turn")
         return retried
+
+    @staticmethod
+    def _flush_deferred_failure(result: TurnResult) -> TurnResult:
+        """Write a held-back attempt failure now that the turn is settled.
+
+        Idempotent: the record is cleared as it is written, so a result that
+        passes through more than one terminal path cannot double-record.
+        """
+        pending = result.deferred_failure
+        if pending:
+            result.deferred_failure = None
+            record_failure(**pending)
+        return result
 
     @staticmethod
     def _should_retry_upstream(result: TurnResult) -> bool:
@@ -2688,15 +2727,38 @@ class OpenClawAdapter(HarnessAdapter):
                             # fail-closed downstream: the upgraded OpenClaw host
                             # already attempted the only safe, tools-disabled
                             # finalization. See _classify_chat_error.
-                            record_failure(
-                                source="harness",
-                                severity="error",
-                                error_class=err_class,
-                                error_message=str(err_msg),
-                                session_id=session_id,
-                                model=observed_model or model_override,
-                                context=failure_context,
+                            err_latency_ms = int(
+                                (time.time() - chat_send_at) * 1000
                             )
+                            failure_record = {
+                                "source": "harness",
+                                "severity": "error",
+                                "error_class": err_class,
+                                "error_message": str(err_msg),
+                                "session_id": session_id,
+                                "model": observed_model or model_override,
+                                "context": failure_context,
+                            }
+                            # Hold the row back when `process()` may still
+                            # recover this turn by replaying it. The predicate
+                            # mirrors `_should_retry_upstream` on the result
+                            # this branch is about to return, so a deferred row
+                            # is exactly a row whose turn gets a second attempt.
+                            # `process()` flushes it if that attempt does not
+                            # land; nothing else reads it.
+                            deferred_failure = (
+                                failure_record
+                                if (
+                                    err_class == "OpenClawChatError"
+                                    and not tool_calls
+                                    and not tool_starts
+                                    and err_latency_ms
+                                    <= UPSTREAM_RETRY_MAX_LATENCY_MS
+                                )
+                                else None
+                            )
+                            if deferred_failure is None:
+                                record_failure(**failure_record)
                             # Never post the accumulated scratchpad narration
                             # as if it were the answer — frame it as a failed
                             # partial (issue #1138 F4).
@@ -2729,12 +2791,13 @@ class OpenClawAdapter(HarnessAdapter):
                                 usage_capture_complete=bool(
                                     err_usage.get("capture_complete")
                                 ),
-                                latency_ms=int((time.time() - chat_send_at) * 1000),
+                                latency_ms=err_latency_ms,
                                 messages=messages_log,
                                 tool_calls=tool_calls,
                                 tools_in_flight=len(tool_starts),
                                 failed=True,
                                 error_class=err_class,
+                                deferred_failure=deferred_failure,
                             )
 
                         elif state == "aborted":

--- a/infra/agent-image/skills/psd-freshservice/SKILL.md
+++ b/infra/agent-image/skills/psd-freshservice/SKILL.md
@@ -57,6 +57,10 @@ node get_service_request.js --user <email> --id <ticket_id>
 node create_ticket.js --user <email> \
   --data '{"subject":"...","description":"...","email":"requester@...","priority":2,"workspace_id":2}'
 
+# Create when the workspace requires a department — see "department_id" below
+node create_ticket.js --user <email> \
+  --data '{"subject":"...","description":"...","email":"requester@...","department_id":6000119622}'
+
 # Update — status 2 Open / 3 Pending / 4 Resolved / 5 Closed; priority 1-4
 node update_ticket.js --user <email> --id <id> --data '{"status":4}'
 
@@ -165,6 +169,21 @@ On a 403 (`freshservice_endpoint_forbidden`):
   workspaces are available rather than declaring the integration broken.
 - If they need a workspace they cannot reach, the fix is a Freshservice role
   change on their account, not a new key. Say that plainly.
+
+### `department_id` is mandatory on some accounts
+
+Some PSD Freshservice accounts reject every create with 400 `department_id
+should be of type Positive Integer`. Retrying, or dropping `email` /
+`requester_id` / `workspace_id`, does not help — the field is simply required.
+
+Pass the requester's own department:
+
+1. Read it off any existing ticket of theirs — `get_ticket.js` returns
+   `department_id` in the ticket body.
+2. Include it in `--data`: `{"...", "department_id": 6000119622}`.
+
+Do not guess a department id. If no ticket of theirs is available to read it
+from, say the create needs a department id and ask which department they are in.
 
 ## Security
 

--- a/infra/agent-image/skills/psd-freshservice/create_ticket.js
+++ b/infra/agent-image/skills/psd-freshservice/create_ticket.js
@@ -31,10 +31,17 @@ async function main() {
   // Allowlist of Freshservice ticket fields the agent may set. Prevents callers
   // from injecting privileged fields (e.g. source, type, internal metadata) that
   // Freshservice may accept but the agent should not control.
+  //
+  // `department_id` is REQUIRED by some PSD workspaces: without it every create
+  // returns 400 "department_id should be of type Positive Integer", and with no
+  // way to pass it the caller could not file a ticket at all (failure 12777,
+  // 2026-08-24). It routes the ticket to the requester's own department, the
+  // same requester the caller already names via `email`/`requester_id`, so it
+  // grants no authority the field list did not already imply.
   const ALLOWED_FIELDS = new Set([
     'subject', 'description', 'email', 'requester_id', 'status', 'priority',
-    'workspace_id', 'group_id', 'responder_id', 'cc_emails', 'tags',
-    'category', 'sub_category', 'item_category', 'due_by', 'fr_due_by',
+    'workspace_id', 'department_id', 'group_id', 'responder_id', 'cc_emails',
+    'tags', 'category', 'sub_category', 'item_category', 'due_by', 'fr_due_by',
     'urgency', 'impact',
   ]);
   const filtered = Object.create(null);

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -352,6 +352,19 @@ made. Files you create are owned by your agent account, and Drive only lets an
 document and has to open an IT ticket (issue #1636, reported 2026-08-12).
 Offer the transfer when you hand over anything they will keep.
 
+**Transfer LAST. Write the whole file before you hand it over.** Ownership
+transfer is the final step of a handover, never a step in the middle of one. Once
+the file belongs to the caller it is no longer yours to author, and further
+writes — `docs.documents.batchUpdate`, `sheets.spreadsheets.values.update`,
+`slides.presentations.batchUpdate`, `forms.forms.batchUpdate` — can come back
+403 from Drive. That is what happened on 2026-08-26: a Doc was created,
+transferred, and only then populated, so all three batchUpdate attempts were
+refused and the user got an empty document (failure 13767).
+
+The order is always: create → populate → verify → transfer. If you have already
+transferred and still need to write, do not retry the write — say the file is
+now the caller's and ask them to make the edit, or create a fresh doc.
+
 Never allowed: `type: "anyone"` or `"group"`, external addresses/domains,
 domain-wide `writer`, `owner` transfer **to anyone other than the caller**, or
 any permission change on user-owned files.
@@ -484,6 +497,30 @@ Then report it under Rule 11 with the fileId and both scopes you tried. Do not
 loop. On 2026-08-14 a supervision schedule was retried nine times across eight
 minutes, re-shared as a different file type, and still abandoned — the user had
 shared it correctly the whole time (agent_failures 8289, 8322).
+
+### When Drive says you exceeded your sharing quota
+
+`Rate limit exceeded: Sorry, you have exceeded your sharing quota` on
+`drive.permissions.create` is a Google anti-abuse throttle on the SHARING
+account, not a transient error and not a problem with the file. It is most
+common on a freshly-provisioned `agnt_` account, whose sharing allowance starts
+low and rises over its first days.
+
+Retrying inside the turn cannot clear it — the window is hours, not seconds. On
+2026-08-24 and 2026-08-25 two turns each burned three attempts and ~90 seconds
+of the user's clock before giving up (failures 12744, 13241).
+
+So on this error, once:
+
+1. **Stop.** Do not retry, and do not try a different role — `writer` hits the
+   same quota as `owner`.
+2. **Give them the file anyway.** The document is built and live; only the
+   share failed. Send the `https://docs.google.com/…/d/<id>` link, and say the
+   file is currently owned by `agnt_<their-uniqname>@psd401.net`.
+3. **Say what to do.** Either they ask you to share it again later, or they open
+   it via the link and copy it into their own Drive now.
+
+Never report this as "I could not create the document" — the document exists.
 
 ## My inbox vs your inbox
 

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -414,6 +414,33 @@ gws gmail.users.labels.create --scope user --user hagelk@psd401.net \
   --json '{"name":"Digested"}'
 ```
 
+**Gmail filters.** Same reasoning as labels — a filter organizes the user's own
+inbox — so it is on the user slot too. List, create and delete are all allowed:
+
+```bash
+gws gmail.users.settings.filters.list --scope user --user hagelk@psd401.net
+
+# Skip the inbox and label instead. Get label IDs from gmail.users.labels.list;
+# INBOX and UNREAD are built-in ids you can remove directly.
+gws gmail.users.settings.filters.create --scope user --user hagelk@psd401.net \
+  --json '{"criteria":{"from":"eoc-alarms@psd401.net"},
+           "action":{"addLabelIds":["Label_12"],"removeLabelIds":["INBOX"]}}'
+
+gws gmail.users.settings.filters.delete --scope user --user hagelk@psd401.net \
+  --params '{"id":"<filterId>"}'
+```
+
+Filters need `gmail.settings.basic`, which `gmail.modify` does NOT include, so
+a user whose connection predates 2026-08-28 gets `scope-upgrade-required` on
+the first filter call. That is the ordinary re-consent path — hand them the
+link and retry after they authorize; it is not a failure to report.
+
+Two things this does NOT cover, both by design: **forwarding addresses** and
+**send-as aliases / delegates** live behind `gmail.settings.sharing`, which is
+not granted. If a user asks you to stop mail being forwarded away, you can
+remove the FILTER that forwards it, but you cannot remove a
+Settings → Forwarding rule — say so and point them at Gmail settings.
+
 **Granting a request someone already made.** When a user hits "request access" on an
 agent-owned file, Drive records an access proposal. List them with
 `drive accessproposals list` and grant one with `drive accessproposals resolve`
@@ -521,6 +548,31 @@ So on this error, once:
    it via the link and copy it into their own Drive now.
 
 Never report this as "I could not create the document" — the document exists.
+
+**Google Tasks.** The agent may add tasks to the user's own lists and reorder
+them — `tasks.tasks.insert`, `tasks.tasks.move` — on the user slot. `move`
+takes the destination in `--params`, not `--json`:
+
+```bash
+# Put a task directly under a heading task, as its child.
+gws tasks.tasks.move --scope user --user hagelk@psd401.net \
+  --params '{"tasklist":"@default","task":"<taskId>","parent":"<headingTaskId>"}'
+
+# Or just reposition it after another task at the same level.
+gws tasks.tasks.move --scope user --user hagelk@psd401.net \
+  --params '{"tasklist":"@default","task":"<taskId>","previous":"<afterTaskId>"}'
+```
+
+Deleting tasks or task lists stays forbidden on both slots (Phase 1).
+
+**Finding a person's DM space.** To deliver into your one-to-one Chat with
+someone, resolve the space first — `chat.spaces.list` only returns spaces that
+already exist for you, so a DM you have never used will not appear there:
+
+```bash
+gws chat.spaces.findDirectMessage --scope agent --user hagelk@psd401.net \
+  --params '{"name":"users/<googleUserId>"}'
+```
 
 ## My inbox vs your inbox
 

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -1833,6 +1833,65 @@ class WorkspaceRestoreFailureIsRecorded(unittest.TestCase):
         self.assertIn("workspace_prefix", window)
 
 
+class PendingCheckpointRetryDoesNotKillTheInvocation(unittest.TestCase):
+    """A pending checkpoint that cannot be replayed must not cost a turn.
+
+    The pre-restore retry replays the PREVIOUS turn's fenced batch using the
+    proof stored from that invocation. Until the broker learned to accept an
+    identical journaled replay, that proof was bound to an invocation that no
+    longer existed, so the retry 409'd every time; the exception escaped to the
+    outer restore handler, push was disabled, and the user got a workspace
+    error — after which the NEXT invocation performed the exact committed
+    restore anyway. Six rows across five users in the week of 2026-08-21, all
+    reading "Workspace finalization proof is invalid".
+
+    The unreconcilable local changes are lost either way. Losing the user's
+    turn on top of that was the avoidable half.
+    """
+
+    def source(self):
+        import inspect
+
+        return inspect.getsource(agentcore_wrapper)
+
+    def test_the_retry_push_is_guarded(self):
+        # Pinned by source for the same reason the restore-failure tests are:
+        # the call site is inside an async generator behind a real mount.
+        source = self.source()
+        start = source.index("retry_push = functools.partial(")
+        end = source.index('error_class="WorkspaceCheckpointRetryAbandoned"')
+        self.assertLess(start, end, "the abandonment path must follow the push")
+        window = source[start:end]
+        self.assertIn("try:", window)
+        self.assertIn("except Exception as retry_exc", window)
+
+    def test_the_abandonment_is_recorded_as_recovered_not_as_an_outage(self):
+        # The turn continues on an exact committed restore, so this row must
+        # not read like the WorkspaceMigrationFailed it replaces.
+        source = self.source()
+        start = source.index('error_class="WorkspaceCheckpointRetryAbandoned"')
+        window = source[max(0, start - 900) : start + 900]
+        self.assertIn('severity="warn"', window)
+        self.assertIn('"recovered": True', window)
+        self.assertIn("user_id=user_email", window)
+        self.assertIn("session_id=session_id", window)
+
+    def test_the_invocation_continues_into_the_committed_restore(self):
+        # The point of the change: quarantine, then keep going. The refresh
+        # that rebuilds the tree must still run after the abandonment, and the
+        # handler must not short-circuit the invocation on its way there.
+        source = self.source()
+        start = source.index('error_class="WorkspaceCheckpointRetryAbandoned"')
+        tail = source[start:]
+        refresh = tail.index("workspace_sync.refresh_workspace")
+        self.assertNotIn("return", tail[:refresh])
+        self.assertIn(
+            "_fail_closed_workspace_after_restore_error",
+            source[max(0, start - 1200) : start],
+            "local state must be invalidated so the refresh prunes it",
+        )
+
+
 class EveryWrapperFailureIsRecorded(unittest.TestCase):
     """No user-visible failure in the wrapper may be telemetry-silent.
 
@@ -1863,6 +1922,7 @@ class EveryWrapperFailureIsRecorded(unittest.TestCase):
         source = self.source()
         for error_class in (
             "WorkspaceMigrationFailed",
+            "WorkspaceCheckpointRetryAbandoned",
             "InvocationContextInvalid",
             "WorkspaceAuthorityChanged",
             "OpenClawStartupFailed",

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -1169,6 +1169,125 @@ class TestUpstreamRetry(unittest.TestCase):
         self.assertTrue(result.failed)
         self.assertEqual(result.error_class, "OpenClawChatError")
 
+    def test_a_recovered_turn_writes_no_failure_row(self):
+        # The whole point of deferring: a turn the retry rescued is not a
+        # failure, so it must not leave a severity=error row behind. In the
+        # week of 2026-08-21 this alone accounted for 8 of the 10
+        # OpenClawChatError rows in prod.
+        adapter = OpenClawAdapter()
+        held = {
+            "source": "harness",
+            "severity": "error",
+            "error_class": "OpenClawChatError",
+            "error_message": "LLM request failed.",
+            "session_id": "s1",
+            "model": None,
+            "context": {"phase": "chat_event_error"},
+        }
+        calls = []
+
+        def fake_once(*_a, **_kw):
+            calls.append(1)
+            if len(calls) == 1:
+                return self._result(deferred_failure=dict(held))
+            return harness_adapter.TurnResult(text="recovered", failed=False)
+
+        with mock.patch.object(adapter, "_process_once", side_effect=fake_once), \
+                mock.patch.object(harness_adapter.time, "sleep"), \
+                mock.patch.object(
+                    harness_adapter, "record_failure"
+                ) as record_failure:
+            result = adapter.process("x", "s1")
+
+        self.assertFalse(result.failed)
+        record_failure.assert_not_called()
+
+    def test_an_unrecovered_turn_still_writes_its_failure_row(self):
+        # Deferring must never LOSE a row — a turn that stays broken is
+        # exactly what the Failures tab exists to show.
+        adapter = OpenClawAdapter()
+        held = {
+            "source": "harness",
+            "severity": "error",
+            "error_class": "OpenClawChatError",
+            "error_message": "LLM request failed.",
+            "session_id": "s1",
+            "model": None,
+            "context": {"phase": "chat_event_error"},
+        }
+
+        with mock.patch.object(
+            adapter,
+            "_process_once",
+            side_effect=lambda *a, **k: self._result(
+                deferred_failure=dict(held)
+            ),
+        ), mock.patch.object(harness_adapter.time, "sleep"), \
+                mock.patch.object(
+                    harness_adapter, "record_failure"
+                ) as record_failure:
+            result = adapter.process("x", "s1")
+
+        self.assertTrue(result.failed)
+        # Both attempts really failed, so both are recorded.
+        self.assertEqual(record_failure.call_count, 2)
+        self.assertEqual(
+            record_failure.call_args.kwargs["error_class"], "OpenClawChatError"
+        )
+
+    def test_a_deferred_row_is_flushed_when_no_retry_is_attempted(self):
+        # A held row whose turn never gets a second attempt must still land.
+        # Reaching `process` at all means the caller thinks the turn is over.
+        adapter = OpenClawAdapter()
+        held = {
+            "source": "harness",
+            "severity": "error",
+            "error_class": "OpenClawChatError",
+            "error_message": "LLM request failed.",
+            "session_id": "s1",
+            "model": None,
+            "context": {"phase": "chat_event_error"},
+        }
+
+        with mock.patch.object(
+            adapter,
+            "_process_once",
+            # tool_calls makes the turn replay-UNSAFE, so no retry happens.
+            side_effect=lambda *a, **k: self._result(
+                tool_calls=[{"name": "docs.create"}],
+                deferred_failure=dict(held),
+            ),
+        ), mock.patch.object(harness_adapter.time, "sleep"), \
+                mock.patch.object(
+                    harness_adapter, "record_failure"
+                ) as record_failure:
+            result = adapter.process("x", "s1")
+
+        self.assertTrue(result.failed)
+        record_failure.assert_called_once()
+
+    def test_flushing_a_deferred_row_twice_records_it_once(self):
+        # `process` flushes on more than one path; a row must not double-write
+        # if a result ever crosses two of them.
+        result = self._result(
+            deferred_failure={
+                "source": "harness",
+                "severity": "error",
+                "error_class": "OpenClawChatError",
+                "error_message": "LLM request failed.",
+                "session_id": "s1",
+                "model": None,
+                "context": {},
+            }
+        )
+        with mock.patch.object(
+            harness_adapter, "record_failure"
+        ) as record_failure:
+            OpenClawAdapter._flush_deferred_failure(result)
+            OpenClawAdapter._flush_deferred_failure(result)
+        record_failure.assert_called_once()
+        self.assertIsNone(result.deferred_failure)
+
     def test_never_retries_a_turn_with_a_tool_still_in_flight(self):
         # The dangerous case tool_calls alone cannot see: the call STARTED,
         # may already have created the Doc, and its result event never
@@ -1275,6 +1394,96 @@ class TestUpstreamRetry(unittest.TestCase):
         self.assertEqual(result.tool_calls, [], "the start never completed")
         self.assertEqual(result.tools_in_flight, 1)
         self.assertFalse(OpenClawAdapter._should_retry_upstream(result))
+
+    def test_a_clean_upstream_error_defers_its_row_end_to_end(self):
+        # The mirror of the tool-in-flight test above, and the half that makes
+        # the deferral real: drive a turn that dies as a clean upstream error
+        # with NO tool activity and assert `_process_once` wrote nothing —
+        # `process` owns that decision now, because only `process` knows
+        # whether the retry rescued the turn.
+        chat_id = None
+
+        class FakeWebSocket:
+            def __init__(self, messages):
+                self.messages = list(messages)
+                self.sent = []
+
+            def send(self, payload):
+                nonlocal chat_id
+                parsed = json.loads(payload)
+                self.sent.append(parsed)
+                if parsed.get("method") == "chat.send":
+                    chat_id = parsed["id"]
+
+            def recv(self):
+                message = self.messages.pop(0)
+                return message() if callable(message) else message
+
+            def settimeout(self, _timeout):
+                return None
+
+            def close(self):
+                return None
+
+        def envelope(**fields):
+            return json.dumps(fields)
+
+        messages = [
+            envelope(type="event", event="connect.challenge", payload={}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={"tools": []}),
+            lambda: envelope(type="res", id=socket.sent[-1]["id"], ok=True,
+                             payload={}),
+            lambda: envelope(type="res", id=chat_id, ok=True,
+                             payload={"runId": chat_id, "status": "started"}),
+            # The exact prod shape: dies immediately, no tool ever started.
+            lambda: envelope(
+                type="event",
+                event="chat",
+                payload={
+                    "runId": chat_id,
+                    "seq": 3,
+                    "state": "error",
+                    "errorMessage": "LLM request failed.",
+                },
+            ),
+        ]
+        socket = FakeWebSocket(messages)
+        fake_websocket_module = mock.Mock()
+        fake_websocket_module.create_connection.return_value = socket
+        fake_websocket_module.WebSocketTimeoutException = TimeoutError
+        empty_usage = {
+            "input": 0,
+            "output": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+            "model_calls": 0,
+            "capture_complete": False,
+        }
+        adapter = OpenClawAdapter()
+        adapter._ready = True
+
+        with (
+            mock.patch.dict(sys.modules, {"websocket": fake_websocket_module}),
+            mock.patch.object(adapter, "_read_turn_usage",
+                              return_value=empty_usage),
+            mock.patch("harness_adapter.record_failure") as record_failure,
+            mock.patch("harness_adapter.time.time", return_value=100.0),
+        ):
+            result = adapter._process_once("summarize", "s1", deadline_s=550)
+
+        self.assertEqual(result.error_class, "OpenClawChatError")
+        self.assertTrue(OpenClawAdapter._should_retry_upstream(result))
+        record_failure.assert_not_called()
+        self.assertIsNotNone(result.deferred_failure)
+        self.assertEqual(
+            result.deferred_failure["error_class"], "OpenClawChatError"
+        )
+        self.assertEqual(
+            result.deferred_failure["context"]["phase"], "chat_event_error"
+        )
 
     def test_retry_runs_inside_the_remaining_turn_budget(self):
         # A second FULL deadline would blow through the 550s ceiling that

--- a/infra/lambdas/agent-cron/index.ts
+++ b/infra/lambdas/agent-cron/index.ts
@@ -89,6 +89,7 @@ import {
   createRunTelemetry,
   isPromotedRunPending,
   reservePromotedRunId,
+  settlePromotedTurnFailure,
   updatePromotedRunTerminal,
 } from './run-telemetry';
 import { runSchedulePreflight } from './schedule-preflight';
@@ -1638,6 +1639,29 @@ async function tryPromoteScheduledResult(
       log,
     );
     return false;
+  }
+  // The turn is recovering on the job path, so the harness's row no longer
+  // describes a failed turn. Telemetry hygiene only — never let it break a
+  // promotion that already succeeded.
+  try {
+    await settlePromotedTurnFailure(
+      {
+        databaseResourceArn: DATABASE_RESOURCE_ARN,
+        databaseSecretArn: DATABASE_SECRET_ARN,
+        databaseName: DATABASE_NAME,
+      },
+      runTelemetryRdsClient,
+      {
+        sessionId: runtimeSessionId,
+        errorClass: result.errorClass ?? '',
+      },
+    );
+  } catch (error) {
+    log.warn('Could not settle the promoted turn\'s failure row', {
+      sessionId: runtimeSessionId,
+      errorClass: result.errorClass ?? null,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
   await sendPromotionAcknowledgement(context, reason);
   return true;

--- a/infra/lambdas/agent-cron/run-telemetry.ts
+++ b/infra/lambdas/agent-cron/run-telemetry.ts
@@ -499,6 +499,58 @@ export async function writeCronFailure(
   );
 }
 
+/**
+ * Settle the HARNESS's failure row after a scheduled turn was promoted.
+ *
+ * Mirrors agent-router's `markPromotedTurnRecovered` — see the reasoning
+ * there. The row this touches is not one this Lambda wrote: the harness
+ * records it inside the container the moment the interactive clock runs out or
+ * the transcript overflows, keyed on the AgentCore runtime session id, before
+ * anything here knows the turn is about to be resumed on the job path.
+ *
+ * `sessionId` must therefore be the RUNTIME session (`runtimeSessionId`), not
+ * the per-schedule conversation session — matching what the container wrote.
+ *
+ * Bounded to the newest unacknowledged row of this class in the last five
+ * minutes so a runtime session id, which is stable per owner rather than per
+ * turn, cannot settle an unrelated failure.
+ */
+export async function settlePromotedTurnFailure(
+  config: RunTelemetryConfig,
+  rdsDataClient: RunTelemetryRdsClient,
+  params: { sessionId: string; errorClass: string },
+): Promise<void> {
+  if (!config.databaseResourceArn || !config.databaseSecretArn) {
+    throw new Error('Cron failure telemetry database is not configured');
+  }
+  await rdsDataClient.execute({
+    resourceArn: config.databaseResourceArn,
+    secretArn: config.databaseSecretArn,
+    database: config.databaseName,
+    sql: `UPDATE agent_failures
+             SET severity = 'warn',
+                 acknowledged = TRUE,
+                 acknowledged_by = 'system:job-promotion',
+                 acknowledged_at = NOW(),
+                 context = COALESCE(context, '{}'::jsonb)
+                           || '{"promoted":true}'::jsonb
+           WHERE id = (
+             SELECT id
+               FROM agent_failures
+              WHERE session_id = :session_id
+                AND error_class = :error_class
+                AND acknowledged = FALSE
+                AND occurred_at > NOW() - INTERVAL '5 minutes'
+              ORDER BY occurred_at DESC
+              LIMIT 1
+           )`,
+    parameters: [
+      { name: 'session_id', value: { stringValue: params.sessionId } },
+      { name: 'error_class', value: { stringValue: params.errorClass } },
+    ],
+  });
+}
+
 type CronFailureRecorder = (
   params: CronFailureRecord,
   log: CronTelemetryLogger,

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -38,6 +38,7 @@ const {
   isDuplicateMessage,
   parseDeferredChatDelivery,
   parseDeferredChatDeliveryRecord,
+  markPromotedTurnRecoveredWithDependencies,
   btwSlashCommandId,
 } = agentRouterTestHelpers
 
@@ -2219,5 +2220,98 @@ describe("dmSpaceForUserRecord", () => {
       dmSpaceForUserRecord({ name: "DDD4", type: "DM" }, "DDD4"),
     ).toBeUndefined()
     expect(dmSpaceForUserRecord({ name: "", type: "DM" }, "")).toBeUndefined()
+  })
+})
+
+describe("settling a promoted turn's harness failure row", () => {
+  // The harness writes its deadline / overflow row from inside the container
+  // the moment the interactive clock runs out — before the router decides to
+  // resume the same request on the job path and answer it for real. Every
+  // promotable row in prod during the week of 2026-08-21 was in fact promoted
+  // within ~20 seconds (10/10 ChatDeadlineExpired*, 4/4 ContextOverflow), so
+  // 14 of that week's 35 hard-error rows described turns the user got answered.
+  function sqlSpy() {
+    const statements: string[] = []
+    const values: unknown[][] = []
+    const sql = ((strings: TemplateStringsArray, ...args: unknown[]) => {
+      statements.push(strings.join("?"))
+      values.push(args)
+      return Promise.resolve([{ id: 1 }])
+    }) as unknown as Parameters<
+      typeof markPromotedTurnRecoveredWithDependencies
+    >[3] extends () => Promise<infer S>
+      ? S
+      : never
+    return { sql, statements, values }
+  }
+
+  const log = createLogger({ action: "test" })
+
+  test("downgrades and self-acknowledges the row rather than deleting it", async () => {
+    const spy = sqlSpy()
+
+    await markPromotedTurnRecoveredWithDependencies(
+      "agent-rt-abc-def",
+      "ChatDeadlineExpired",
+      log,
+      async () => spy.sql
+    )
+
+    expect(spy.statements).toHaveLength(1)
+    const statement = spy.statements[0]
+    // Kept, not removed: the 550s ceiling is worth trending.
+    expect(statement).toContain("UPDATE agent_failures")
+    expect(statement).not.toContain("DELETE")
+    expect(statement).toContain("severity = 'warn'")
+    expect(statement).toContain("acknowledged = TRUE")
+    expect(statement).toContain("'system:job-promotion'")
+    expect(statement).toContain('\'{"promoted":true}\'::jsonb')
+    expect(spy.values[0]).toEqual([
+      "agent-rt-abc-def",
+      "ChatDeadlineExpired",
+    ])
+  })
+
+  test("cannot settle a row belonging to another turn", async () => {
+    // The runtime session id is stable per OWNER, not per turn, so an
+    // unbounded match could acknowledge a genuinely-broken failure of theirs.
+    const spy = sqlSpy()
+
+    await markPromotedTurnRecoveredWithDependencies(
+      "agent-rt-abc-def",
+      "ContextOverflow",
+      log,
+      async () => spy.sql
+    )
+
+    const statement = spy.statements[0]
+    expect(statement).toContain("acknowledged = FALSE")
+    expect(statement).toContain("NOW() - INTERVAL '5 minutes'")
+    expect(statement).toContain("ORDER BY occurred_at DESC")
+    expect(statement).toContain("LIMIT 1")
+  })
+
+  test("does nothing without a session id or an error class", async () => {
+    const spy = sqlSpy()
+
+    await markPromotedTurnRecoveredWithDependencies("", "ChatDeadlineExpired", log, async () => spy.sql)
+    await markPromotedTurnRecoveredWithDependencies("agent-rt-abc-def", "", log, async () => spy.sql)
+
+    expect(spy.statements).toHaveLength(0)
+  })
+
+  test("never lets telemetry hygiene fail a promotion that already succeeded", async () => {
+    // Reached only AFTER the job task is accepted. The user's work is already
+    // in flight; a database problem here must not turn that into an error.
+    await expect(
+      markPromotedTurnRecoveredWithDependencies(
+        "agent-rt-abc-def",
+        "ChatDeadlineExpired",
+        log,
+        async () => {
+          throw new Error("pool exhausted")
+        }
+      )
+    ).resolves.toBeUndefined()
   })
 })

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -3880,6 +3880,87 @@ async function recordFailure(
 }
 
 /**
+ * Settle the harness's failure row after the turn was promoted to a job.
+ *
+ * The harness writes the row the moment the interactive clock runs out (or the
+ * transcript overflows) — it cannot know that this Lambda is about to hand the
+ * same request to the job runner on a 2-hour deadline and deliver the real
+ * answer. Left alone, a designed, successful recovery reads as an
+ * unacknowledged failure: in the week of 2026-08-21 EVERY promotable row in
+ * prod had in fact been promoted within ~20 seconds — 10/10
+ * ChatDeadlineExpired* and 4/4 ContextOverflow — 14 of that week's 35
+ * hard-error rows describing turns the user got answered.
+ *
+ * The row is kept (the 550s ceiling and the overflow rate are both worth
+ * trending) but downgraded to warn and self-acknowledged, so the Failures tab
+ * shows what actually broke.
+ *
+ * Never throws — this is telemetry hygiene running after the user's work is
+ * already safely in flight.
+ *
+ * Scoping note: `sessionId` is the build-rotated runtime session, which is
+ * stable per owner rather than per turn, so the match is additionally bounded
+ * to the newest unacknowledged row of THIS error class in the last five
+ * minutes. A promotable turn ends either at the ~550s ceiling or on a
+ * first-call overflow, so the wrong row cannot be in range.
+ */
+async function markPromotedTurnRecovered(
+  sessionId: string,
+  errorClass: string,
+  log: ReturnType<typeof createLogger>
+): Promise<void> {
+  if (!DATABASE_HOST || !DATABASE_SECRET_ARN) return;
+  await markPromotedTurnRecoveredWithDependencies(
+    sessionId,
+    errorClass,
+    log,
+    getDbClient
+  );
+}
+
+async function markPromotedTurnRecoveredWithDependencies(
+  sessionId: string,
+  errorClass: string,
+  log: ReturnType<typeof createLogger>,
+  getSql: () => Promise<postgres.Sql>
+): Promise<void> {
+  if (!sessionId || !errorClass) return;
+  try {
+    const sql = await getSql();
+    const updated = await sql`
+      UPDATE agent_failures
+         SET severity = 'warn',
+             acknowledged = TRUE,
+             acknowledged_by = 'system:job-promotion',
+             acknowledged_at = NOW(),
+             context = COALESCE(context, '{}'::jsonb)
+                       || '{"promoted":true}'::jsonb
+       WHERE id = (
+         SELECT id
+           FROM agent_failures
+          WHERE session_id = ${sessionId}
+            AND error_class = ${errorClass}
+            AND acknowledged = FALSE
+            AND occurred_at > NOW() - INTERVAL '5 minutes'
+          ORDER BY occurred_at DESC
+          LIMIT 1
+       )
+       RETURNING id`;
+    log.info('Settled the promoted turn\'s failure row', {
+      sessionId,
+      errorClass,
+      rowsSettled: updated.length,
+    });
+  } catch (error) {
+    log.warn('Could not settle the promoted turn\'s failure row', {
+      sessionId,
+      errorClass,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
  * Observe a failed agent turn without changing the user-facing behavior (the
  * error text is still delivered to Chat by the caller). Fixes the gap where a
  * 0-token error turn — e.g. an OpenClaw session-init conflict — was logged as a
@@ -5300,6 +5381,14 @@ async function promoteOwnerTurn(
   );
   if (!promoted) return false;
 
+  // The turn is recovering on the job path, so the harness's row no longer
+  // describes a failed turn. Settle it before telemetry.
+  await markPromotedTurnRecovered(
+    turn.sessionId,
+    turn.result.errorClass ?? '',
+    log
+  );
+
   const latencyMs =
     turn.result.latencyMs > 0
       ? turn.result.latencyMs
@@ -5523,6 +5612,7 @@ export const agentRouterTestHelpers = {
   isDuplicateMessage,
   parseDeferredChatDelivery,
   parseDeferredChatDeliveryRecord,
+  markPromotedTurnRecoveredWithDependencies,
   btwSlashCommandId: BTW_SLASH_COMMAND_ID,
 };
 

--- a/lib/agent-workspace/atrium-owner-operation.ts
+++ b/lib/agent-workspace/atrium-owner-operation.ts
@@ -21,7 +21,7 @@ import type { PublishDestination } from "@/lib/content/publish-adapters/types"
 import { requesterForUserId } from "@/lib/content/requester-from-auth"
 import {
   assertContentAuthoringCapability,
-  contentDeepLink,
+  contentSurfaceLink,
   resolveCollectionId,
 } from "@/lib/content/surface-helpers"
 import { contentSourceRefSchema } from "@/lib/content/source-ref"
@@ -331,7 +331,7 @@ async function executeSingleSegmentRead(
     return success([...collectionsById.values()], requestId)
   }
   const object = await contentService.get(req, segment)
-  return success({ ...object, url: contentDeepLink(object.slug) }, requestId)
+  return success({ ...object, url: contentSurfaceLink(object) }, requestId)
 }
 
 async function executeTwoSegmentRead(
@@ -444,7 +444,7 @@ async function executeAtriumRead(
     return success(
       items.map((item) => ({
         ...item,
-        url: contentDeepLink(item.slug),
+        url: contentSurfaceLink(item),
       })),
       input.requestId
     )
@@ -538,7 +538,7 @@ async function executeContentWrite(
     audit.objectId = created.id
     recordAudit(req, audit, input.requestId, "ok")
     return success(
-      { ...created, url: contentDeepLink(created.slug) },
+      { ...created, url: contentSurfaceLink(created) },
       input.requestId,
       201
     )

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -70,6 +70,19 @@ const READ_ACTIONS = new Set([
   "get",
   "list",
   "search",
+  // Chat's `spaces.findDirectMessage` is a GET that resolves the DM space the
+  // caller shares with one person; it creates nothing and sends nothing. Being
+  // spelled as a verb rather than `get` was the only reason it fell through to
+  // the write allowlist and was refused with operation_not_allowed, which left
+  // a scheduled digest with no way to find the DM it was supposed to deliver
+  // into (agent_failures 14394, 2026-08-28).
+  //
+  // Classified as a READ rather than allowlisted as a Chat write on purpose:
+  // ALLOWED_CHAT_WRITES is derived from ALLOWED_WRITES precisely because every
+  // Chat WRITE leaves the owner's Workspace and must reach the outbound audit
+  // log. A lookup that sends nothing would enter that derivation as an audit
+  // row with a null space and null body, which is not what the log means.
+  "finddirectmessage",
 ])
 
 // Bare mutating verbs only. `+`-prefixed helper verbs are covered by the
@@ -129,6 +142,25 @@ const ALLOWED_WRITES = new Set([
   "gmail users drafts create",
   "gmail users drafts update",
   "gmail users labels create",
+  // Inbox filters, on the user's own mailbox — the organizing counterpart to
+  // the label create directly above, and useless without it: three users asked
+  // for skip-inbox-and-label rules or for existing rules to be removed, and
+  // every attempt was refused (agent_failures 12909, 13866, 14559).
+  //
+  // NOTE THE TRUNCATION. operationTokens caps at FOUR positionals, so this one
+  // entry is the whole `gmail.users.settings.filters` resource — create, get,
+  // list and delete alike, since the fifth token never reaches the operation
+  // string. That is the intended grant here (removing a filter is half the
+  // ask), but it means this entry cannot be narrowed to a subset of actions
+  // without a payload-level validator. Sibling settings resources are NOT
+  // covered: `forwardingAddresses`, `sendAs`, `delegates` and `updateVacation`
+  // each occupy the fourth token themselves and so remain refused.
+  //
+  // Requires `gmail.settings.basic`, which `gmail.modify` does NOT imply — see
+  // SCOPES_BY_KIND in actions/agent-workspace.actions.ts and the scope gap in
+  // requiredWorkspaceScopeGap below, without which this widening would only
+  // convert our refusal into a Google 403.
+  "gmail users settings filters",
   "gmail users messages modify",
   // Helper forms of writes already permitted in canonical form. Verified
   // against the pinned gws v0.22.5 binary: `sheets +append` and `drive
@@ -161,6 +193,18 @@ const ALLOWED_WRITES = new Set([
   "slides presentations batchupdate",
   "slides presentations create",
   "tasks tasks insert",
+  // Reordering / reparenting a task inside a list the agent may already insert
+  // into. A user asked for their tasks grouped under four heading tasks; the
+  // four headings were inserted on the user slot and then could not be moved,
+  // so the list was left worse than before (agent_failures 14031).
+  //
+  // Placed with `tasks tasks insert` — i.e. NOT in AGENT_ONLY_WRITES — rather
+  // than with `patch`/`update`, which are agent-only. A move changes position
+  // and parent, never content, and the user slot already permits the strictly
+  // larger act of creating the task being moved. Drawing the impersonation
+  // line between "may add a task to your list" and "may reorder it" would
+  // leave the reported case broken for no gain in containment.
+  "tasks tasks move",
   "tasks tasks patch",
   "tasks tasks update",
 ])
@@ -236,6 +280,8 @@ const AGENT_ONLY_WRITES = new Set([
 const DRIVE_FOLDER_MIME = "application/vnd.google-apps.folder"
 const DRIVE_READ_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
 const DRIVE_METADATA_SCOPE = "https://www.googleapis.com/auth/drive.metadata"
+const GMAIL_SETTINGS_SCOPE =
+  "https://www.googleapis.com/auth/gmail.settings.basic"
 const DRIVE_METADATA_FIELDS = new Set([
   "name",
   "starred",
@@ -1147,7 +1193,23 @@ export function requiredWorkspaceScopeGap(
   const operation = tokens.join(" ")
   const granted = new Set(grantedScopeString.split(/\s+/).filter(Boolean))
   const required: WorkspaceScopeGap | null =
-    operation === "drive files update"
+    // `gmail.modify` does not imply `gmail.settings.basic`, and Gmail requires
+    // the latter for every settings.filters call. Without this branch the
+    // allowlist entry above would simply move the failure downstream: instead
+    // of our operation_not_allowed the user would get an opaque Google 403,
+    // which is the shape of the Classroom scope failure from the same week
+    // (agent_failures 13536). Reported as a gap instead, this reaches the
+    // existing `scope-upgrade-required` path and the skill hands the user a
+    // re-authorize link.
+    //
+    // Every user with an existing refresh token needs that re-consent: a
+    // stored token keeps the scope set it was ISSUED with.
+    operation === "gmail users settings filters"
+      ? {
+          scopes: [GMAIL_SETTINGS_SCOPE],
+          capability: "manage the filters in your Gmail inbox",
+        }
+      : operation === "drive files update"
       ? {
           scopes: [DRIVE_METADATA_SCOPE],
           capability: "rename and move files in your Drive",

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -204,6 +204,9 @@ const ALLOWED_WRITES = new Set([
   // larger act of creating the task being moved. Drawing the impersonation
   // line between "may add a task to your list" and "may reorder it" would
   // leave the reported case broken for no gain in containment.
+  //
+  // The inconsistency with `patch`/`update` was raised and the user-slot
+  // placement was confirmed deliberately (2026-08-28). Settled, not overlooked.
   "tasks tasks move",
   "tasks tasks patch",
   "tasks tasks update",

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -818,11 +818,38 @@ async function createWorkspaceFinalizationProof(
   return `${WORKSPACE_FINALIZATION_PROOF_VERSION}.${encoded}.${signature}`
 }
 
+/**
+ * Verify a checkpoint finalization proof.
+ *
+ * `journaledReplay` relaxes ONLY the invocation binding (`invocationNonce`,
+ * `expiresAt`) — never the signature, the workspace prefix, or the generation.
+ *
+ * Why it has to: a final flush that fails or times out leaves a fenced batch
+ * pending in the harness, which retries that exact batch at the START OF THE
+ * NEXT INVOCATION (agentcore_wrapper.py, pre-restore retry). The stored proof
+ * carries the ORIGINAL invocation's nonce and expiry, so with the binding
+ * enforced the retry could never succeed — it 409'd every time, the restore
+ * aborted, push was disabled for the microVM, and the user lost the turn plus
+ * their un-pushed local changes. That is the entire `WorkspaceMigrationFailed`
+ * cluster (6 rows / 5 users in the week of 2026-08-21, all with the message
+ * "Workspace finalization proof is invalid").
+ *
+ * Why it is safe to: the caller only passes `journaledReplay` when a journal
+ * entry on THIS prefix already matches the request byte for byte — same owner
+ * hash, base generation, proof hash, reservation ids, and deleted paths. That
+ * entry can only exist because a correctly-bound invocation already admitted
+ * this request. The binding's job is to stop a proof being replayed as a
+ * DIFFERENT request; an identical replay of an already-admitted one is exactly
+ * the idempotent resume the journal exists to allow. Cross-generation and
+ * cross-owner replay stay blocked by the retained generation claim and the
+ * manifest-generation check below.
+ */
 // Proof verification deliberately checks every authenticated claim before use.
 // eslint-disable-next-line complexity
 async function verifyWorkspaceFinalizationProof(
   proof: string,
   expected: WorkspaceFinalizationProofClaims,
+  options: { journaledReplay?: boolean } = {},
 ): Promise<void> {
   if (
     !proof ||
@@ -885,10 +912,20 @@ async function verifyWorkspaceFinalizationProof(
     candidate.signedWorkspacePrefix !==
       expected.signedWorkspacePrefix ||
     candidate.workspaceGeneration !== expected.workspaceGeneration ||
-    candidate.invocationNonce !== expected.invocationNonce ||
-    candidate.expiresAt !== expected.expiresAt ||
-    !Number.isInteger(candidate.expiresAt) ||
-    candidate.expiresAt! < Math.floor(Date.now() / 1000)
+    typeof candidate.invocationNonce !== "string" ||
+    !candidate.invocationNonce ||
+    !Number.isInteger(candidate.expiresAt)
+  ) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof is invalid",
+    )
+  }
+  // The invocation binding is the only thing a journaled replay may outlive.
+  if (
+    !options.journaledReplay &&
+    (candidate.invocationNonce !== expected.invocationNonce ||
+      candidate.expiresAt !== expected.expiresAt ||
+      candidate.expiresAt! < Math.floor(Date.now() / 1000))
   ) {
     throw new WorkspaceStorageCompletionError(
       "Workspace finalization proof is invalid",
@@ -4241,13 +4278,19 @@ export async function finalizeWorkspaceCheckpoint(
         const existingJournal = await readWorkspaceFinalizationJournal(
           prefix,
         )
-        if (
+        // A byte-identical journal entry proves THIS EXACT request was already
+        // admitted under a valid invocation binding: same owner, same prefix,
+        // same base generation, same proof hash, same reservations, same
+        // deletions. The replay may therefore arrive on a LATER invocation —
+        // see the `journaledReplay` note on verifyWorkspaceFinalizationProof.
+        const journaledReplay = Boolean(
           existingJournal &&
           workspaceFinalizationRequestsEqual(
             existingJournal,
             journalRequest,
           )
-        ) {
+        )
+        if (existingJournal && journaledReplay) {
           if (existingJournal.state !== "pending") {
             if (
               manifest &&
@@ -4296,6 +4339,7 @@ export async function finalizeWorkspaceCheckpoint(
             invocationNonce,
             expiresAt: invocationExpiresAt,
           },
+          { journaledReplay },
         )
         if (
           !manifest ||

--- a/lib/content/reader-links.ts
+++ b/lib/content/reader-links.ts
@@ -20,6 +20,45 @@ export function contentDeepLink(slug: string): string {
 }
 
 /**
+ * The authoring-surface link for an object that has no live reader page.
+ *
+ * Artifacts get the chrome-free full-screen view; documents get the authoring
+ * page, which is where their body actually renders. Both are gated purely on
+ * `canView`, so an owner reaches their own unpublished content through either.
+ */
+function atriumSurfaceLink(id: string, kind: "document" | "artifact"): string {
+  const base = process.env.ATRIUM_PUBLIC_BASE_URL?.replace(/\/$/, "") ?? "";
+  return `${base}/atrium/${id}/${kind === "artifact" ? "view" : "edit"}`;
+}
+
+/**
+ * The link to hand a caller for a content object — the one that will actually
+ * open for someone who can view it.
+ *
+ * `/c/{slug}` requires a LIVE INTRANET PUBLICATION (see the reader page). For a
+ * draft it 404s, and because the reader masks existence it 404s for the OWNER
+ * too. Returning it unconditionally therefore handed every API and skill caller
+ * a dead link for content that had just been created: psd-morning-brief creates
+ * a private artifact and never publishes it, so EVERY morning brief DM linked
+ * to a page that 404'd for its own recipient — every user, every day, from the
+ * feature's first run until this fix. It surfaced only because one user
+ * reported it twice (failures 13503 / 13998, week of 2026-08-21).
+ *
+ * Published objects keep the canonical reader link; everything else gets the
+ * authoring surface, which renders the head version for anyone who can view it.
+ */
+export function contentSurfaceLink(object: {
+  id: string;
+  slug: string;
+  kind: "document" | "artifact";
+  status: "draft" | "published" | "archived";
+}): string {
+  return object.status === "published"
+    ? contentDeepLink(object.slug)
+    : atriumSurfaceLink(object.id, object.kind);
+}
+
+/**
  * The PUBLIC (anonymous) reader link for a content object at `/p/[slug]` — the
  * `external_ref` the `public_web` publish adapter records and the URL a
  * public-web publication is served at (Phase 7, #1057). Built from

--- a/lib/content/surface-helpers.ts
+++ b/lib/content/surface-helpers.ts
@@ -102,7 +102,11 @@ export async function resolveCollectionId(
 // The two reader-link builders moved to the dependency-free `./reader-links`
 // leaf (#1336) so services can import them without pulling in this module's
 // capability/DB graph. Re-exported here so every existing import path is unchanged.
-export { contentDeepLink, publicReaderLink } from "./reader-links";
+export {
+  contentDeepLink,
+  contentSurfaceLink,
+  publicReaderLink,
+} from "./reader-links";
 
 /** The capability every Atrium authoring entry point (UI actions + agent surfaces) gates on. */
 export const ATRIUM_CONTENT_CAPABILITY = "atrium-content";

--- a/lib/mcp/content-tool-handlers.ts
+++ b/lib/mcp/content-tool-handlers.ts
@@ -30,7 +30,7 @@ import {
 } from "@/lib/content";
 import {
   assertContentAuthoringCapability,
-  contentDeepLink,
+  contentSurfaceLink,
   resolveCollectionId,
 } from "@/lib/content/surface-helpers";
 import {
@@ -238,7 +238,7 @@ async function createContent(
     return ok({
       id: created.id,
       slug: created.slug,
-      url: contentDeepLink(created.slug),
+      url: contentSurfaceLink(created),
       visibilityLevel: created.visibilityLevel,
       sourceRef: created.sourceRef,
     });
@@ -333,7 +333,7 @@ async function handleGetContent(
             authorActor: obj.version.authorActor,
           }
         : null,
-      url: contentDeepLink(obj.slug),
+      url: contentSurfaceLink(obj),
     });
   } catch (err) {
     return failRead(err);

--- a/tests/unit/agent-atrium-owner-operation.test.ts
+++ b/tests/unit/agent-atrium-owner-operation.test.ts
@@ -52,6 +52,17 @@ jest.mock("@/lib/content/surface-helpers", () => ({
   assertContentAuthoringCapability: (...args: unknown[]) =>
     assertContentAuthoringCapabilityMock(...args),
   contentDeepLink: (slug: string) => `/c/${slug}`,
+  // Mirrors the real builder: only PUBLISHED objects have a reader page, so a
+  // draft is linked to its authoring surface instead of a `/c/` URL that 404s.
+  contentSurfaceLink: (object: {
+    id: string
+    slug: string
+    kind: "document" | "artifact"
+    status: string
+  }) =>
+    object.status === "published"
+      ? `/c/${object.slug}`
+      : `/atrium/${object.id}/${object.kind === "artifact" ? "view" : "edit"}`,
   resolveCollectionId: (...args: unknown[]) => resolveCollectionIdMock(...args),
 }))
 jest.mock("@/lib/content", () => {
@@ -435,8 +446,9 @@ describe("signed-owner Atrium operations", () => {
   })
 
   it("resolves the signed email to the owner requester for reads", async () => {
+    const draft = { kind: "document", status: "draft" }
     contentListMock.mockResolvedValue([
-      { id: "content-1", slug: "staff-handbook" },
+      { id: "content-1", slug: "staff-handbook", ...draft },
     ])
     await expect(
       executeOwnerAtriumOperation({
@@ -457,7 +469,10 @@ describe("signed-owner Atrium operations", () => {
           {
             id: "content-1",
             slug: "staff-handbook",
-            url: "/c/staff-handbook",
+            ...draft,
+            // NOT `/c/staff-handbook`: that reader needs a live intranet
+            // publication and 404s without one, for the owner too.
+            url: "/atrium/content-1/edit",
           },
         ],
         meta: { requestId: "request-1" },
@@ -500,6 +515,8 @@ describe("signed-owner Atrium mutations", () => {
     contentCreateMock.mockResolvedValue({
       id: "content-1",
       slug: "new-document",
+      kind: "document",
+      status: "draft",
     })
     await expect(
       executeOwnerAtriumOperation({
@@ -519,7 +536,11 @@ describe("signed-owner Atrium mutations", () => {
         data: {
           id: "content-1",
           slug: "new-document",
-          url: "/c/new-document",
+          kind: "document",
+          status: "draft",
+          // A just-created object is never published, so the link an agent
+          // hands its user must be one that opens.
+          url: "/atrium/content-1/edit",
         },
         meta: { requestId: "request-2" },
       },

--- a/tests/unit/agent-cron-run-telemetry.test.ts
+++ b/tests/unit/agent-cron-run-telemetry.test.ts
@@ -3,6 +3,7 @@ import {
   createRunTelemetry,
   isPromotedRunPending,
   reservePromotedRunId,
+  settlePromotedTurnFailure,
   updatePromotedRunTerminal,
   writePreflightRun,
   type CronTelemetryLogger,
@@ -25,6 +26,70 @@ function harness(overrides: Partial<typeof config> = {}) {
   const log = { warn, error } satisfies CronTelemetryLogger
   return { telemetry, execute, warn, error, log }
 }
+
+describe("settling a promoted turn's harness failure row", () => {
+  // The harness writes its row the moment the interactive clock runs out or
+  // the transcript overflows — before anything knows the turn is about to be
+  // resumed on the job path and answered. In the week of 2026-08-21 that made
+  // 14 of prod's 35 hard-error rows describe turns the user got answered
+  // (10/10 ChatDeadlineExpired*, 4/4 ContextOverflow — every promotable row
+  // was in fact promoted, within ~20s).
+  it("downgrades and self-acknowledges the row rather than deleting it", async () => {
+    const execute = jest.fn().mockResolvedValue({})
+
+    await settlePromotedTurnFailure(config, { execute }, {
+      sessionId: "agent-rt-abc-def",
+      errorClass: "ChatDeadlineExpired",
+    })
+
+    const { sql, parameters } = execute.mock.calls[0][0]
+    // Kept, not removed: the 550s ceiling is worth trending.
+    expect(sql).toContain("UPDATE agent_failures")
+    expect(sql).not.toContain("DELETE")
+    expect(sql).toContain("severity = 'warn'")
+    expect(sql).toContain("acknowledged = TRUE")
+    expect(sql).toContain("'system:job-promotion'")
+    expect(sql).toContain('\'{"promoted":true}\'::jsonb')
+    expect(parameters).toEqual([
+      { name: "session_id", value: { stringValue: "agent-rt-abc-def" } },
+      {
+        name: "error_class",
+        value: { stringValue: "ChatDeadlineExpired" },
+      },
+    ])
+  })
+
+  it("cannot settle a row belonging to another turn", async () => {
+    // The runtime session id is stable per OWNER, not per turn, so the match
+    // has to be bounded or a promotion could acknowledge an unrelated,
+    // genuinely-broken failure from the same user.
+    const execute = jest.fn().mockResolvedValue({})
+
+    await settlePromotedTurnFailure(config, { execute }, {
+      sessionId: "agent-rt-abc-def",
+      errorClass: "ContextOverflow",
+    })
+
+    const { sql } = execute.mock.calls[0][0]
+    expect(sql).toContain("acknowledged = FALSE")
+    expect(sql).toContain("NOW() - INTERVAL '5 minutes'")
+    expect(sql).toContain("ORDER BY occurred_at DESC")
+    expect(sql).toContain("LIMIT 1")
+  })
+
+  it("refuses to run without a configured database", async () => {
+    const execute = jest.fn()
+
+    await expect(
+      settlePromotedTurnFailure(
+        { ...config, databaseResourceArn: "" },
+        { execute },
+        { sessionId: "agent-rt-abc-def", errorClass: "ChatDeadlineExpired" },
+      ),
+    ).rejects.toThrow("not configured")
+    expect(execute).not.toHaveBeenCalled()
+  })
+})
 
 describe("agent-cron run telemetry", () => {
   it("reserves a promoted row ID without creating the row", async () => {

--- a/tests/unit/agent-workspace-user-slot-scopes.test.ts
+++ b/tests/unit/agent-workspace-user-slot-scopes.test.ts
@@ -45,6 +45,10 @@ function userAccountScopes(): string[] {
 
 const DRIVE_READONLY = "https://www.googleapis.com/auth/drive.readonly";
 const DRIVE_METADATA = "https://www.googleapis.com/auth/drive.metadata";
+const GMAIL_SETTINGS_BASIC =
+  "https://www.googleapis.com/auth/gmail.settings.basic";
+const GMAIL_SETTINGS_SHARING =
+  "https://www.googleapis.com/auth/gmail.settings.sharing";
 
 describe("user-slot consent scopes", () => {
   it("is exactly the approved set — no more, no less", () => {
@@ -59,9 +63,26 @@ describe("user-slot consent scopes", () => {
         DRIVE_METADATA,
         DRIVE_READONLY,
         "https://www.googleapis.com/auth/gmail.modify",
+        GMAIL_SETTINGS_BASIC,
         "https://www.googleapis.com/auth/tasks",
       ].sort()
     );
+  });
+
+  it("grants gmail.settings.basic for inbox filters (approved 2026-08-28)", () => {
+    // gmail.modify does NOT cover settings.filters, so filter management was
+    // impossible for three users who asked for it (agent_failures 12909,
+    // 13866, 14559) — the broker allowlist alone could not have fixed it.
+    expect(userAccountScopes()).toContain(GMAIL_SETTINGS_BASIC);
+  });
+
+  it("never requests gmail.settings.sharing — the account-takeover half", () => {
+    // `.basic` covers filters, labels, vacation and IMAP/POP. `.sharing` is
+    // the one that adds FORWARDING ADDRESSES, SEND-AS ALIASES and DELEGATES:
+    // standing configuration that redirects a mailbox or lets another account
+    // send as this user. Nothing asked for needs it, and it must not arrive as
+    // a side effect of wanting filters.
+    expect(userAccountScopes()).not.toContain(GMAIL_SETTINGS_SHARING);
   });
 
   it("grants the two Drive scopes #1305 added", () => {

--- a/tests/unit/atrium-content-code-encoding-routes.test.ts
+++ b/tests/unit/atrium-content-code-encoding-routes.test.ts
@@ -74,6 +74,17 @@ jest.mock("@/lib/content/rest", () => {
 jest.mock("@/lib/content/surface-helpers", () => ({
   assertContentAuthoringCapability: jest.fn(),
   contentDeepLink: (slug: string) => `/c/${slug}`,
+  // Mirrors the real builder: only PUBLISHED objects have a reader page, so a
+  // draft is linked to its authoring surface instead of a `/c/` URL that 404s.
+  contentSurfaceLink: (object: {
+    id: string
+    slug: string
+    kind: "document" | "artifact"
+    status: string
+  }) =>
+    object.status === "published"
+      ? `/c/${object.slug}`
+      : `/atrium/${object.id}/${object.kind === "artifact" ? "view" : "edit"}`,
   resolveCollectionId: (...a: unknown[]) => mockResolveCollectionId(...a),
 }));
 
@@ -237,6 +248,8 @@ describe("POST /api/v1/content — codeEncoding decode", () => {
     const recovered = {
       id: "object-committed-once",
       slug: "region-capture",
+      kind: "document",
+      status: "draft",
       visibilityLevel: "private",
       currentVersionId: null,
       version: null,
@@ -285,7 +298,9 @@ describe("POST /api/v1/content — codeEncoding decode", () => {
       {
         data: {
           ...recovered,
-          url: "/c/region-capture",
+          // A recovered capture is still a draft, and `/c/region-capture`
+          // 404s without a live intranet publication — for the owner too.
+          url: "/atrium/object-committed-once/edit",
         },
         meta: { requestId: "req-recovery" },
       },

--- a/tests/unit/atrium-content-etag-route.test.ts
+++ b/tests/unit/atrium-content-etag-route.test.ts
@@ -25,6 +25,17 @@ jest.mock("@/lib/content/rest", () => ({
 jest.mock("@/lib/content/surface-helpers", () => ({
   assertContentAuthoringCapability: jest.fn(),
   contentDeepLink: (slug: string) => `/c/${slug}`,
+  // Mirrors the real builder: only PUBLISHED objects have a reader page, so a
+  // draft is linked to its authoring surface instead of a `/c/` URL that 404s.
+  contentSurfaceLink: (object: {
+    id: string
+    slug: string
+    kind: "document" | "artifact"
+    status: string
+  }) =>
+    object.status === "published"
+      ? `/c/${object.slug}`
+      : `/atrium/${object.id}/${object.kind === "artifact" ? "view" : "edit"}`,
   resolveCollectionId: jest.fn(),
 }));
 

--- a/tests/unit/atrium-content-surface-link.test.ts
+++ b/tests/unit/atrium-content-surface-link.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `contentSurfaceLink` — the link a caller is handed for a content object.
+ *
+ * `/c/{slug}` is served only when the object has a LIVE INTRANET PUBLICATION.
+ * Without one the reader calls `notFound()`, and because it masks existence
+ * rather than returning 403, it 404s for the OWNER too. Returning that URL for
+ * every object therefore handed API and skill callers a dead link for anything
+ * they had just created.
+ *
+ * That is not hypothetical: psd-morning-brief creates a private artifact and
+ * never publishes it, so every morning-brief DM linked to a page that 404'd
+ * for its own recipient — every user, every day, until this was fixed. One
+ * user reported it twice (agent_failures 13503 and 13998, 2026-08-26).
+ */
+
+const BASE = "https://aistudio.psd401.ai";
+
+describe("contentSurfaceLink", () => {
+  let contentSurfaceLink: typeof import(
+    "@/lib/content/reader-links"
+  )["contentSurfaceLink"];
+  let contentDeepLink: typeof import(
+    "@/lib/content/reader-links"
+  )["contentDeepLink"];
+  const originalBase = process.env.ATRIUM_PUBLIC_BASE_URL;
+
+  beforeAll(() => {
+    process.env.ATRIUM_PUBLIC_BASE_URL = BASE;
+    // The module reads the env var per call, but require after setting it so
+    // this suite is order-independent.
+    ({ contentSurfaceLink, contentDeepLink } = jest.requireActual<
+      typeof import("@/lib/content/reader-links")
+    >("@/lib/content/reader-links"));
+  });
+
+  afterAll(() => {
+    if (originalBase === undefined) delete process.env.ATRIUM_PUBLIC_BASE_URL;
+    else process.env.ATRIUM_PUBLIC_BASE_URL = originalBase;
+  });
+
+  it("uses the reader deep link once the object is published", () => {
+    expect(
+      contentSurfaceLink({
+        id: "obj-1",
+        slug: "staff-handbook",
+        kind: "document",
+        status: "published",
+      })
+    ).toBe(contentDeepLink("staff-handbook"));
+    expect(
+      contentSurfaceLink({
+        id: "obj-1",
+        slug: "staff-handbook",
+        kind: "document",
+        status: "published",
+      })
+    ).toBe(`${BASE}/c/staff-handbook`);
+  });
+
+  it("sends a draft ARTIFACT to the full-screen view, not the reader", () => {
+    // The morning brief's exact shape: a private, never-published artifact.
+    expect(
+      contentSurfaceLink({
+        id: "obj-2",
+        slug: "morning-brief-2026-08-26",
+        kind: "artifact",
+        status: "draft",
+      })
+    ).toBe(`${BASE}/atrium/obj-2/view`);
+  });
+
+  it("sends a draft DOCUMENT to its authoring page", () => {
+    expect(
+      contentSurfaceLink({
+        id: "obj-3",
+        slug: "new-document",
+        kind: "document",
+        status: "draft",
+      })
+    ).toBe(`${BASE}/atrium/obj-3/edit`);
+  });
+
+  it("keeps an ARCHIVED object off the reader too", () => {
+    // Archiving retracts publications, so `/c/` would 404 exactly as a draft
+    // does. Only `published` earns the reader link.
+    expect(
+      contentSurfaceLink({
+        id: "obj-4",
+        slug: "retired-policy",
+        kind: "document",
+        status: "archived",
+      })
+    ).toBe(`${BASE}/atrium/obj-4/edit`);
+  });
+});

--- a/tests/unit/atrium-mcp-unpublish-handler.test.ts
+++ b/tests/unit/atrium-mcp-unpublish-handler.test.ts
@@ -61,6 +61,17 @@ jest.mock("@/lib/content", () => {
 jest.mock("@/lib/content/surface-helpers", () => ({
   assertContentAuthoringCapability: (...a: unknown[]) => mockAssertCapability(...a),
   contentDeepLink: (slug: string) => `/c/${slug}`,
+  // Mirrors the real builder: only PUBLISHED objects have a reader page, so a
+  // draft is linked to its authoring surface instead of a `/c/` URL that 404s.
+  contentSurfaceLink: (object: {
+    id: string
+    slug: string
+    kind: "document" | "artifact"
+    status: string
+  }) =>
+    object.status === "published"
+      ? `/c/${object.slug}`
+      : `/atrium/${object.id}/${object.kind === "artifact" ? "view" : "edit"}`,
   resolveCollectionId: (...a: unknown[]) => mockResolveCollectionId(...a),
 }));
 
@@ -242,6 +253,8 @@ describe("create_document handler", () => {
     mockCreate.mockResolvedValue({
       id: "obj-1",
       slug: "my-doc",
+      kind: "document",
+      status: "draft",
       visibilityLevel: "private",
     });
 
@@ -254,7 +267,9 @@ describe("create_document handler", () => {
     expect(payloadOf(result)).toEqual({
       id: "obj-1",
       slug: "my-doc",
-      url: "/c/my-doc",
+      // A brand-new document has no live intranet publication, so `/c/my-doc`
+      // would 404 — for its own author, because the reader masks existence.
+      url: "/atrium/obj-1/edit",
       visibilityLevel: "private",
     });
   });

--- a/tests/unit/atrium-rest-content-list-query.test.ts
+++ b/tests/unit/atrium-rest-content-list-query.test.ts
@@ -54,6 +54,17 @@ jest.mock("@/lib/content/rest", () => {
 jest.mock("@/lib/content/surface-helpers", () => ({
   assertContentAuthoringCapability: jest.fn(),
   contentDeepLink: (slug: string) => `/c/${slug}`,
+  // Mirrors the real builder: only PUBLISHED objects have a reader page, so a
+  // draft is linked to its authoring surface instead of a `/c/` URL that 404s.
+  contentSurfaceLink: (object: {
+    id: string
+    slug: string
+    kind: "document" | "artifact"
+    status: string
+  }) =>
+    object.status === "published"
+      ? `/c/${object.slug}`
+      : `/atrium/${object.id}/${object.kind === "artifact" ? "view" : "edit"}`,
   resolveCollectionId: (...a: unknown[]) => mockResolveCollectionId(...a),
 }));
 

--- a/tests/unit/lib/agent-workspace/allowlist-doc-drift.test.ts
+++ b/tests/unit/lib/agent-workspace/allowlist-doc-drift.test.ts
@@ -75,6 +75,41 @@ describe("SKILL.md examples stay reachable through the broker", () => {
         "--json", '{"action":"accept","role":"writer"}',
       ],
     },
+    // Widened 2026-08-28 — the three operations users hit all week with
+    // operation_not_allowed (agent_failures 12909/13866/14559, 14394, 14031).
+    {
+      scope: "user",
+      argv: ["gmail", "users", "settings", "filters", "list"],
+    },
+    {
+      scope: "user",
+      argv: [
+        "gmail", "users", "settings", "filters", "create",
+        "--json",
+        '{"criteria":{"from":"a@psd401.net"},"action":{"removeLabelIds":["INBOX"]}}',
+      ],
+    },
+    {
+      scope: "user",
+      argv: [
+        "gmail", "users", "settings", "filters", "delete",
+        "--params", '{"id":"f1"}',
+      ],
+    },
+    {
+      scope: "user",
+      argv: [
+        "tasks", "tasks", "move",
+        "--params", '{"tasklist":"@default","task":"t1","parent":"h1"}',
+      ],
+    },
+    {
+      scope: "agent",
+      argv: [
+        "chat", "spaces", "findDirectMessage",
+        "--params", '{"name":"users/1"}',
+      ],
+    },
   ]
 
   it.each(DOCUMENTED_WORKED_EXAMPLES)(

--- a/tests/unit/lib/agent-workspace/allowlist-widening-2026-08-28.test.ts
+++ b/tests/unit/lib/agent-workspace/allowlist-widening-2026-08-28.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The three operations opened on 2026-08-28, and — more importantly — where
+ * each one stops.
+ *
+ * All three were refused with `operation_not_allowed` during the week of
+ * 2026-08-21 with no way around it:
+ *   - `gmail users settings filters`  (12909, 13866, 14559) — three users
+ *     asking for skip-inbox rules, or for existing rules to be removed.
+ *   - `chat spaces findDirectMessage` (14394) — a scheduled digest with no way
+ *     to resolve the DM it was meant to deliver into.
+ *   - `tasks tasks move`              (14031) — four heading tasks inserted on
+ *     the user slot that then could not be arranged.
+ *
+ * Widening an allowlist is the easiest place in this file to give away more
+ * than intended, so every test here has a matching boundary test.
+ */
+
+import {
+  requiredWorkspaceScopeGap,
+  validateWorkspaceCommand,
+} from "@/lib/agent-workspace/command-executor";
+
+const OWNER = "owner@psd401.net";
+const GMAIL_SETTINGS_BASIC =
+  "https://www.googleapis.com/auth/gmail.settings.basic";
+const GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify";
+
+function check(argv: string[], scope: "agent" | "user"): void {
+  validateWorkspaceCommand({ argv, scope }, OWNER);
+}
+
+describe("gmail users settings filters", () => {
+  it.each([["list"], ["get"], ["create"], ["delete"]])(
+    "allows filters.%s on the user's own mailbox",
+    (action) => {
+      expect(() =>
+        check(["gmail", "users", "settings", "filters", action], "user")
+      ).not.toThrow();
+    }
+  );
+
+  it("covers the whole resource because the operation truncates at four tokens", () => {
+    // Not a hidden assumption — the reason one entry grants create AND delete.
+    // `operationTokens` caps at four positionals, so the fifth (the real
+    // action) never reaches the operation string. Recorded here so a future
+    // reader does not try to narrow the entry by action and quietly fail.
+    expect(() =>
+      check(
+        ["gmail", "users", "settings", "filters", "totally-made-up"],
+        "user"
+      )
+    ).not.toThrow();
+  });
+
+  it("does NOT reach the sibling settings resources", () => {
+    // These are the dangerous half of Gmail settings: standing configuration
+    // that redirects a mailbox or lets another account act as this user. Each
+    // occupies the FOURTH token itself, so none collides with `filters` — but
+    // that is a property worth pinning rather than assuming.
+    for (const resource of [
+      "forwardingaddresses",
+      "sendas",
+      "delegates",
+      "updatevacation",
+      "updateimap",
+    ]) {
+      expect(() =>
+        check(["gmail", "users", "settings", resource, "create"], "user")
+      ).toThrow(/not allowed/i);
+    }
+  });
+
+  it("asks for a re-consent instead of letting Google 403 an old token", () => {
+    // `gmail.modify` does not imply `gmail.settings.basic`. Without this gap
+    // the widening would only change WHICH layer refused the call.
+    expect(
+      requiredWorkspaceScopeGap(
+        ["gmail", "users", "settings", "filters", "list"],
+        GMAIL_MODIFY
+      )
+    ).toEqual({
+      scopes: [GMAIL_SETTINGS_BASIC],
+      capability: "manage the filters in your Gmail inbox",
+    });
+  });
+
+  it("reports no gap once the user has re-consented", () => {
+    expect(
+      requiredWorkspaceScopeGap(
+        ["gmail", "users", "settings", "filters", "list"],
+        `${GMAIL_MODIFY} ${GMAIL_SETTINGS_BASIC}`
+      )
+    ).toBeNull();
+  });
+
+  it("still refuses to send mail", () => {
+    // The filters grant must not be read as a general loosening of Gmail.
+    for (const argv of [
+      ["gmail", "users", "messages", "send"],
+      ["gmail", "+send", "--to", "a@psd401.net"],
+    ]) {
+      expect(() => check(argv, "user")).toThrow();
+    }
+  });
+});
+
+describe("chat spaces findDirectMessage", () => {
+  it("is allowed on the agent slot", () => {
+    expect(() =>
+      check(
+        ["chat", "spaces", "findDirectMessage", "--params", '{"name":"users/1"}'],
+        "agent"
+      )
+    ).not.toThrow();
+  });
+
+  it("is classified as a READ, so it never claims to be an outbound send", () => {
+    // Treated as a read rather than added to ALLOWED_WRITES on purpose:
+    // ALLOWED_CHAT_WRITES is derived from ALLOWED_WRITES by the `chat ` prefix
+    // because every Chat WRITE has to reach the outbound audit log. A lookup
+    // that sends nothing would land there as a row with a null space and null
+    // body. Being a read is also why it needs no agent-slot confinement.
+    expect(() =>
+      check(
+        ["chat", "spaces", "findDirectMessage", "--params", '{"name":"users/1"}'],
+        "user"
+      )
+    ).not.toThrow();
+  });
+
+  it("cannot smuggle a mutation in front of the lookup", () => {
+    // The read branch screens earlier MUTATING verbs and every `+` helper, so
+    // a trailing read action cannot be used to carry one past the write
+    // allowlist. Without that, "read" would be a hole rather than a
+    // classification.
+    expect(() =>
+      check(["chat", "spaces", "create", "findDirectMessage"], "agent")
+    ).toThrow(/mutation/i);
+    expect(() =>
+      check(["chat", "+send", "findDirectMessage"], "agent")
+    ).toThrow(/helper verb/i);
+  });
+
+  it("does not open the rest of Chat", () => {
+    for (const argv of [
+      ["chat", "spaces", "delete"],
+      ["chat", "spaces", "members", "delete"],
+    ]) {
+      expect(() => check(argv, "agent")).toThrow();
+    }
+  });
+});
+
+describe("tasks tasks move", () => {
+  it("is allowed on the user slot, like the insert it reorders", () => {
+    // Deliberately NOT agent-only, unlike `tasks tasks patch`/`update`: a move
+    // changes position and parent, never content, and the user slot already
+    // permits creating the task being moved. The reported case (14031) was a
+    // user-slot insert followed by a user-slot move.
+    expect(() =>
+      check(
+        [
+          "tasks", "tasks", "move",
+          "--params", '{"tasklist":"@default","task":"t1","parent":"h1"}',
+        ],
+        "user"
+      )
+    ).not.toThrow();
+  });
+
+  it("is allowed on the agent slot too", () => {
+    expect(() =>
+      check(["tasks", "tasks", "move", "--params", '{"task":"t1"}'], "agent")
+    ).not.toThrow();
+  });
+
+  it("does not make tasks destructible", () => {
+    // Phase 1's "never destructive" rule is unaffected by reordering.
+    for (const argv of [
+      ["tasks", "tasks", "delete"],
+      ["tasks", "tasklists", "delete"],
+    ]) {
+      expect(() => check(argv, "user")).toThrow();
+    }
+  });
+});

--- a/tests/unit/lib/agent-workspace/allowlist-widening-2026-08-28.test.ts
+++ b/tests/unit/lib/agent-workspace/allowlist-widening-2026-08-28.test.ts
@@ -157,6 +157,10 @@ describe("tasks tasks move", () => {
     // changes position and parent, never content, and the user slot already
     // permits creating the task being moved. The reported case (14031) was a
     // user-slot insert followed by a user-slot move.
+    //
+    // The inconsistency with patch/update was raised and this placement was
+    // confirmed deliberately (2026-08-28), so moving `tasks tasks move` into
+    // AGENT_ONLY_WRITES is a reversal of a settled decision, not a cleanup.
     expect(() =>
       check(
         [

--- a/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
@@ -1774,47 +1774,91 @@ describe("durable workspace checkpoints", () => {
     }
   })
 
-  it("fails closed when an exact pending journal is retried by a different invocation", async () => {
+  it("commits an exact pending batch replayed by a later invocation", async () => {
+    // The harness retries a failed final flush at the START OF THE NEXT
+    // invocation, replaying the batch with the proof it stored from the
+    // original one. That proof is bound to an invocation nonce and expiry
+    // that no longer exist, so enforcing the binding made this replay
+    // impossible: it 409'd every time, the restore aborted, push was disabled
+    // for the microVM, and the user lost the turn along with their un-pushed
+    // work. Six rows across five users in the week of 2026-08-21, every one
+    // reading "Workspace finalization proof is invalid".
+    //
+    // A byte-identical journal entry proves this exact request was already
+    // admitted under a valid binding, so the replay is the idempotent resume
+    // the journal exists to allow. Only the binding is relaxed — the
+    // signature, prefix and generation claims are all still enforced, and the
+    // manifest-generation check below still refuses a moved-on workspace.
     const expiresAt = Math.floor(Date.now() / 1000) + 5
     const checkpoint = await ensureFinalizationCheckpoint(
       "invocation-pending",
       expiresAt,
     )
-    const proofHash = createHash("sha256")
-      .update(checkpoint.proof)
-      .digest("hex")
-    const ownerHash = createHash("sha256")
-      .update("owner@example.com")
-      .digest("hex")
-    const request = {
-      version: 1,
-      ownerHash,
-      signedWorkspacePrefix: PREFIX,
-      baseWorkspaceGeneration: checkpoint.workspaceGeneration,
-      proofHash,
-      reservationIds: [] as string[],
-      deletedPaths: [] as string[],
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    seedPendingFinalizationJournal(
+      checkpoint.workspaceGeneration,
+      checkpoint.proof,
+      [RESERVATION_ONE],
+    )
+    returnActiveReservationAsVerifying()
+    const now = jest
+      .spyOn(Date, "now")
+      .mockReturnValue((expiresAt + 10) * 1_000)
+    try {
+      const result = await finalizeWorkspaceCheckpoint(
+        "owner@example.com",
+        PREFIX,
+        checkpoint.workspaceGeneration,
+        [RESERVATION_ONE],
+        [],
+        checkpoint.proof,
+        "invocation-later",
+        expiresAt + 300,
+      )
+
+      expect(result.uploads).toEqual([
+        {
+          reservationId: RESERVATION_ONE,
+          key: `${PREFIX}/state/a.sqlite`,
+          eTag: '"a-new"',
+        },
+      ])
+      expect(store.current(`${PREFIX}/state/a.sqlite`)?.body).toBe("nnnn")
+      expect(manifest().workspaceGeneration).toBe(result.workspaceGeneration)
+    } finally {
+      now.mockRestore()
     }
-    const requestDigest = createHash("sha256")
-      .update(JSON.stringify(request))
-      .digest("hex")
-    const journal = JSON.stringify({
-      version: 1,
-      state: "pending",
-      ownerHash,
-      signedWorkspacePrefix: PREFIX,
-      baseWorkspaceGeneration: checkpoint.workspaceGeneration,
-      proofHash,
-      reservationIds: [],
-      deletedPaths: [],
-      requestDigest,
-    })
-    store.add(finalizationJournalKey(), {
-      size: Buffer.byteLength(journal),
-      eTag: '"pending-journal"',
-      body: journal,
-      scope: "Scope=checkpoint",
-    })
+  })
+
+  it("still refuses a rebound proof whose journal describes another batch", async () => {
+    // The relaxation above is licensed by the journal, not by the proof. A
+    // pending journal for a DIFFERENT request must not launder an expired,
+    // rebound proof into authority over this one — otherwise any stale proof
+    // would be replayable as long as some journal happened to exist.
+    const expiresAt = Math.floor(Date.now() / 1000) + 5
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-pending",
+      expiresAt,
+    )
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    // Journal records a batch with NO reservations; the call claims one.
+    seedPendingFinalizationJournal(
+      checkpoint.workspaceGeneration,
+      checkpoint.proof,
+      [],
+    )
+    returnActiveReservationAsVerifying()
+    const beforeFinalize = store.commands.length
     const now = jest
       .spyOn(Date, "now")
       .mockReturnValue((expiresAt + 10) * 1_000)
@@ -1824,18 +1868,22 @@ describe("durable workspace checkpoints", () => {
           "owner@example.com",
           PREFIX,
           checkpoint.workspaceGeneration,
-          [],
+          [RESERVATION_ONE],
           [],
           checkpoint.proof,
           "invocation-later",
           expiresAt + 300,
         ),
       ).rejects.toThrow("finalization proof is invalid")
+
+      expect(store.current(`${PREFIX}/state/a.sqlite`)).toBeUndefined()
       expect(
-        JSON.parse(
-          store.current(finalizationJournalKey())?.body ?? "{}",
+        store.commands.slice(beforeFinalize).some(
+          (command) =>
+            command.name === "CopyObjectCommand" ||
+            command.name === "DeleteObjectCommand",
         ),
-      ).toMatchObject({ state: "pending", requestDigest })
+      ).toBe(false)
     } finally {
       now.mockRestore()
     }


### PR DESCRIPTION
## What this is

A read of every prod `agent_failures` row from 2026-08-21 to 2026-08-28 (101 rows, all unacknowledged, 35 of them hard errors), each cross-checked against `/aws/lambda/psd-agent-router-prod`, `/aws/lambda/psd-agent-cron-prod` and the AgentCore runtime logs — then the fixes for what it found.

Two clusters were real and cost users work. A third of the feed was turns that had already been recovered, which is why the real ones went unnoticed.

## 1. Workspace finalization proof could not survive its own retry

`WorkspaceMigrationFailed` — 6 rows, 5 users, every one `"Workspace finalization proof is invalid"`.

When a final flush fails, the harness retries that fenced batch at the **start of the next invocation**, using the proof stored from the original one. That proof carries an invocation nonce and expiry that no longer exist, and `finalizeWorkspaceCheckpoint` verified the binding on the one path that re-runs the batch (`pending`; `prepared`/`committed` return early). The retry 409'd **every time** — the restore aborted, push was disabled for the microVM, the user got an error, and the next invocation did the exact committed restore anyway.

- **Broker:** `verifyWorkspaceFinalizationProof` gains `journaledReplay`, relaxing only the invocation binding — signature, prefix and generation are still enforced, and it is set only when a journal entry matches the request byte for byte (owner hash, base generation, proof hash, reservation ids, deleted paths). Such an entry can only exist because a correctly-bound invocation already admitted this request.
- **Harness:** the pre-restore retry is now guarded. A conflict quarantines the unreconcilable local changes and the invocation **continues** into a full pruning restore. Those changes were lost either way; the turn did not have to be.

⚠️ **This flips a deliberate, tested fail-closed decision** (`2491240ba`, "fails closed when an exact pending journal is retried by a different invocation") — worth a close look. That commit's own message says the journal exists so "new-invocation retries return the exact committed result"; the `pending` state never got there. The replaced test is now a companion pair: one asserts the commit, one asserts a rebound proof whose journal describes a *different* batch is still rejected without touching an object.

## 2. Failure rows described an attempt, not a turn

18 of the 35 hard-error rows were turns the user got answered:

| Class | Rows | Recovered |
|---|---|---|
| `ChatDeadlineExpired*` | 10 | 10 — promoted, ~20s |
| `ContextOverflow` | 4 | 4 — promoted |
| `OpenClawChatError` | 10 | 8 — the harness's own upstream retry |

Every one of those `OpenClawChatError` rows was `Session transcript parent entry was not persisted`, an OpenClaw transcript race the existing retry already handles. Only **2** unrecovered chat errors all week.

- **harness_adapter:** a chat error `process()` may still retry is held as `deferred_failure` and written only if the turn ends failed — the same policy `nudged` already documents. Held only for the provably replayable shape, so no row can be lost.
- **router + cron:** a confirmed promotion settles the harness's row (warn, self-acknowledged `system:job-promotion`, `context.promoted`). Kept for trending, bounded to the newest unacknowledged row of that class in five minutes, never throws.

## 3. Atrium handed out links that 404 for their own recipient

`/c/{slug}` needs a live intranet publication and masks existence, so a draft 404s **for the owner**. `url` was decorated with `contentDeepLink(slug)` unconditionally — including on the create that just returned a draft.

psd-morning-brief creates a private artifact and never publishes it, so **every morning brief DM has linked to a 404 for its recipient, every user, every day**, since the feature shipped. One user reported it twice (13503, 13998). Confirmed in prod: `morning-brief-2026-08-26`, owner robuckt, status `draft`.

`contentSurfaceLink` replaces it at the four result-decorating call sites — published keeps the reader link, everything else gets the authoring surface. `publish-service` is untouched; there `contentDeepLink` is a live publication's URL.

## 4. Two skill defects with no way around them

- **psd-freshservice** (12777): some accounts require `department_id` on create and it was not in the allowlist, so no phrasing could file a ticket. Allowlisted + documented.
- **psd-workspace** (13767): a Doc was transferred to the caller and *then* populated — all three batchUpdates 403'd, user got an empty document. SKILL.md now states the order (create → populate → verify → transfer). Also documents Google's sharing-quota throttle on new `agnt_` accounts (12744, 13241), where two turns burned ~90s retrying something that clears in hours.

## 5. The three broker operations users had no route to (approved 2026-08-28)

All three were refused `operation_not_allowed` all week with no workaround.

**`gmail users settings filters`** (12909, 13866, 14559) — the organizing counterpart to `gmail users labels create`, which was already allowed and is near-useless alone: one turn created the label successfully, then couldn't write the rule to put anything in it.

Two changes were needed — **the allowlist alone would not have fixed this**:
- `operationTokens` caps at **four** positionals, so one entry is the whole resource (create/get/list/delete). That's the intended grant, and it's pinned by test because it means the entry can't later be narrowed by action without a payload validator. Siblings each occupy the 4th token themselves and stay refused: `forwardingAddresses`, `sendAs`, `delegates`, `updateVacation`, `updateImap`.
- **Scope.** Gmail needs `gmail.settings.basic`; `gmail.modify` does not imply it. Without this the widening would only move the failure downstream into an opaque Google 403 — the same shape as the Classroom failure from this week (13536). So `gmail.settings.basic` joins the user-slot consent set, and `requiredWorkspaceScopeGap` reports it so old tokens get the existing re-authorize link instead. **`.sharing` — forwarding addresses, send-as, delegates — stays unrequested, now pinned by a test that fails if it ever appears.**

**`chat spaces findDirectMessage`** (14394) — classified as a **read**, not allowlisted as a Chat write. `ALLOWED_CHAT_WRITES` is *derived* from `ALLOWED_WRITES` precisely because every Chat write must reach the outbound audit log; a lookup that sends nothing would land there as a null-space, null-body row.

**`tasks tasks move`** (14031) — placed with `tasks tasks insert`, **not** with the agent-only `patch`/`update`. A move changes position and parent, never content, and the user slot already permits the larger act of creating the task being moved. ⚠️ This differs from where `patch`/`update` sit — flagged rather than assumed.

I probed the skill-side Phase 1 gate directly (node against `enforcePhase1Gates`): it already allowed all three, so the broker was the only blocker — and it still blocks `tasks.tasks.delete` and `gmail.users.messages.send` on the same run. Every widening has a matching boundary test.

## Verification

`lint` clean · `typecheck` clean · `test:ci` 594 suites / 5726 tests green · agent-image pytest 1045 green · agent-router 131 green · psd-workspace 84 · psd-morning-brief 25.

Pre-existing and unrelated: 4 failures in `psd-freshservice/lib/summary-utils.test.js` (confirmed identical on a clean tree).

## Deliberately not changed

- `agnt_` provisioning **already** fires on a user's first *turn*, not their first Workspace call (`shouldCheckAgentAccount`). The remaining rows are new users inside the ~30-min OneSync window — not a code defect, so the planned pre-provisioning task is dropped.
- chat-chart refusing a ragged series is a documented deliberate choice.
- psd-data warehouse coverage gaps (21 rows) are data-pipeline work.

## Deploy note

1–2 and the skill changes need an **agent image rebuild**; 3 and 5's allowlist/scope-gap ship with the app; the router/cron halves need those Lambdas deployed.

**The new Gmail scope reaches users on their next consent click** — a stored refresh token keeps the scope set it was issued with, so every existing user must re-consent before filter calls work. Until they do they get the re-authorize prompt, not an error.
