### PR TITLE
fix(atrium): make the Favorites and Unfiled library chips actually filter the grid

### DIFF
--- a/components/atrium/LibraryList.tsx
+++ b/components/atrium/LibraryList.tsx
@@ -430,6 +430,13 @@ interface LibraryListProps {
   /** Toggle one id's membership in the selection. */
   onToggleSelect: (id: string) => void;
   /**
+   * A card's star was toggled and the write is durable. `LibraryView` uses it
+   * to drop a card unstarred INSIDE the Favorites view (where the star is the
+   * grid's own filter); every other view ignores it. Optional so the archived
+   * management surface and any future caller can leave it off.
+   */
+  onFavoriteChange?: (id: string, isFavorite: boolean) => void;
+  /**
    * The active search term, non-empty only when the user is filtering. Drives
    * the zero-match empty state (which must NOT be confused with an empty
    * library — the copy and the missing "create" affordance differ).
@@ -455,6 +462,7 @@ export function LibraryList({
   archivedView,
   selected,
   onToggleSelect,
+  onFavoriteChange,
   searchTerm,
   tagTerm,
 }: LibraryListProps): React.JSX.Element {
@@ -501,6 +509,7 @@ export function LibraryList({
           it={it}
           selected={selected.has(it.id)}
           onToggle={onToggleSelect}
+          onFavoriteChange={onFavoriteChange}
         >
           {it.kind === "artifact" ? (
             <ArtifactCard it={it} sandboxSrc={sandboxSrc} />

--- a/components/atrium/LibraryView.tsx
+++ b/components/atrium/LibraryView.tsx
@@ -531,17 +531,70 @@ function viewToFilter(view: LibraryFilterView): {
 }
 
 /**
+ * The section scope to send with the active view. "Unfiled" means "in no
+ * section", so a section scope (the legacy `?collection=` deep link, where the
+ * Home chip and its "See all unfiled" stay reachable) would AND
+ * `collection_id = X` with `collection_id IS NULL`: an empty grid by
+ * construction, rendered as the generic empty library and indistinguishable
+ * from a broken filter. Same shape of rule as Archived-vs-status.
+ */
+function scopedCollectionId(
+  collectionId: string | null,
+  filed: "unfiled" | undefined
+): string | undefined {
+  if (filed === "unfiled") return undefined;
+  return collectionId ?? undefined;
+}
+
+/**
+ * Filters changed (or first mount): reload page one and drop the selection.
+ * `fetchPage`'s identity changes exactly when a server filter changes, so it is
+ * the correct trigger for both. A hook so `LibraryView` stays under the
+ * max-lines lint.
+ */
+function useFilterChangeReset(
+  fetchPage: (offset: number) => Promise<void>,
+  clearSelection: () => void
+): void {
+  useEffect(() => {
+    clearSelection();
+    void fetchPage(0);
+  }, [fetchPage, clearSelection]);
+}
+
+/**
+ * Unstarring INSIDE the Favorites view: the card no longer matches the grid's
+ * own filter, so it leaves at once (the home band does the same via a refetch).
+ * Any other view keeps the card — a star is not a filter there. A hook so the
+ * branch does not count against `LibraryView`'s complexity budget.
+ */
+function useFavoriteViewPrune(
+  favoriteView: boolean,
+  removeItem: (id: string) => void
+): (id: string, isFavorite: boolean) => void {
+  return useCallback(
+    (id: string, isFavorite: boolean) => {
+      if (favoriteView && !isFavorite) removeItem(id);
+    },
+    [favoriteView, removeItem]
+  );
+}
+
+/**
  * The "Load more" control. Renders nothing once a short page signals the end,
- * while the first page loads, on error, or when the current filter matched
- * nothing (a zero-result search must not render a dangling "Load more" —
- * #1336). Its own component so those four conditions do not count against
- * `LibraryView`'s complexity budget.
+ * while the first page loads, on a PAGE-ONE error, or when the current filter
+ * matched nothing (a zero-result search must not render a dangling "Load more"
+ * — #1336). A failed APPEND is different: the pages already on screen stay,
+ * and the button stays with them so the append can simply be retried. Its own
+ * component so those conditions do not count against `LibraryView`'s
+ * complexity budget.
  */
 function LoadMore({
   hasMore,
   loading,
   loadingMore,
   error,
+  loadMoreError,
   itemCount,
   onLoadMore,
 }: {
@@ -549,12 +602,18 @@ function LoadMore({
   loading: boolean;
   loadingMore: boolean;
   error: string | null;
+  loadMoreError: string | null;
   itemCount: number;
   onLoadMore: () => void;
 }): React.JSX.Element | null {
   if (!hasMore || loading || error || itemCount === 0) return null;
   return (
-    <div className="mt-5 flex justify-center">
+    <div className="mt-5 flex flex-col items-center gap-2">
+      {loadMoreError && (
+        <p className="text-sm text-destructive" role="alert">
+          {loadMoreError}
+        </p>
+      )}
       <button
         type="button"
         className={cn("mer-btn", loadingMore && "opacity-60")}
@@ -631,63 +690,74 @@ function useSearchHotkey(ref: React.RefObject<HTMLInputElement | null>): void {
 }
 
 /**
+ * Every field the library grid can filter on. `limit`/`offset` are the hook's
+ * own paging, so the type refuses them from a caller.
+ */
+type LibraryPageFilter = Omit<ListFilter, "limit" | "offset">;
+
+/**
  * The library's paged fetch (extracted from `LibraryView` so its body stays
  * under the max-lines lint). `fetchPage(0)` REPLACES the list for the current
  * filters; a non-zero offset APPENDS (the "Load more" path). A monotonic
  * sequence ref drops stale responses so a slow earlier request cannot overwrite
  * a newer one.
  */
-function useLibraryPage(filter: ListFilter) {
+function useLibraryPage(filter: LibraryPageFilter) {
   const [items, setItems] = useState<ContentObjectDTO[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   // Whether the LAST fetched page was full (== PAGE_SIZE rows): a short page
   // means the end was reached, so "Load more" hides.
   const [hasMore, setHasMore] = useState(false);
+  // A page-one failure: `LibraryList` renders it INSTEAD of the grid.
   const [error, setError] = useState<string | null>(null);
-  // The query/status the COMMITTED items were fetched with (undefined until the
-  // first fetch commits), set in the same state batch as `setItems` (so they can
-  // never describe a grid the view isn't showing). Rendered as `data-results-*`
-  // on the library section: the only deterministic "the grid now reflects THIS
-  // search + view" signal — `loading` flips inside a post-paint effect, leaving
-  // a window where the filters have changed but neither `loading` nor the items
-  // say so. E2E search pinning awaits these instead of racing the debounce.
-  const [settledQuery, setSettledQuery] = useState<string | undefined>(undefined);
-  const [settledStatus, setSettledStatus] = useState<string | undefined>(undefined);
+  // A failed "Load more" is kept apart from `error` on purpose: it must not
+  // take the pages already on screen down with it, and `LoadMore` keeps its
+  // button so the append can be retried.
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+  // The serialized filter the on-screen result (the items, or the page-one
+  // error) was fetched with — undefined until the first fetch finishes, then
+  // set in the same state batch as `setItems`/`setError` so it can never
+  // describe a grid the view isn't showing. Rendered as `data-results-key`
+  // (plus the older `data-results-query`/`-status` projections) on the library
+  // section: the only deterministic "the grid now reflects THIS filter set"
+  // signal — `loading` flips inside a post-paint effect, leaving a window where
+  // the filters have changed but neither `loading` nor the items say so, and
+  // the loading spinner unmounts every card, so "the other card is gone" alone
+  // proves nothing. E2E waits on this instead of racing the debounce or a
+  // chip's refetch.
+  const [settledKey, setSettledKey] = useState<string | undefined>(undefined);
   const reqSeqRef = useRef(0);
 
-  const {
-    collectionId,
-    kind,
-    owner,
-    status,
-    filed,
-    favorite,
-    tag,
-    tagMatch,
-    actor,
-    query,
-  } = filter;
+  // Identity by VALUE. The caller builds a fresh literal every render, and a
+  // hand-maintained field list here (destructure + payload + deps) is exactly
+  // what silently dropped `filed`/`favorite`: three commits edited that list,
+  // two of them missed the fields, and nothing could flag it — an
+  // un-destructured field is never referenced, so neither the type system nor
+  // exhaustive-deps sees it. Keying on the serialized filter forwards EVERY
+  // field and rebuilds `fetchPage` iff a value changes, the same idiom
+  // `useBand` uses in LibraryHome. Deterministic: one call site, fixed literal
+  // key order, primitives only, `undefined` omitted.
+  const filterKey = JSON.stringify(filter);
 
   const fetchPage = useCallback(
     async (offset: number) => {
       const reqSeq = ++reqSeqRef.current;
       const append = offset > 0;
-      if (append) setLoadingMore(true);
-      else setLoading(true);
-      setError(null);
+      const fail = (message: string) => {
+        if (append) setLoadMoreError(message);
+        else setError(message);
+      };
+      if (append) {
+        setLoadingMore(true);
+        setLoadMoreError(null);
+      } else {
+        setLoading(true);
+        setError(null);
+      }
       try {
         const res = await listContentAction({
-          collectionId,
-          kind,
-          owner,
-          status,
-          filed,
-          favorite,
-          tag,
-          tagMatch,
-          actor,
-          query,
+          ...(JSON.parse(filterKey) as LibraryPageFilter),
           limit: PAGE_SIZE,
           offset,
         });
@@ -695,15 +765,16 @@ function useLibraryPage(filter: ListFilter) {
         if (res.isSuccess) {
           setItems((prev) => (append ? [...prev, ...res.data] : res.data));
           setHasMore(res.data.length === PAGE_SIZE);
-          setSettledQuery(query ?? "");
-          setSettledStatus(status ?? "");
         } else {
-          setError(res.message ?? "Could not load content");
+          fail(res.message ?? "Could not load content");
           log.warn("listContentAction failed", { message: res.message });
         }
+        // Success OR failure: whatever is on screen now answers to this filter.
+        setSettledKey(filterKey);
       } catch (e) {
         if (reqSeq !== reqSeqRef.current) return;
-        setError("Could not load content");
+        fail("Could not load content");
+        setSettledKey(filterKey);
         log.error("listContentAction threw", {
           error: e instanceof Error ? e.message : String(e),
         });
@@ -714,7 +785,7 @@ function useLibraryPage(filter: ListFilter) {
         }
       }
     },
-    [collectionId, kind, owner, status, filed, favorite, tag, tagMatch, actor, query]
+    [filterKey]
   );
 
   // A STABLE re-fetch handle that always runs the CURRENT `fetchPage`.
@@ -735,16 +806,41 @@ function useLibraryPage(filter: ListFilter) {
     void fetchPageRef.current(0);
   }, []);
 
+  // Append the next offset page. `items.length` (not a page counter) is the
+  // offset so a short final page can never skip rows.
+  const loadMore = useCallback(() => {
+    void fetchPage(items.length);
+  }, [fetchPage, items.length]);
+
+  // Drop one row locally — a card unstarred inside the Favorites view no longer
+  // matches the grid's own filter. Cheaper and calmer than `refresh()`: no
+  // spinner, no collapse of "Load more" pages, and `loadMore`'s `items.length`
+  // offset stays right because the server's result set shrank by the same row.
+  const removeItem = useCallback((id: string) => {
+    setItems((prev) => prev.filter((it) => it.id !== id));
+  }, []);
+
+  // The older per-field projections, derived from the key so they can never
+  // disagree with it (search pinning in other specs awaits `data-results-query`).
+  const settled =
+    settledKey === undefined
+      ? undefined
+      : (JSON.parse(settledKey) as LibraryPageFilter);
+
   return {
     items,
     loading,
     loadingMore,
     hasMore,
     error,
-    settledQuery,
-    settledStatus,
+    loadMoreError,
+    settledKey,
+    settledQuery: settled ? (settled.query ?? "") : undefined,
+    settledStatus: settled ? (settled.status ?? "") : undefined,
     fetchPage,
+    loadMore,
     refresh,
+    removeItem,
   };
 }
 
@@ -894,12 +990,16 @@ export function LibraryView({
     loadingMore,
     hasMore,
     error,
+    loadMoreError,
+    settledKey,
     settledQuery,
     settledStatus,
     fetchPage,
+    loadMore,
     refresh,
+    removeItem,
   } = useLibraryPage({
-      collectionId: collectionId ?? undefined,
+      collectionId: scopedCollectionId(collectionId, filed),
       kind,
       owner: ownerFilter === "any" ? undefined : ownerFilter,
       status: effectiveStatus,
@@ -916,19 +1016,9 @@ export function LibraryView({
   const { selected, clearSelection, toggleSelect, removeFromSelection } =
     useLibrarySelection();
 
-  // Filters changed (or first mount): reload page one and drop the selection.
-  // `fetchPage`'s identity changes exactly when a server filter changes, so it
-  // is the correct trigger for both.
-  useEffect(() => {
-    clearSelection();
-    void fetchPage(0);
-  }, [fetchPage, clearSelection]);
+  useFilterChangeReset(fetchPage, clearSelection);
 
-  // Append the next offset page. `items.length` (not a page counter) is the
-  // offset so a short final page can never skip rows.
-  const loadMore = useCallback(() => {
-    void fetchPage(items.length);
-  }, [fetchPage, items.length]);
+  const handleFavoriteChange = useFavoriteViewPrune(favorite === true, removeItem);
 
   // `refresh` (re-fetch page one after a bulk mutation, so archived rows leave
   // the default views and moved rows leave a section view) comes from the hook
@@ -937,13 +1027,13 @@ export function LibraryView({
 
   return (
     <div className="w-full px-5 py-6 md:px-8 md:py-8">
-      {/* `data-results-*`: which query/view the committed grid was fetched for
-          (absent until the first fetch commits) — see the settled-state note in
-          `useLibraryPage`. */}
+      {/* `data-results-*`: the filter set the on-screen result was fetched for
+          (absent until the first fetch finishes) — see `useLibraryPage`. */}
       <section
         className="mx-auto min-w-0 max-w-6xl"
         data-results-query={settledQuery}
         data-results-status={settledStatus}
+        data-results-key={settledKey}
       >
         <LibraryHeader
           search={search}
@@ -996,6 +1086,7 @@ export function LibraryView({
           archivedView={archivedView}
           selected={selected}
           onToggleSelect={toggleSelect}
+          onFavoriteChange={handleFavoriteChange}
           searchTerm={debouncedSearch}
           tagTerm={debouncedTag}
         />
@@ -1005,6 +1096,7 @@ export function LibraryView({
           loading={loading}
           loadingMore={loadingMore}
           error={error}
+          loadMoreError={loadMoreError}
           itemCount={items.length}
           onLoadMore={loadMore}
         />

--- a/components/atrium/LibraryView.tsx
+++ b/components/atrium/LibraryView.tsx
@@ -656,8 +656,18 @@ function useLibraryPage(filter: ListFilter) {
   const [settledStatus, setSettledStatus] = useState<string | undefined>(undefined);
   const reqSeqRef = useRef(0);
 
-  const { collectionId, kind, owner, status, tag, tagMatch, actor, query } =
-    filter;
+  const {
+    collectionId,
+    kind,
+    owner,
+    status,
+    filed,
+    favorite,
+    tag,
+    tagMatch,
+    actor,
+    query,
+  } = filter;
 
   const fetchPage = useCallback(
     async (offset: number) => {
@@ -672,6 +682,8 @@ function useLibraryPage(filter: ListFilter) {
           kind,
           owner,
           status,
+          filed,
+          favorite,
           tag,
           tagMatch,
           actor,
@@ -702,7 +714,7 @@ function useLibraryPage(filter: ListFilter) {
         }
       }
     },
-    [collectionId, kind, owner, status, tag, tagMatch, actor, query]
+    [collectionId, kind, owner, status, filed, favorite, tag, tagMatch, actor, query]
   );
 
   // A STABLE re-fetch handle that always runs the CURRENT `fetchPage`.

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -35,7 +35,21 @@ import run_report as R  # noqa: E402
 HERE = pathlib.Path(__file__).resolve().parent
 FIXTURES = HERE.parent / "test-fixtures"
 
-_PATCHABLE = ("query", "query_one", "run_json", "workspace")
+_PATCHABLE = ("query", "query_one", "run_json", "workspace", "datetime")
+
+# The clock, pinned for the tests that reason about "has this year started".
+# run_report reaches it only through its own `datetime` binding
+# (`datetime.date.today()`), so swapping that one module attribute — restored by
+# RestoresModuleFunctions like any other patched name — freezes it without
+# touching the shared stdlib module for other tests. 2026-08-17 is the incident
+# date those tests describe.
+_TODAY = datetime.date(2026, 8, 17)
+
+
+class _FrozenDate(datetime.date):
+    @classmethod
+    def today(cls):
+        return _TODAY
 
 
 class RestoresModuleFunctions(unittest.TestCase):
@@ -694,13 +708,11 @@ class TheDefaultYearMustHaveStarted(RestoresModuleFunctions):
     passed the completed year by hand. A growth report needs a baseline AND an
     ending window, so a year that has not started cannot produce one.
 
-    "Today" is PINNED to that incident date. On the real clock this class
-    started failing on 2026-09-01 — the day 2026-27 actually began, so the
-    fixture's "not started" year had started and the assertion inverted. A
+    "Today" is PINNED to that incident date (`_TODAY`). On the real clock this
+    class started failing on 2026-09-01 — the day 2026-27 actually began, so
+    the fixture's "not started" year had started and the assertion inverted. A
     test about calendar boundaries must not itself drift across one.
     """
-
-    TODAY = datetime.date(2026, 8, 17)
 
     YEARS = [
         {"yearid": 36, "year_name": "2026-2027", "first_day": "2026-09-01"},
@@ -710,23 +722,20 @@ class TheDefaultYearMustHaveStarted(RestoresModuleFunctions):
 
     def setUp(self):
         super().setUp()
-        pinned = self.TODAY
-
-        class FrozenDate(datetime.date):
-            @classmethod
-            def today(cls):
-                return cls(pinned.year, pinned.month, pinned.day)
-
-        # run_report reaches the clock only through its own `datetime` binding
-        # (`datetime.date.today()`), so swapping that one name freezes it
-        # without touching the shared stdlib module for other tests.
-        self._saved_datetime = R.datetime
-        R.datetime = types.SimpleNamespace(date=FrozenDate)
-        self.addCleanup(setattr, R, "datetime", self._saved_datetime)
+        R.datetime = types.SimpleNamespace(date=_FrozenDate)
 
     def test_a_year_that_has_not_started_is_skipped(self):
         R.query = lambda *a, **k: self.YEARS
         self.assertEqual(R.resolve_year(None)["year_name"], "2025-2026")
+
+    def test_a_year_starting_today_counts_as_started(self):
+        # The boundary is INCLUSIVE: a year whose first day is today has begun.
+        # Every other year is in the future, so a slip to a strict comparison
+        # would leave nothing started and raise instead of returning yearid 36.
+        rows = [dict(y, first_day="2099-09-01") for y in self.YEARS]
+        rows[0] = dict(rows[0], first_day=_TODAY.isoformat())
+        R.query = lambda *a, **k: rows
+        self.assertEqual(R.resolve_year(None)["yearid"], 36)
 
     def test_the_newest_started_year_wins(self):
         started = [dict(y, first_day="2020-09-01") for y in self.YEARS]

--- a/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
+++ b/infra/agent-image/skills/quartile-growth-report/scripts/test_run_report.py
@@ -18,10 +18,12 @@ The two external CLIs (psd-data, psd-workspace) are stubbed. Everything
 between them is the real code path.
 """
 
+import datetime
 import json
 import pathlib
 import sys
 import tempfile
+import types
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -691,13 +693,36 @@ class TheDefaultYearMustHaveStarted(RestoresModuleFunctions):
     the report came out empty until the user worked out what had happened and
     passed the completed year by hand. A growth report needs a baseline AND an
     ending window, so a year that has not started cannot produce one.
+
+    "Today" is PINNED to that incident date. On the real clock this class
+    started failing on 2026-09-01 — the day 2026-27 actually began, so the
+    fixture's "not started" year had started and the assertion inverted. A
+    test about calendar boundaries must not itself drift across one.
     """
+
+    TODAY = datetime.date(2026, 8, 17)
 
     YEARS = [
         {"yearid": 36, "year_name": "2026-2027", "first_day": "2026-09-01"},
         {"yearid": 35, "year_name": "2025-2026", "first_day": "2025-09-02"},
         {"yearid": 34, "year_name": "2024-2025", "first_day": "2024-09-03"},
     ]
+
+    def setUp(self):
+        super().setUp()
+        pinned = self.TODAY
+
+        class FrozenDate(datetime.date):
+            @classmethod
+            def today(cls):
+                return cls(pinned.year, pinned.month, pinned.day)
+
+        # run_report reaches the clock only through its own `datetime` binding
+        # (`datetime.date.today()`), so swapping that one name freezes it
+        # without touching the shared stdlib module for other tests.
+        self._saved_datetime = R.datetime
+        R.datetime = types.SimpleNamespace(date=FrozenDate)
+        self.addCleanup(setattr, R, "datetime", self._saved_datetime)
 
     def test_a_year_that_has_not_started_is_skipped(self):
         R.query = lambda *a, **k: self.YEARS

--- a/scripts/db/cleanup-e2e-content.ts
+++ b/scripts/db/cleanup-e2e-content.ts
@@ -51,7 +51,7 @@ const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 /** Title shapes the E2E specs generate. Keep in sync with tests/e2e/*.spec.ts. */
 const TITLE_PREFIXES = ["e2e %", "E2E %"] as const;
 const TOKENED_TITLE_REGEX =
-  "^(Quarterly plan|Dashboard|Bulk probe [0-9]+|Comments probe|Cover probe|Sync probe|OAuth PKCE e2e) [0-9]{12,}$";
+  "^(Quarterly plan|Dashboard|Bulk probe [0-9]+|Comments probe|Cover probe|Sync probe|OAuth PKCE e2e|Starred probe|Plain probe|Filed probe|Loose probe) [0-9]{12,}$";
 
 /** Seeded reference fixtures (tests/e2e/fixtures/*.sql) — never deleted. */
 const FIXTURE_ID_PREFIX = "a7100000-%";
@@ -76,11 +76,12 @@ const GRAPH_E2E_NAME_REGEX = "(E2E-[A-Z]+-|E2EGRAPH)[0-9]{12,}";
  * until they were pruned by hand (twice).
  *
  * Anchored to the exact shapes those specs generate ("E2E Private <token>",
- * "E2E Child <token>", "E2E Admin Private <token>", "E2E District <token>") so
- * a real collection that merely starts with "E2E" is never matched.
+ * "E2E Child <token>", "E2E Admin Private <token>", "E2E District <token>",
+ * and the view-filters spec's "Filing cabinet <token>") so a real collection
+ * that merely starts with "E2E" is never matched.
  */
 const COLLECTION_E2E_NAME_REGEX =
-  "^E2E (Private|Child|Admin Private|District) [A-Za-z0-9]+$";
+  "^(E2E (Private|Child|Admin Private|District) [A-Za-z0-9]+|Filing cabinet [0-9]{12,})$";
 
 interface CandidateRow {
   id: string;

--- a/tests/e2e/atrium-library-view-filters.functional.spec.ts
+++ b/tests/e2e/atrium-library-view-filters.functional.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from './fixtures'
+import { test, expect, type Page } from './fixtures'
+import type { Route } from '@playwright/test'
 import {
   authenticateContext,
   SEEDED_ADMIN_EMAIL,
   SEEDED_ADMIN_SUB,
 } from './helpers/session-auth'
-import { mkdirSync } from 'node:fs'
 
 /**
  * E2E functional coverage for the Favorites and Unfiled library VIEW chips.
@@ -18,13 +18,19 @@ import { mkdirSync } from 'node:fs'
  *
  *  - FAVORITES (B1). Seed two docs, star one, switch to the Favorites chip:
  *    the starred doc must remain and the unstarred one must LEAVE the grid.
- *    The chip toggles `favorite` with every other filter unchanged, so this
- *    also proves the dependency-array half (no other dep changes to mask a
- *    missing refetch).
+ *    Then unstar it INSIDE the view (it must leave at once), restore All
+ *    content, and force the chip's refetch to fail (the error state must show
+ *    instead of stale cards or a dangling "Load more").
  *  - UNFILED (B2). Seed one doc inside a collection and one loose, enter the
  *    Unfiled view via the home band's "See all unfiled" (the same
  *    `useSeeAllHandler` path the bug report named): the loose doc must remain
- *    and the FILED one must leave.
+ *    and the FILED one must leave — including when the page was opened with a
+ *    legacy `?collection=` scope, which "unfiled" must drop rather than AND
+ *    into an empty-by-construction grid.
+ *
+ * Every wait on the grid goes through `data-results-key`, which the hook sets
+ * in the same state batch as the items: the loading spinner unmounts every
+ * card, so "the other card is gone" on its own would be satisfiable mid-fetch.
  *
  * Auth: mints a NextAuth session cookie for the seeded admin
  * (helpers/session-auth). Requires AUTH_SECRET and the host :3100 dev server —
@@ -40,44 +46,317 @@ function runToken(): string {
 }
 
 /**
- * Best-effort teardown for the drafts a spec created (leaving rows behind slows
- * every other library spec — they page through the same list). Failures are
- * ignored so teardown can never mask the real assertion failure.
+ * Create one tagged draft doc through the REST API and return its id. The
+ * titles ("<Name> probe <token>") are listed in scripts/db/cleanup-e2e-content.ts
+ * so `bun run db:cleanup:e2e` can prune anything a crashed run leaves behind.
+ */
+async function seedDoc(
+  page: Page,
+  opts: { title: string; tag: string; collectionId?: string }
+): Promise<string> {
+  const res = await page.request.post('/api/v1/content', {
+    data: {
+      kind: 'document',
+      title: opts.title,
+      body: '# probe',
+      bodyFormat: 'markdown',
+      tags: [opts.tag],
+      ...(opts.collectionId ? { collectionId: opts.collectionId } : {}),
+    },
+  })
+  expect(res.status()).toBe(201)
+  const id = (await res.json())?.data?.id as string | undefined
+  expect(id).toBeTruthy()
+  return id as string
+}
+
+/**
+ * Best-effort teardown, run from `finally` so a FAILED assertion still removes
+ * what the test seeded: rows left behind slow every other library spec, and a
+ * leftover starred probe would surface in the Home Favorites band on every
+ * later run. Failures are swallowed so teardown can never mask the real
+ * failure. Takes the request context (not the page) so it works after a
+ * mid-test throw; ids are pushed as they are created so a seeding failure
+ * still cleans up whatever landed.
  */
 async function cleanup(
-  page: import('@playwright/test').Page,
-  ids: string[]
+  request: Page['request'],
+  ids: readonly string[],
+  collectionId?: string
 ): Promise<void> {
   for (const id of ids) {
     try {
-      await page.request.delete(`/api/v1/content/${id}`)
+      await request.delete(`/api/v1/content/${id}`)
+    } catch {
+      // Ignored on purpose — see the docblock.
+    }
+  }
+  if (collectionId) {
+    try {
+      await request.patch(`/api/v1/content/collections/${collectionId}`, {
+        data: { archived: true },
+      })
     } catch {
       // Ignored on purpose — see the docblock.
     }
   }
 }
 
-function searchBox(page: import('@playwright/test').Page) {
+function searchBox(page: Page) {
   return page.getByRole('textbox', { name: 'Search content by title or tag' })
 }
 
-function chips(page: import('@playwright/test').Page) {
+function chips(page: Page) {
   return page.getByRole('group', { name: 'Filter content' })
+}
+
+function card(page: Page, id: string) {
+  return page.locator(`a[href="/atrium/${id}/edit"]`)
 }
 
 /**
  * Wait until the grid has COMMITTED a fetch for `query` — `data-results-query`
  * is set in the same state batch as the items (see the settled-state note in
- * `useLibraryPage`), so a passing wait means the grid on screen was fetched
- * with the CURRENT view's full filter set, debounce included.
+ * `useLibraryPage`), so the debounced search cannot race it.
  */
-async function awaitResultsFor(
-  page: import('@playwright/test').Page,
-  query: string
-) {
+async function awaitResultsFor(page: Page, query: string) {
   await expect(
     page.locator(`section[data-results-query="${query}"]`)
   ).toBeVisible({ timeout: 15000 })
+}
+
+/**
+ * Wait until the on-screen result was fetched with a filter whose serialized
+ * form matches `pattern`. This is the barrier for a VIEW change: the query does
+ * not change when a chip is clicked, so `data-results-query` cannot express
+ * it, and the loading spinner unmounts every card, so a bare `toHaveCount(0)`
+ * on the excluded card would be satisfiable before the refetch even returns.
+ * Also set on a FAILED fetch (the error is what is on screen for this filter).
+ */
+async function awaitSettledKey(page: Page, pattern: RegExp) {
+  await expect(page.locator('section[data-results-key]')).toHaveAttribute(
+    'data-results-key',
+    pattern,
+    { timeout: 15000 }
+  )
+}
+
+/**
+ * Wait for a star write to be DURABLE, not just optimistic: `aria-pressed`
+ * flips in the same commit as `data-busy="true"`, so once the expected pressed
+ * state is observed, busy returning to "false" means the server action
+ * resolved. The trailing pressed check is the only direct "write succeeded"
+ * assertion — busy returns to "false" on the FAILURE commit too, where the
+ * star reverts — and it turns a failed write into a clear message here rather
+ * than a confusing timeout further down.
+ */
+async function awaitStarSettled(
+  star: ReturnType<Page['getByTestId']>,
+  pressed: 'true' | 'false'
+) {
+  await expect(star).toHaveAttribute('aria-pressed', pressed)
+  await expect(star).toHaveAttribute('data-busy', 'false')
+  await expect(star).toHaveAttribute('aria-pressed', pressed)
+}
+
+const isAtriumPage = (url: URL) => url.pathname === '/atrium'
+
+// Each test is registered from its own function (the convention the polish
+// spec uses) so the describe callback stays under the max-lines lint.
+function defineFavoritesChipTest() {
+  test('atrium-library-favorites-chip: the Favorites chip narrows the grid to starred content, an unstar leaves it at once, All content restores it, and a failed refetch shows the error state', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+    })
+    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+    const ids: string[] = []
+    try {
+      const page = await context.newPage()
+      const token = runToken()
+      const tag = `favchip${token}`
+
+      // Two drafts isolated by a unique tag: one will be starred, the other is
+      // the card whose DISAPPEARANCE is the actual regression assertion.
+      const starredId = await seedDoc(page, {
+        title: `Starred probe ${token}`,
+        tag,
+      })
+      ids.push(starredId)
+      const plainId = await seedDoc(page, { title: `Plain probe ${token}`, tag })
+      ids.push(plainId)
+      const starredCard = card(page, starredId)
+      const plainCard = card(page, plainId)
+
+      await page.goto('/atrium')
+      await searchBox(page).fill(tag)
+      await awaitResultsFor(page, tag)
+      await expect(starredCard).toBeVisible()
+      await expect(plainCard).toBeVisible()
+
+      // Star one doc; switching views before the write is durable could refetch
+      // ahead of the favorite row committing.
+      const star = page.getByTestId(`favorite-${starredId}`)
+      await star.click()
+      await awaitStarSettled(star, 'true')
+
+      // The Favorites chip: the starred doc stays, the plain one must LEAVE.
+      // Before the fix this changed nothing (no refetch, `favorite` never
+      // sent), so the plain card lingering is the regression signal.
+      const favoritesChip = chips(page).getByRole('button', {
+        name: 'Favorites',
+        exact: true,
+      })
+      await favoritesChip.click()
+      await expect(favoritesChip).toHaveAttribute('aria-pressed', 'true')
+      await awaitSettledKey(page, /"favorite":true/)
+      await expect(starredCard).toBeVisible()
+      await expect(plainCard).toHaveCount(0)
+
+      await page.screenshot({
+        path: `${SHOT_DIR}/atrium-library-favorites-chip.png`,
+      })
+
+      // Unstarring INSIDE the Favorites view drops the card at once: it no
+      // longer matches the grid's own filter (a local removal, no refetch). A
+      // failed write reverts the star and the card stays, so this also proves
+      // the write. The star unmounts with the card, so the card is the signal.
+      await star.click()
+      await expect(starredCard).toHaveCount(0)
+
+      // And back: All content must refetch WITHOUT the favorite restriction.
+      await chips(page)
+        .getByRole('button', { name: 'All content', exact: true })
+        .click()
+      await expect(page.locator('section[data-results-key]')).not.toHaveAttribute(
+        'data-results-key',
+        /"favorite"/,
+        { timeout: 15000 }
+      )
+      await expect(starredCard).toBeVisible()
+      await expect(plainCard).toBeVisible()
+
+      // ERROR STATE: make the chip's refetch fail exactly once by aborting the
+      // server-action POST (the page URL with a `next-action` header). The grid
+      // must report it — no stale cards, no dangling "Load more". Installed
+      // only now, so no earlier write was ever intercepted; `page.request`
+      // calls (teardown) bypass page routes anyway.
+      let aborted = false
+      const abortOnce = async (route: Route): Promise<void> => {
+        const req = route.request()
+        if (
+          !aborted &&
+          req.method() === 'POST' &&
+          req.headers()['next-action'] !== undefined
+        ) {
+          aborted = true
+          await route.abort('failed')
+          return
+        }
+        await route.continue()
+      }
+      await page.route(isAtriumPage, abortOnce)
+      await favoritesChip.click()
+      await awaitSettledKey(page, /"favorite":true/)
+      // Scoped to the library section: Next's route announcer is a page-level
+      // role="alert" too.
+      await expect(
+        page.locator('section[data-results-key]').getByRole('alert')
+      ).toHaveText('Could not load content')
+      await expect(starredCard).toHaveCount(0)
+      await expect(plainCard).toHaveCount(0)
+      await expect(page.getByRole('button', { name: 'Load more' })).toHaveCount(0)
+      await page.unroute(isAtriumPage, abortOnce)
+
+      await page.screenshot({
+        path: `${SHOT_DIR}/atrium-library-favorites-chip-error.png`,
+      })
+    } finally {
+      await cleanup(context.request, ids)
+      await context.close()
+    }
+  })
+}
+
+function defineUnfiledChipTest() {
+  test('atrium-library-unfiled-chip: "See all unfiled" narrows the grid to content outside every collection, and drops a ?collection= scope instead of ANDing it', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+    })
+    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+    const ids: string[] = []
+    let collectionId: string | undefined
+    try {
+      const page = await context.newPage()
+      const token = runToken()
+      const tag = `unfchip${token}`
+
+      // A private collection to file one probe into (private keeps the shared
+      // sections sidebar clean for unrelated specs).
+      const coll = await page.request.post('/api/v1/content/collections', {
+        data: { name: `Filing cabinet ${token}`, scope: 'private' },
+      })
+      expect(coll.status()).toBe(201)
+      collectionId = (await coll.json())?.data?.id as string | undefined
+      expect(collectionId).toBeTruthy()
+
+      const filedId = await seedDoc(page, {
+        title: `Filed probe ${token}`,
+        tag,
+        collectionId,
+      })
+      ids.push(filedId)
+      const looseId = await seedDoc(page, { title: `Loose probe ${token}`, tag })
+      ids.push(looseId)
+      const looseCard = card(page, looseId)
+      const filedCard = card(page, filedId)
+
+      // Enter the Unfiled view the way a person does — the home band's
+      // "See all unfiled" (useSeeAllHandler), which also proves the chip row
+      // adds the active non-primary chip back.
+      await page.goto('/atrium')
+      await page.getByRole('button', { name: 'See all unfiled' }).click()
+      await expect(
+        chips(page).getByRole('button', { name: 'Unfiled', exact: true })
+      ).toHaveAttribute('aria-pressed', 'true')
+
+      // Narrow to this run's probes. The loose doc stays; the FILED one must be
+      // excluded. Before the fix the `filed` restriction was silently dropped
+      // from the fetch, so both rendered.
+      await searchBox(page).fill(tag)
+      await awaitResultsFor(page, tag)
+      await awaitSettledKey(page, /"filed":"unfiled"/)
+      await expect(looseCard).toBeVisible()
+      await expect(filedCard).toHaveCount(0)
+
+      await page.screenshot({
+        path: `${SHOT_DIR}/atrium-library-unfiled-chip.png`,
+      })
+
+      // A section scope must not poison the view. Arriving via the legacy
+      // `?collection=` deep link keeps the Home chip (and its "See all unfiled")
+      // reachable; "unfiled" means "in no section", so the scope is DROPPED
+      // rather than ANDed with `collection_id IS NULL` into an empty grid.
+      await page.goto(`/atrium?collection=${collectionId}`)
+      await chips(page).getByRole('button', { name: 'Home', exact: true }).click()
+      await page.getByRole('button', { name: 'See all unfiled' }).click()
+      await searchBox(page).fill(tag)
+      await awaitResultsFor(page, tag)
+      await awaitSettledKey(page, /"filed":"unfiled"/)
+      await expect(page.locator('section[data-results-key]')).not.toHaveAttribute(
+        'data-results-key',
+        /"collectionId"/
+      )
+      await expect(looseCard).toBeVisible()
+      await expect(filedCard).toHaveCount(0)
+    } finally {
+      await cleanup(context.request, ids, collectionId)
+      await context.close()
+    }
+  })
 }
 
 test.describe('Atrium library view filters — Favorites & Unfiled chips (authenticated)', () => {
@@ -90,178 +369,6 @@ test.describe('Atrium library view filters — Favorites & Unfiled chips (authen
   // default 60s per-test budget is too tight (same as the polish suite).
   test.describe.configure({ timeout: 180_000 })
 
-  test.beforeAll(() => {
-    mkdirSync(SHOT_DIR, { recursive: true })
-  })
-
-  test('atrium-library-favorites-chip: the Favorites chip narrows the grid to starred content and All content restores it', async ({
-    browser,
-  }) => {
-    const context = await browser.newContext({
-      viewport: { width: 1440, height: 900 },
-    })
-    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
-    try {
-      const page = await context.newPage()
-      const token = runToken()
-      const tag = `favchip${token}`
-
-      // Two drafts isolated by a unique tag: one will be starred, the other is
-      // the card whose DISAPPEARANCE is the actual regression assertion.
-      const ids: string[] = []
-      for (const name of ['Starred', 'Plain']) {
-        const res = await page.request.post('/api/v1/content', {
-          data: {
-            kind: 'document',
-            title: `${name} probe ${token}`,
-            body: '# hi',
-            bodyFormat: 'markdown',
-            tags: [tag],
-          },
-        })
-        expect(res.status()).toBe(201)
-        ids.push((await res.json())?.data?.id as string)
-      }
-      const [starredId, plainId] = ids
-      const starredCard = page.locator(`a[href="/atrium/${starredId}/edit"]`)
-      const plainCard = page.locator(`a[href="/atrium/${plainId}/edit"]`)
-
-      await page.goto('/atrium')
-      await searchBox(page).fill(tag)
-      await awaitResultsFor(page, tag)
-      await expect(starredCard).toBeVisible()
-      await expect(plainCard).toBeVisible()
-
-      // Star one doc and wait for the write to be DURABLE, not just optimistic:
-      // `aria-pressed` flips in the same commit as `data-busy="true"`, so once
-      // pressed is observed, busy returning to "false" means the server action
-      // resolved (and pressed still being true means it succeeded). Switching
-      // views before this could refetch ahead of the favorite row committing.
-      const star = page.getByTestId(`favorite-${starredId}`)
-      await star.click()
-      await expect(star).toHaveAttribute('aria-pressed', 'true')
-      await expect(star).toHaveAttribute('data-busy', 'false')
-      await expect(star).toHaveAttribute('aria-pressed', 'true')
-
-      // The Favorites chip: the starred doc stays, the plain one must LEAVE.
-      // Before the fix this changed nothing (no refetch, `favorite` never sent),
-      // so the plain card lingering is the regression signal.
-      const favoritesChip = chips(page).getByRole('button', {
-        name: 'Favorites',
-        exact: true,
-      })
-      await favoritesChip.click()
-      await expect(favoritesChip).toHaveAttribute('aria-pressed', 'true')
-      await expect(starredCard).toBeVisible({ timeout: 15000 })
-      await expect(plainCard).toHaveCount(0, { timeout: 15000 })
-
-      await page.screenshot({
-        path: `${SHOT_DIR}/atrium-library-favorites-chip.png`,
-        fullPage: false,
-      })
-
-      // And back: All content must refetch WITHOUT the favorite restriction.
-      await chips(page)
-        .getByRole('button', { name: 'All content', exact: true })
-        .click()
-      await expect(starredCard).toBeVisible({ timeout: 15000 })
-      await expect(plainCard).toBeVisible({ timeout: 15000 })
-
-      await cleanup(page, ids)
-    } finally {
-      await context.close()
-    }
-  })
-
-  test('atrium-library-unfiled-chip: "See all unfiled" narrows the grid to content outside every collection', async ({
-    browser,
-  }) => {
-    const context = await browser.newContext({
-      viewport: { width: 1440, height: 900 },
-    })
-    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
-    try {
-      const page = await context.newPage()
-      const token = runToken()
-      const tag = `unfchip${token}`
-
-      // A private collection to file one probe into (private keeps the shared
-      // sections sidebar clean for unrelated specs).
-      const coll = await page.request.post('/api/v1/content/collections', {
-        data: { name: `Filing cabinet ${token}`, scope: 'private' },
-      })
-      expect(coll.status()).toBe(201)
-      const collectionId = (await coll.json())?.data?.id as string
-      expect(collectionId).toBeTruthy()
-
-      const filed = await page.request.post('/api/v1/content', {
-        data: {
-          kind: 'document',
-          title: `Filed probe ${token}`,
-          body: '# filed',
-          bodyFormat: 'markdown',
-          tags: [tag],
-          collectionId,
-        },
-      })
-      expect(filed.status()).toBe(201)
-      const filedId = (await filed.json())?.data?.id as string
-
-      const loose = await page.request.post('/api/v1/content', {
-        data: {
-          kind: 'document',
-          title: `Loose probe ${token}`,
-          body: '# loose',
-          bodyFormat: 'markdown',
-          tags: [tag],
-        },
-      })
-      expect(loose.status()).toBe(201)
-      const looseId = (await loose.json())?.data?.id as string
-
-      // Enter the Unfiled view the way a person does — the home band's
-      // "See all unfiled" (useSeeAllHandler), which also proves the chip row
-      // adds the active non-primary chip back.
-      await page.goto('/atrium')
-      await page.getByRole('button', { name: 'See all unfiled' }).click()
-      await expect(
-        chips(page).getByRole('button', { name: 'Unfiled', exact: true })
-      ).toHaveAttribute('aria-pressed', 'true')
-
-      // Narrow to this run's probes. `data-results-query` commits atomically
-      // with the items, so after this wait the grid was fetched with the
-      // CURRENT (unfiled) view's filters — no settled signal exists for `filed`
-      // itself.
-      await searchBox(page).fill(tag)
-      await awaitResultsFor(page, tag)
-
-      // The loose doc stays; the FILED one must be excluded. Before the fix the
-      // `filed` restriction was silently dropped from the fetch, so both
-      // rendered.
-      await expect(
-        page.locator(`a[href="/atrium/${looseId}/edit"]`)
-      ).toBeVisible({ timeout: 15000 })
-      await expect(
-        page.locator(`a[href="/atrium/${filedId}/edit"]`)
-      ).toHaveCount(0, { timeout: 15000 })
-
-      await page.screenshot({
-        path: `${SHOT_DIR}/atrium-library-unfiled-chip.png`,
-        fullPage: false,
-      })
-
-      await cleanup(page, [filedId, looseId])
-      // Best-effort: archive the scratch collection so it does not accumulate
-      // in the seeded admin's private tree across runs.
-      try {
-        await page.request.patch(`/api/v1/content/collections/${collectionId}`, {
-          data: { archived: true },
-        })
-      } catch {
-        // Ignored — teardown must never mask the real assertion failure.
-      }
-    } finally {
-      await context.close()
-    }
-  })
+  defineFavoritesChipTest()
+  defineUnfiledChipTest()
 })

--- a/tests/e2e/atrium-library-view-filters.functional.spec.ts
+++ b/tests/e2e/atrium-library-view-filters.functional.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect } from './fixtures'
+import {
+  authenticateContext,
+  SEEDED_ADMIN_EMAIL,
+  SEEDED_ADMIN_SUB,
+} from './helpers/session-auth'
+import { mkdirSync } from 'node:fs'
+
+/**
+ * E2E functional coverage for the Favorites and Unfiled library VIEW chips.
+ *
+ * Regression guard: `useLibraryPage` destructured every `ListFilter` field
+ * EXCEPT `filed` and `favorite`, so both chips fetched the unfiltered "All
+ * content" grid — and because the two fields were also missing from the
+ * `fetchPage` dependency array, switching chips did not even refetch. The grid
+ * looked correct (no error, cards rendered), which is exactly why only an
+ * assertion that a NON-matching card is absent can catch it:
+ *
+ *  - FAVORITES (B1). Seed two docs, star one, switch to the Favorites chip:
+ *    the starred doc must remain and the unstarred one must LEAVE the grid.
+ *    The chip toggles `favorite` with every other filter unchanged, so this
+ *    also proves the dependency-array half (no other dep changes to mask a
+ *    missing refetch).
+ *  - UNFILED (B2). Seed one doc inside a collection and one loose, enter the
+ *    Unfiled view via the home band's "See all unfiled" (the same
+ *    `useSeeAllHandler` path the bug report named): the loose doc must remain
+ *    and the FILED one must leave.
+ *
+ * Auth: mints a NextAuth session cookie for the seeded admin
+ * (helpers/session-auth). Requires AUTH_SECRET and the host :3100 dev server —
+ * see docs/guides/e2e-authenticated-testing.md. Gated behind
+ * PLAYWRIGHT_AUTH_ENABLED so default CI (no seeded session) skips.
+ */
+
+const SHOT_DIR = '.verification'
+
+/** Unique-per-run token so seeded rows never collide across runs or workers. */
+function runToken(): string {
+  return `${Date.now()}${Math.floor(Math.random() * 1000)}`
+}
+
+/**
+ * Best-effort teardown for the drafts a spec created (leaving rows behind slows
+ * every other library spec — they page through the same list). Failures are
+ * ignored so teardown can never mask the real assertion failure.
+ */
+async function cleanup(
+  page: import('@playwright/test').Page,
+  ids: string[]
+): Promise<void> {
+  for (const id of ids) {
+    try {
+      await page.request.delete(`/api/v1/content/${id}`)
+    } catch {
+      // Ignored on purpose — see the docblock.
+    }
+  }
+}
+
+function searchBox(page: import('@playwright/test').Page) {
+  return page.getByRole('textbox', { name: 'Search content by title or tag' })
+}
+
+function chips(page: import('@playwright/test').Page) {
+  return page.getByRole('group', { name: 'Filter content' })
+}
+
+/**
+ * Wait until the grid has COMMITTED a fetch for `query` — `data-results-query`
+ * is set in the same state batch as the items (see the settled-state note in
+ * `useLibraryPage`), so a passing wait means the grid on screen was fetched
+ * with the CURRENT view's full filter set, debounce included.
+ */
+async function awaitResultsFor(
+  page: import('@playwright/test').Page,
+  query: string
+) {
+  await expect(
+    page.locator(`section[data-results-query="${query}"]`)
+  ).toBeVisible({ timeout: 15000 })
+}
+
+test.describe('Atrium library view filters — Favorites & Unfiled chips (authenticated)', () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== 'true',
+    'Requires an authenticated session — set PLAYWRIGHT_AUTH_ENABLED=true and run against the host :3100 dev server (see docs/guides/e2e-authenticated-testing.md)'
+  )
+
+  // Several server actions compile on first hit against the dev server, so the
+  // default 60s per-test budget is too tight (same as the polish suite).
+  test.describe.configure({ timeout: 180_000 })
+
+  test.beforeAll(() => {
+    mkdirSync(SHOT_DIR, { recursive: true })
+  })
+
+  test('atrium-library-favorites-chip: the Favorites chip narrows the grid to starred content and All content restores it', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+    })
+    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+    try {
+      const page = await context.newPage()
+      const token = runToken()
+      const tag = `favchip${token}`
+
+      // Two drafts isolated by a unique tag: one will be starred, the other is
+      // the card whose DISAPPEARANCE is the actual regression assertion.
+      const ids: string[] = []
+      for (const name of ['Starred', 'Plain']) {
+        const res = await page.request.post('/api/v1/content', {
+          data: {
+            kind: 'document',
+            title: `${name} probe ${token}`,
+            body: '# hi',
+            bodyFormat: 'markdown',
+            tags: [tag],
+          },
+        })
+        expect(res.status()).toBe(201)
+        ids.push((await res.json())?.data?.id as string)
+      }
+      const [starredId, plainId] = ids
+      const starredCard = page.locator(`a[href="/atrium/${starredId}/edit"]`)
+      const plainCard = page.locator(`a[href="/atrium/${plainId}/edit"]`)
+
+      await page.goto('/atrium')
+      await searchBox(page).fill(tag)
+      await awaitResultsFor(page, tag)
+      await expect(starredCard).toBeVisible()
+      await expect(plainCard).toBeVisible()
+
+      // Star one doc and wait for the write to be DURABLE, not just optimistic:
+      // `aria-pressed` flips in the same commit as `data-busy="true"`, so once
+      // pressed is observed, busy returning to "false" means the server action
+      // resolved (and pressed still being true means it succeeded). Switching
+      // views before this could refetch ahead of the favorite row committing.
+      const star = page.getByTestId(`favorite-${starredId}`)
+      await star.click()
+      await expect(star).toHaveAttribute('aria-pressed', 'true')
+      await expect(star).toHaveAttribute('data-busy', 'false')
+      await expect(star).toHaveAttribute('aria-pressed', 'true')
+
+      // The Favorites chip: the starred doc stays, the plain one must LEAVE.
+      // Before the fix this changed nothing (no refetch, `favorite` never sent),
+      // so the plain card lingering is the regression signal.
+      const favoritesChip = chips(page).getByRole('button', {
+        name: 'Favorites',
+        exact: true,
+      })
+      await favoritesChip.click()
+      await expect(favoritesChip).toHaveAttribute('aria-pressed', 'true')
+      await expect(starredCard).toBeVisible({ timeout: 15000 })
+      await expect(plainCard).toHaveCount(0, { timeout: 15000 })
+
+      await page.screenshot({
+        path: `${SHOT_DIR}/atrium-library-favorites-chip.png`,
+        fullPage: false,
+      })
+
+      // And back: All content must refetch WITHOUT the favorite restriction.
+      await chips(page)
+        .getByRole('button', { name: 'All content', exact: true })
+        .click()
+      await expect(starredCard).toBeVisible({ timeout: 15000 })
+      await expect(plainCard).toBeVisible({ timeout: 15000 })
+
+      await cleanup(page, ids)
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('atrium-library-unfiled-chip: "See all unfiled" narrows the grid to content outside every collection', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+    })
+    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+    try {
+      const page = await context.newPage()
+      const token = runToken()
+      const tag = `unfchip${token}`
+
+      // A private collection to file one probe into (private keeps the shared
+      // sections sidebar clean for unrelated specs).
+      const coll = await page.request.post('/api/v1/content/collections', {
+        data: { name: `Filing cabinet ${token}`, scope: 'private' },
+      })
+      expect(coll.status()).toBe(201)
+      const collectionId = (await coll.json())?.data?.id as string
+      expect(collectionId).toBeTruthy()
+
+      const filed = await page.request.post('/api/v1/content', {
+        data: {
+          kind: 'document',
+          title: `Filed probe ${token}`,
+          body: '# filed',
+          bodyFormat: 'markdown',
+          tags: [tag],
+          collectionId,
+        },
+      })
+      expect(filed.status()).toBe(201)
+      const filedId = (await filed.json())?.data?.id as string
+
+      const loose = await page.request.post('/api/v1/content', {
+        data: {
+          kind: 'document',
+          title: `Loose probe ${token}`,
+          body: '# loose',
+          bodyFormat: 'markdown',
+          tags: [tag],
+        },
+      })
+      expect(loose.status()).toBe(201)
+      const looseId = (await loose.json())?.data?.id as string
+
+      // Enter the Unfiled view the way a person does — the home band's
+      // "See all unfiled" (useSeeAllHandler), which also proves the chip row
+      // adds the active non-primary chip back.
+      await page.goto('/atrium')
+      await page.getByRole('button', { name: 'See all unfiled' }).click()
+      await expect(
+        chips(page).getByRole('button', { name: 'Unfiled', exact: true })
+      ).toHaveAttribute('aria-pressed', 'true')
+
+      // Narrow to this run's probes. `data-results-query` commits atomically
+      // with the items, so after this wait the grid was fetched with the
+      // CURRENT (unfiled) view's filters — no settled signal exists for `filed`
+      // itself.
+      await searchBox(page).fill(tag)
+      await awaitResultsFor(page, tag)
+
+      // The loose doc stays; the FILED one must be excluded. Before the fix the
+      // `filed` restriction was silently dropped from the fetch, so both
+      // rendered.
+      await expect(
+        page.locator(`a[href="/atrium/${looseId}/edit"]`)
+      ).toBeVisible({ timeout: 15000 })
+      await expect(
+        page.locator(`a[href="/atrium/${filedId}/edit"]`)
+      ).toHaveCount(0, { timeout: 15000 })
+
+      await page.screenshot({
+        path: `${SHOT_DIR}/atrium-library-unfiled-chip.png`,
+        fullPage: false,
+      })
+
+      await cleanup(page, [filedId, looseId])
+      // Best-effort: archive the scratch collection so it does not accumulate
+      // in the seeded admin's private tree across runs.
+      try {
+        await page.request.patch(`/api/v1/content/collections/${collectionId}`, {
+          data: { archived: true },
+        })
+      } catch {
+        // Ignored — teardown must never mask the real assertion failure.
+      }
+    } finally {
+      await context.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The **Favorites** and **Unfiled** view chips in the Atrium library rendered the unfiltered "All content" grid with no error. Selecting either chip (or "See all favorites" / "See all unfiled" on the LibraryHome bands) looked healthy — cards rendered, nothing failed — but the restriction never reached the server.

## Root cause

The mapping layer was correct end to end (`viewToFilter()` → `resolveView()` → the `useLibraryPage({ …, filed, favorite, … })` call site), but the hook itself dropped both fields: its hand-maintained destructure / `listContentAction()` payload / `useCallback` dependency-array triplet omitted them, so the restriction was never sent AND switching chips never refetched. That triplet had been edited in three commits; two of them missed the fields, and nothing could flag it, since an un-destructured field is never referenced.

## What changed (three commits)

**`1b839d60f` — the fix + regression spec.** Forward `filed`/`favorite`; new `atrium-library-view-filters.functional.spec.ts` asserting the *non-matching* card leaves the grid (verified red on the pre-fix code, green after).

**`5a8ee356c` — unrelated CI red.** A Python unit test in the quartile-growth-report skill compared a fixture against the real clock and inverted on 2026-09-01 (the day the 2026-27 school year began), failing "Test, Lint, and Type Check" for every PR. Pinned the clock inside the test class; no production code touched.

**`6698c0784` — the review round.** A full review (Claude `/code-review`, extra-high effort: 10 finder angles, 1-vote verification, gap sweep) produced 15 verified findings; 13 are fixed here, 2 are deliberately left (below).
- `useLibraryPage` keys `fetchPage` on `JSON.stringify(filter)` and spreads the parsed filter into the action — the idiom `useBand` already uses — so every `ListFilter` field is forwarded and the field-list class of bug is gone (`collectionIds`/`since` were also being dropped). Param type is `Omit<ListFilter, "limit" | "offset">`.
- One serialized settled signal, `data-results-key`, set in the same batch as the items **or the error**; the older `data-results-query`/`-status` are derived from it (no longer stale after a failed fetch). E2E can now await a *view* change deterministically — the loading spinner unmounts every card, so "the excluded card is gone" alone was satisfiable mid-fetch.
- A failed "Load more" no longer wipes the loaded pages: separate `loadMoreError`, button kept for retry.
- Unfiled + legacy `?collection=` deep link no longer ANDs `collection_id = X` with `collection_id IS NULL` into an empty grid.
- Unstarring *inside* the Favorites view removes the card at once (`LibraryList` now accepts `onFavoriteChange`; local removal, no spinner).
- Spec: teardown in `finally`; every wait via `data-results-key`; new cases for unstar-in-view, the error state (server-action POST aborted via `page.route`), and the `?collection=` scope; `seedDoc`/`type Page` cleanups. `scripts/db/cleanup-e2e-content.ts` now matches this spec's rows.
- Python test: `"datetime"` in `_PATCHABLE` instead of a hand-rolled restore; inclusive `first_day == today` boundary case added.

### Reviewed, deliberately not changed
- **"See all unfiled" scope.** The band is `{ filed: "unfiled", owner: "mine" }` ("Not in a section yet") but the grid it opens is owner-less, so an admin lands on every unfiled object district-wide. Intent is unstated (the introducing commit wrote both, and "See all yours" also widens past its band); the owner select can still narrow. Product call — say the word and it's a one-line `setOwnerFilter("mine")`.
- **Parallel-worker interference** between this spec and `atrium-usability`'s favorite-persistence test (stars the newest card as the same admin). The harness and pre-push hook run `workers=1`; a fix would belong to the sibling spec.

## Verification

| Check | Result |
|---|---|
| `bun run lint` / `bun run typecheck` (entire codebase) | passing |
| View-filters spec on the `:3100` harness | 2/2 |
| Sibling library specs (polish, usability, meridian) | 11/11 |
| Python file with the CI invocation | 85/85 |
| Pre-push full local E2E suite (final head) | 323 passed / 41 skipped / 0 failed |

**Review bots:** the `claude-review` GitHub workflow has failed action-side (`is_error`, $0, 1 turn) on every run repo-wide since 2026-08-23 and only fires on open/reopen; the Codex connector has not commented on any recent PR. The review above was run locally instead.
