### PR TITLE
fix(agent): deliver alarms, record dead-letters, stop the token false alarm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,18 @@ jobs:
       env:
         CI: true
 
+    # agent-router (bun:test). These 131 tests sit BESIDE the source as
+    # *.test.ts, and every runner in this repo missed them: root jest ignores
+    # all of infra/ except one triage path, infra's own `lambdas` project only
+    # matches **/__tests__/**, and they are bun:test files that jest cannot
+    # parse anyway. So the Lambda that handles every Google Chat message had a
+    # full suite that ran nowhere. Caught when a change to its lock-lease and
+    # token-alert code broke two of them locally and no gate noticed.
+    - name: Run agent-router Lambda tests (Bun)
+      run: bun run test:lambda:router
+      env:
+        CI: true
+
     # psd-directory (#1239). Same story as psd-workspace above: plain CJS
     # outside the jest roots, so `test:ci` cannot see it. What these tests
     # guard is identity CORRECTNESS — the exact-address rule that stops a

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -10,7 +10,7 @@ const {
   normalizeChatEvent,
   cardClickMessageText,
   parseAgentCoreResult,
-  totalAgentTokens,
+  alertableAgentTokens,
   tryAcquireSessionLock,
   invokeWithSessionLockLease,
   jobPromotionIdentity,
@@ -359,7 +359,11 @@ describe("agent router result coercion", () => {
     ])
     expect(result.errorSource).toBe("harness")
     expect(result.workspaceFinalizationConfirmed).toBe(true)
-    expect(totalAgentTokens(result)).toBe(37)
+    // 37 with cache reads included, 17 without. The alert deliberately
+    // excludes them: they are large by design and bill at ~a tenth of input,
+    // and including them made the 100k threshold fire on most prod turns
+    // (30-day p50 was 153,409 against a 100,000 limit).
+    expect(alertableAgentTokens(result)).toBe(17)
   })
 
   test("uses compatibility defaults for older harness responses", () => {
@@ -1441,7 +1445,7 @@ describe("workspace lock lease lifecycle", () => {
     const released: string[] = []
 
     const result = await invokeWithSessionLockLease(
-      "workspace-lock",
+      { sessionId: "workspace-lock" },
       "lock-token",
       TEST_LOG,
       async () => AGENT_RESULT,
@@ -1477,7 +1481,7 @@ describe("workspace lock lease lifecycle", () => {
     const released: string[] = []
 
     await invokeWithSessionLockLease(
-      "workspace-lock",
+      { sessionId: "workspace-lock" },
       "lock-token",
       TEST_LOG,
       async () => ({
@@ -1504,7 +1508,7 @@ describe("workspace lock lease lifecycle", () => {
 
     await expect(
       invokeWithSessionLockLease(
-        "workspace-lock",
+        { sessionId: "workspace-lock" },
         "lock-token",
         TEST_LOG,
         async () => {

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -544,6 +544,10 @@ const CHAT_DELIVERY_RETRY_VISIBILITY_SECONDS = 60;
 const WORKSPACE_DEFER_ATTRIBUTE = 'PsdWorkspaceDeferV1';
 const WORKSPACE_DEFER_MAX_ATTEMPTS = 180;
 const WORKSPACE_DEFER_MAX_AGE_SECONDS = 3 * 60 * 60;
+// Mirrors the CDK redrive policy on the router queue (maxReceiveCount: 3).
+// Used only to decide whether THIS attempt is the one that sends a record to
+// the dead-letter queue.
+const ROUTER_QUEUE_MAX_RECEIVE_COUNT = 3;
 const CHAT_DELIVERY_ENVELOPE_KIND = 'agent-chat-delivery-v1';
 const MAX_CHAT_DELIVERY_ENVELOPE_BYTES = 32 * 1024;
 
@@ -619,7 +623,9 @@ let cachedChatAuth: GoogleChatAuth | null = null;
 let cachedChatClient: ReturnType<typeof chatPkg.chat> | null = null;
 
 // Cache SSM lookups at module scope to avoid redundant API calls on every invocation.
-// The Runtime ID is resolved from SSM because it's not known at CDK deploy time.
+// Fallback path only. The stack now sets AGENTCORE_RUNTIME_ID directly; this
+// SSM lookup remains for out-of-band overrides and for any deploy where the
+// runtime is not created in the same stack.
 let cachedRuntimeId: string | null = null;
 let runtimeIdCachedAt: number | null = null;
 const RUNTIME_ID_TTL_MS = 10 * 60 * 1000; // 10 minutes
@@ -2096,13 +2102,21 @@ const sessionLockLeaseDependencies: SessionLockLeaseDependencies = {
  * after this Lambda has stopped receiving bytes.
  */
 async function invokeWithSessionLockLease(
-  sessionId: string,
+  /**
+   * The lock's identity plus who it belongs to. `ownerEmail` and `spaceName`
+   * are diagnostic only: when a lease ends up RETAINED the warning has to say
+   * who is now blocked, and sessionId is a hash that cannot be reversed.
+   * Proving six retained-lock events belonged to one user meant correlating
+   * requestIds back to spaces by hand; this makes it a log search.
+   */
+  lease: { sessionId: string; ownerEmail?: string; spaceName?: string },
   lockToken: string,
   log: ReturnType<typeof createLogger>,
   invocation: () => Promise<AgentCoreResult>,
   dependencies: SessionLockLeaseDependencies =
     sessionLockLeaseDependencies
 ): Promise<AgentCoreResult> {
+  const { sessionId, ownerEmail, spaceName } = lease;
   let renewalInFlight: Promise<void> | undefined;
   const renewOnce = () => {
     if (renewalInFlight) return;
@@ -2147,9 +2161,21 @@ async function invokeWithSessionLockLease(
         log
       );
     } else {
+      // sessionId alone is not enough to act on: identifying the six events
+      // that explained one user's outage meant correlating requestIds back to
+      // spaces by hand. The lock is held for up to SESSION_LOCK_TTL_SECONDS
+      // (30 min), during which every turn for this owner defers, so whoever
+      // reads this needs to know WHO is blocked without a research project.
       log.warn(
         'Retaining workspace lock after unconfirmed AgentCore completion',
-        { sessionId }
+        {
+          sessionId,
+          // The lock is held until its TTL expires, and every turn for this
+          // owner defers meanwhile — so name the owner, not just the hash.
+          lockHeldForSeconds: SESSION_LOCK_TTL_SECONDS,
+          ...(ownerEmail ? { ownerEmail } : {}),
+          ...(spaceName ? { spaceName } : {}),
+        }
       );
     }
   }
@@ -4284,6 +4310,11 @@ export async function handler(
         const messageId = event.Records[idx].messageId;
         if (result.reason instanceof ChatDeliveryRetryError) {
           batchItemFailures.push({ itemIdentifier: messageId });
+          await recordIfHeadedForDlq(
+            event.Records[idx],
+            result.reason,
+            log
+          );
           try {
             await deferChatDeliveryRetry(event.Records[idx], log);
           } catch (error) {
@@ -4308,6 +4339,11 @@ export async function handler(
             )
           ) {
             batchItemFailures.push({ itemIdentifier: messageId });
+            await recordIfHeadedForDlq(
+              event.Records[idx],
+              result.reason,
+              log
+            );
           }
           return;
         }
@@ -4333,6 +4369,65 @@ export async function handler(
   );
 
   return { batchItemFailures };
+}
+
+/**
+ * Record a failure row when a record is about to dead-letter.
+ *
+ * Every path that fails a record eventually lands it in the DLQ, but the two
+ * deferral paths return early without calling recordFailure — so a turn could
+ * exhaust its retries and vanish with NO agent_failures row, no metric, and
+ * nothing on the usage dashboard. In prod that is exactly what happened:
+ * 50 real user messages died between 2026-08-20 and 2026-08-31 across 8 people
+ * while the failure table recorded 2 router-sourced rows all week. The only
+ * thing that noticed was a DLQ alarm publishing to a topic with no subscribers.
+ *
+ * SQS gives ApproximateReceiveCount for the attempt in hand, so the last
+ * attempt is identifiable before the redrive happens. Best-effort by design:
+ * a failure to write telemetry must never change how the record is handled.
+ */
+async function recordIfHeadedForDlq(
+  record: SQSRecord,
+  reason: unknown,
+  log: ReturnType<typeof createLogger>
+): Promise<void> {
+  const receiveCount = parseInt(
+    record.attributes?.ApproximateReceiveCount ?? '1',
+    10
+  );
+  if (!Number.isFinite(receiveCount)) return;
+  if (receiveCount < ROUTER_QUEUE_MAX_RECEIVE_COUNT) return;
+  const classified = classifyError(reason);
+  log.error('Chat turn exhausted its retries and is being dead-lettered', {
+    messageId: record.messageId,
+    receiveCount,
+    errorClass: classified.errorClass,
+    error: classified.message,
+  });
+  try {
+    await recordFailure(
+      {
+        source: 'router',
+        severity: 'error',
+        errorClass: 'ChatTurnDeadLettered',
+        errorMessage:
+          `Chat turn dead-lettered after ${receiveCount} attempts: ` +
+          classified.message,
+        stackExcerpt: classified.stack,
+        context: {
+          messageId: record.messageId,
+          receiveCount,
+          underlyingErrorClass: classified.errorClass,
+        },
+      },
+      log
+    );
+  } catch (error) {
+    log.error('Failed to record dead-letter telemetry', {
+      messageId: record.messageId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 async function workspaceDeferredRecordNeedsRetry(
@@ -4773,11 +4868,27 @@ function agentResultTelemetry(
   };
 }
 
-function totalAgentTokens(result: AgentCoreResult): number {
+/**
+ * Tokens for the usage ALERT — deliberately not the same as billed volume.
+ *
+ * This used to add cacheReadInputTokens, which made the alert fire on almost
+ * every turn: measured over 30 days of prod, median total-with-cache was
+ * 153,409 against a 100,000 threshold, p90 was 1,083,781 and the max was
+ * 14.2M. Cache reads are large BY DESIGN — that is prompt caching working —
+ * and they bill at roughly a tenth of input, so they are the last thing an
+ * "unusually expensive turn" alert should be dominated by. 3,485 warnings in
+ * 30 days is not a signal, it is noise that buries the 24 real ones.
+ *
+ * Excluding cache reads, the same 30 days gives p50 597, p90 5,277, p99
+ * 17,856 and a maximum of 42,572 — so the existing 100,000 threshold now
+ * means what it says, and would not have fired once on ordinary traffic.
+ * Cache WRITES stay in: they bill at a premium over input, so a turn writing
+ * a large cache genuinely is expensive.
+ */
+function alertableAgentTokens(result: AgentCoreResult): number {
   return (
     result.inputTokens +
     result.outputTokens +
-    result.cacheReadInputTokens +
     result.cacheWriteInputTokens
   );
 }
@@ -4912,7 +5023,11 @@ async function invokeCrossUserAgent(
     );
   }
   const result = await invokeWithSessionLockLease(
-    workspaceLockId,
+    {
+      sessionId: workspaceLockId,
+      ownerEmail: targetUser.email,
+      spaceName: human.spaceName,
+    },
     lockToken,
     log,
     async () => {
@@ -4938,7 +5053,8 @@ async function invokeCrossUserAgent(
           conversationSessionId
         )
       );
-    }
+    },
+    sessionLockLeaseDependencies,
   );
   return { result, sessionId: conversationSessionId };
 }
@@ -5051,7 +5167,7 @@ async function runCrossUserTurn(
   const turn = await invokeCrossUserAgent(human, invocation, targetUser, log);
   if (!turn) return;
 
-  const totalTokens = totalAgentTokens(turn.result);
+  const totalTokens = alertableAgentTokens(turn.result);
   if (totalTokens > TOKEN_LIMIT) {
     log.warn('Token usage exceeds alerting threshold (cross-user)', {
       invoker: human.senderEmail,
@@ -5273,7 +5389,11 @@ async function invokeOwnerAgentWithDependencies(
     );
   }
   const result = await invokeWithSessionLockLease(
-    workspaceLockId,
+    {
+      sessionId: workspaceLockId,
+      ownerEmail: user.email,
+      spaceName: human.spaceName,
+    },
     lockToken,
     log,
     async () => {
@@ -5301,7 +5421,7 @@ async function invokeOwnerAgentWithDependencies(
       renewSessionLock: dependencies.renewSessionLock,
       releaseSessionLock: dependencies.releaseSessionLock,
       scheduler: dependencies.renewalScheduler,
-    }
+    },
   );
   return {
     result,
@@ -5490,7 +5610,7 @@ async function handleOwnerTurn(
   );
   if (!turn) return;
 
-  const totalTokens = totalAgentTokens(turn.result);
+  const totalTokens = alertableAgentTokens(turn.result);
   if (totalTokens > TOKEN_LIMIT) {
     log.warn('Token usage exceeds alerting threshold', {
       inputTokens: turn.result.inputTokens,
@@ -5584,7 +5704,7 @@ export const agentRouterTestHelpers = {
   normalizeChatEvent,
   cardClickMessageText,
   parseAgentCoreResult,
-  totalAgentTokens,
+  alertableAgentTokens,
   tryAcquireSessionLock,
   invokeWithSessionLockLease,
   jobPromotionIdentity,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -125,6 +125,11 @@ class AgentPlatformBuildResources {
   bedrockApiUser!: iam.User;
   bedrockApiKeySecret!: secretsmanager.Secret;
   agentAlarmTopic?: sns.Topic;
+  /**
+   * Every topic an agent alarm must publish to. ALWAYS contains the shared
+   * monitoring topic, which is why it exists separately from agentAlarmTopic.
+   */
+  agentAlarmTargets: sns.ITopic[];
   runtime?: agentcore.Runtime;
   agentCoreExecutionRole!: iam.Role;
   routerLambdaRole!: iam.Role;
@@ -165,6 +170,24 @@ class AgentPlatformBuildResources {
   alarmTopic?: sns.Topic;
   failureMetricNamespace!: string;
   dbSecret!: secretsmanager.ISecret;
+}
+
+/**
+ * Attach every agent-alarm notification target to one alarm.
+ *
+ * Always use this instead of `addAlarmAction(new SnsAction(agentAlarmTopic))`.
+ * The dedicated topic is optional and its email subscription has silently
+ * disappeared in prod before; the shared monitoring topic is the one that has
+ * a confirmed subscriber. A site that wires only the dedicated topic is a site
+ * that can go quiet without anyone noticing.
+ */
+function notifyAgentAlarm(
+  alarm: cloudwatch.Alarm,
+  resources: AgentPlatformBuildResources,
+): void {
+  for (const topic of resources.agentAlarmTargets ?? []) {
+    alarm.addAlarmAction(new cloudwatchActions.SnsAction(topic));
+  }
 }
 
 export class AgentPlatformStack extends cdk.Stack {
@@ -955,6 +978,37 @@ export class AgentPlatformStack extends cdk.Stack {
       cdk.Tags.of(resources.agentAlarmTopic).add('ManagedBy', 'cdk');
     }
 
+    // The dedicated topic above is NOT sufficient on its own, and the comment
+    // block above says why in the abstract. Here is the concrete instance:
+    // prod's subscription was created 2026-07-24, nobody clicked the
+    // confirmation link, SNS deleted it three days later, and CloudFormation
+    // still reports the resource CREATE_COMPLETE today. The router DLQ alarm
+    // went off on 2026-07-29 and published to a topic with zero subscribers
+    // for 36 days while ~14 users' conversations were dropped on the floor.
+    // No deploy fixes that, because there is no drift for CDK to see.
+    //
+    // So every agent alarm also publishes to the monitoring stack's topic,
+    // which carries a CONFIRMED subscription for the same address plus the
+    // intelligent-alerting Lambda, and is maintained independently of this
+    // stack. Imported by ARN rather than by reference: a cross-stack object
+    // reference would add a dependency (and a possible cycle) purely to send
+    // mail. If the monitoring stack is absent the publish fails and the alarm
+    // still fires locally — strictly better than today's silence.
+    resources.agentAlarmTargets = [];
+    if (resources.agentAlarmTopic) {
+      resources.agentAlarmTargets.push(resources.agentAlarmTopic);
+    }
+    resources.agentAlarmTargets.push(
+      sns.Topic.fromTopicArn(
+        this,
+        'SharedMonitoringAlarmTopic',
+        cdk.Arn.format(
+          { service: 'sns', resource: `aistudio-${environment}-monitoring-alarms` },
+          this,
+        ),
+      ),
+    );
+
     // Shared dead-letter queue for the async-invoked agent Lambdas (EventBridge
     // Rules/Scheduler, custom-resource invoke, cross-Lambda async invoke). Without it
     // a failed async invocation is retried twice by Lambda and then DROPPED with no
@@ -981,9 +1035,7 @@ export class AgentPlatformStack extends cdk.Stack {
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
-    if (resources.agentAlarmTopic) {
-      agentAsyncDlqAlarm.addAlarmAction(new cloudwatchActions.SnsAction(resources.agentAlarmTopic));
-    }
+    notifyAgentAlarm(agentAsyncDlqAlarm, resources);
   }
 
   private createBedrockKeyManager(
@@ -2724,11 +2776,7 @@ export class AgentPlatformStack extends cdk.Stack {
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       },
     );
-    if (resources.agentAlarmTopic) {
-      untrustedLabelMappingAlarm.addAlarmAction(
-        new cloudwatchActions.SnsAction(resources.agentAlarmTopic),
-      );
-    }
+    notifyAgentAlarm(untrustedLabelMappingAlarm, resources);
 
     resources.triageWorkerRole.addToPolicy(new iam.PolicyStatement({
       sid: 'TriageWorkerLogsCorrectArn',
@@ -2945,9 +2993,7 @@ export class AgentPlatformStack extends cdk.Stack {
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
-    if (resources.agentAlarmTopic) {
-      triageWorkDlqAlarm.addAlarmAction(new cloudwatchActions.SnsAction(resources.agentAlarmTopic));
-    }
+    notifyAgentAlarm(triageWorkDlqAlarm, resources);
   }
 
   private createTriageDigest(
@@ -3224,6 +3270,15 @@ export class AgentPlatformStack extends cdk.Stack {
         DATABASE_NAME: props.databaseName || 'aistudio',
         GOOGLE_CREDENTIALS_SECRET_ARN: resources.googleCredentialsSecret.secretArn,
         TOKEN_LIMIT_PER_INTERACTION: '100000',
+        // Pass the runtime id directly rather than making every cold start pay
+        // an SSM GetParameter. The router's own comment claimed the id "is not
+        // known at CDK deploy time", but the SSM parameter a few hundred lines
+        // below is populated from this very token at deploy time, so it plainly
+        // is. 1,345 cold starts in 30 days each did a lookup they did not need.
+        // The SSM fallback stays in the Lambda for out-of-band overrides.
+        ...(resources.runtime
+          ? { AGENTCORE_RUNTIME_ID: resources.runtime.agentRuntimeId }
+          : {}),
         // K-12 safety: fail closed when guardrails are unavailable
         // Only allow messages from configured domain emails
         ALLOWED_DOMAINS: props.allowedDomains || 'psd401.net',
@@ -3875,6 +3930,7 @@ export class AgentPlatformStack extends cdk.Stack {
     resources: AgentPlatformBuildResources,
   ): void {
     const { environment } = props;
+    // Legacy alias. NOT the notification path any more — notifyAgentAlarm is.
     resources.alarmTopic = resources.agentAlarmTopic;
 
     // CloudWatch alarm on the DLQ — fires when any message exhausts the Router
@@ -3973,12 +4029,9 @@ export class AgentPlatformStack extends cdk.Stack {
       },
     );
 
-    if (resources.agentAlarmTopic) {
-      const alarmAction = new cloudwatchActions.SnsAction(resources.agentAlarmTopic);
-      cronErrorAlarm.addAlarmAction(alarmAction);
-      cronThrottleAlarm.addAlarmAction(alarmAction);
-      scheduleReferenceRejectionAlarm.addAlarmAction(alarmAction);
-    }
+    notifyAgentAlarm(cronErrorAlarm, resources);
+    notifyAgentAlarm(cronThrottleAlarm, resources);
+    notifyAgentAlarm(scheduleReferenceRejectionAlarm, resources);
 
     // CloudWatch metric filter — emit a metric every time an
     // AGENT_FAILURE_RECORD line lands in the router Lambda log. Combined with
@@ -4051,13 +4104,11 @@ export class AgentPlatformStack extends cdk.Stack {
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
 
-    // Wire alarm notifications if SNS topic is configured
-    if (resources.alarmTopic) {
-      const snsAction = new cloudwatchActions.SnsAction(resources.alarmTopic);
-      dlqAlarm.addAlarmAction(snsAction);
-      errorAlarm.addAlarmAction(snsAction);
-      failureRateAlarm.addAlarmAction(snsAction);
-    }
+    // The router DLQ alarm is the one that sat in ALARM for 36 days telling
+    // nobody. It goes through notifyAgentAlarm like everything else now.
+    notifyAgentAlarm(dlqAlarm, resources);
+    notifyAgentAlarm(errorAlarm, resources);
+    notifyAgentAlarm(failureRateAlarm, resources);
   }
 
   private createIterationMonitoring(
@@ -4223,11 +4274,8 @@ export class AgentPlatformStack extends cdk.Stack {
       }),
     );
 
-    if (resources.alarmTopic) {
-      const iterationSnsAction = new cloudwatchActions.SnsAction(resources.alarmTopic);
-      for (const a of iterationAlarms) {
-        a.addAlarmAction(iterationSnsAction);
-      }
+    for (const a of iterationAlarms) {
+      notifyAgentAlarm(a, resources);
     }
   }
 

--- a/infra/test/agent-alarm-delivery.test.ts
+++ b/infra/test/agent-alarm-delivery.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Agent alarms must reach a topic somebody is actually subscribed to.
+ *
+ * On 2026-07-24 a deploy created the email subscription on
+ * `psd-agent-alarms-prod`. Nobody clicked the confirmation link, so SNS deleted
+ * it three days later — while CloudFormation kept the subscription resource
+ * CREATE_COMPLETE, which means no later deploy restores it and there is no
+ * drift for anyone to notice. The router dead-letter alarm went into ALARM on
+ * 2026-07-29 and published to a topic with zero subscribers for 36 days. In
+ * that window ~14 users' conversations were dropped and 50 messages died in the
+ * DLQ, and the only thing that knew was an alarm talking to nobody.
+ *
+ * The stack's own comment already warned about this exact failure mode and told
+ * the reader to verify `SubscriptionsConfirmed` out of band. That is a manual
+ * step, and manual steps are what failed. So every agent alarm now ALSO
+ * publishes to `aistudio-<env>-monitoring-alarms`, which is owned by a
+ * different stack and carries a confirmed subscription.
+ *
+ * These tests pin that: an alarm wired to only one topic is one unclicked email
+ * away from silence again.
+ *
+ * Synth notes follow infra/test/agent-platform-resource-cycles.test.ts.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { AgentPlatformStack } from '../lib/agent-platform-stack';
+import { EnvironmentConfig } from '../lib/constructs';
+
+const TEST_ACCOUNT = '123456789012';
+const REGION = 'us-east-1';
+const REAL_VPC_KEY =
+  'vpc-provider:account=390844780692:filter.tag:Name=aistudio-dev-vpc:region=us-east-1:returnAsymmetricSubnets=true';
+
+function buildTemplate(
+  environment: 'dev' | 'prod',
+  alertEmail?: string
+): Template {
+  const cdkContext = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'cdk.context.json'), 'utf8')
+  ) as Record<string, unknown>;
+  const testVpcKey =
+    `vpc-provider:account=${TEST_ACCOUNT}:filter.tag:Name=aistudio-${environment}-vpc` +
+    `:region=${REGION}:returnAsymmetricSubnets=true`;
+  const vpcBlob = JSON.parse(JSON.stringify(cdkContext[REAL_VPC_KEY])) as {
+    subnetGroups: Array<{ subnets: Array<{ availabilityZone: string }> }>;
+  };
+  for (const group of vpcBlob.subnetGroups) {
+    for (const subnet of group.subnets) {
+      if (subnet.availabilityZone === 'us-east-1a') {
+        subnet.availabilityZone = 'us-east-1c';
+      }
+    }
+  }
+  const app = new cdk.App({
+    context: {
+      ...cdkContext,
+      [testVpcKey]: vpcBlob,
+      'aws:cdk:bundling-stacks': [],
+      agentImageTag: 'test-image-tag',
+    },
+  });
+  const stack = new AgentPlatformStack(
+    app,
+    `AIStudio-AgentPlatformStack-${environment}`,
+    {
+      environment,
+      config: EnvironmentConfig.get(environment),
+      databaseResourceArn: `arn:aws:rds:${REGION}:${TEST_ACCOUNT}:cluster:aistudio-${environment}`,
+      databaseSecretArn:
+        `arn:aws:secretsmanager:${REGION}:${TEST_ACCOUNT}:secret:aistudio-${environment}-db-AbCdEf`,
+      databaseHost: `aistudio-${environment}.cluster-abc.${REGION}.rds.amazonaws.com`,
+      databaseName: 'aistudio',
+      guardrailArn: `arn:aws:bedrock:${REGION}:${TEST_ACCOUNT}:guardrail/test`,
+      guardrailId: 'test-guardrail-id',
+      ...(alertEmail ? { alertEmail } : {}),
+      appBaseUrl: `https://${environment}.aistudio.psd401.ai`,
+      env: { account: TEST_ACCOUNT, region: REGION },
+    }
+  );
+  return Template.fromStack(stack);
+}
+
+/** Every alarm in the template, with the SNS targets of its AlarmActions. */
+function alarmsWithActions(
+  template: Template
+): Array<{ name: string; actions: string[] }> {
+  const alarms = template.findResources('AWS::CloudWatch::Alarm');
+  return Object.entries(alarms).map(([logicalId, body]) => {
+    const props = (body as { Properties?: Record<string, unknown> }).Properties ?? {};
+    const raw = (props.AlarmActions as unknown[]) ?? [];
+    return {
+      name: String(props.AlarmName ?? logicalId),
+      actions: raw.map(action => JSON.stringify(action)),
+    };
+  });
+}
+
+const SHARED_TOPIC = (environment: string) =>
+  `aistudio-${environment}-monitoring-alarms`;
+
+/** Alarms that notify at all, for one environment. */
+function notifyingAlarms(
+  environment: 'dev' | 'prod',
+  alertEmail?: string
+): Array<{ name: string; actions: string[] }> {
+  return alarmsWithActions(buildTemplate(environment, alertEmail)).filter(
+    alarm => alarm.actions.length > 0
+  );
+}
+
+function reachesSharedTopic(
+  alarm: { actions: string[] },
+  environment: string
+): boolean {
+  return alarm.actions.some(action => action.includes(SHARED_TOPIC(environment)));
+}
+
+/** Every notifying alarm must reach the topic with a confirmed subscriber. */
+function expectAllAlarmsReachSharedTopic(
+  environment: 'dev' | 'prod',
+  alertEmail?: string
+): void {
+  const alarms = notifyingAlarms(environment, alertEmail);
+  expect(alarms.length).toBeGreaterThan(0);
+  const missing = alarms
+    .filter(alarm => !reachesSharedTopic(alarm, environment))
+    .map(alarm => alarm.name);
+  expect(missing).toEqual([]);
+}
+
+function routerDlqAlarm(environment: 'dev' | 'prod') {
+  return notifyingAlarms(environment, 'alerts@psd401.net').find(
+    alarm => alarm.name === `psd-agent-router-dlq-${environment}`
+  );
+}
+
+describe('agent alarm delivery', () => {
+  it('dev: every alarm reaches the shared monitoring topic', () => {
+    expectAllAlarmsReachSharedTopic('dev', 'alerts@psd401.net');
+  });
+
+  it('prod: every alarm reaches the shared monitoring topic', () => {
+    expectAllAlarmsReachSharedTopic('prod', 'alerts@psd401.net');
+  });
+
+  // The old code created NO topic without alertEmail, so every
+  // `if (agentAlarmTopic)` guard silently skipped its action and the stack
+  // deployed alarms that evaluated correctly and notified nobody.
+  it('dev: still notifies with no alertEmail configured', () => {
+    expectAllAlarmsReachSharedTopic('dev');
+  });
+
+  it('prod: still notifies with no alertEmail configured', () => {
+    expectAllAlarmsReachSharedTopic('prod');
+  });
+
+  it('keeps the dedicated topic as a second target when an address is given', () => {
+    const template = buildTemplate('prod', 'alerts@psd401.net');
+    template.hasResourceProperties('AWS::SNS::Topic', {
+      TopicName: 'psd-agent-alarms-prod',
+    });
+    const dlq = alarmsWithActions(template).find(
+      alarm => alarm.name === 'psd-agent-router-dlq-prod'
+    );
+    expect(dlq).toBeDefined();
+    expect(dlq?.actions.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('routes the router DLQ alarm — the one that went unheard for 36 days', () => {
+    const dlq = routerDlqAlarm('prod');
+    expect(dlq).toBeDefined();
+    expect(reachesSharedTopic(dlq!, 'prod')).toBe(true);
+  });
+
+  it('passes the AgentCore runtime id to the router without an SSM lookup', () => {
+    const fns = buildTemplate('prod', 'alerts@psd401.net').findResources(
+      'AWS::Lambda::Function'
+    );
+    const router = Object.values(fns).find(fn => {
+      const env = (
+        fn as { Properties?: { Environment?: { Variables?: Record<string, unknown> } } }
+      ).Properties?.Environment?.Variables;
+      // ROUTER_QUEUE_URL alone also matches the cron Lambda, which publishes to
+      // the same queue. TOKEN_LIMIT_PER_INTERACTION is the router's own.
+      return (
+        env !== undefined &&
+        'ROUTER_QUEUE_URL' in env &&
+        'TOKEN_LIMIT_PER_INTERACTION' in env
+      );
+    });
+    expect(router).toBeDefined();
+    const vars = (
+      router as { Properties: { Environment: { Variables: Record<string, unknown> } } }
+    ).Properties.Environment.Variables;
+    expect(vars).toHaveProperty('AGENTCORE_RUNTIME_ID');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:smoke:auth-edge-production": "node scripts/test/auth-edge-production.smoke.cjs",
     "agent:probe-context": "bun run scripts/agent-workspace/mint-agent-probe-context.ts",
     "test:skill:workspace": "cd infra/agent-image/skills/psd-workspace && bun test common.test.js",
+    "test:lambda:router": "cd infra/lambdas/agent-router && bun test",
     "test:skill:directory": "cd infra/agent-image/skills/psd-directory && bun test run.test.js",
     "test:skill:workflows": "cd infra/agent-image/skills/psd-workflows && node --test",
     "test:skill:schedules": "cd infra/agent-image/skills/psd-schedules && bun test",


### PR DESCRIPTION
## Why

Between 08-20 and 08-31, **50 Google Chat messages from 8 staff died** in
`psd-agent-router-dlq-prod` with no reply — ~14 conversations, 12 of the
messages being somebody asking why the agent had gone quiet.

Nothing looked broken: zero Lambda errors, zero timeouts, zero
`Record processing failed`, and 2 router-sourced `agent_failures` rows all week.

The DLQ alarm **did** fire, on 2026-07-29, and has been in ALARM since. It
publishes to `psd-agent-alarms-prod`, which has zero subscribers:

```
CFN  AgentAlarmTopictechalertspsd401net5CAAD122  CREATE_COMPLETE  2026-07-24 00:26
     → arn:...:psd-agent-alarms-prod:83ac8feb-…
SNS  GetSubscriptionAttributes → NotFound — Subscription does not exist
     SubscriptionsConfirmed=0  Pending=0  Deleted=0
```

Created 07-24, never confirmed, SNS deleted it after 3 days, CloudFormation
still believes it exists — so no deploy restores it and there is no drift to
notice. **36 days of an alarm talking to nobody.**

## What changed

| Fix | Detail |
|---|---|
| **Alarm delivery** | All 9 alarm sites go through one `notifyAgentAlarm()` and also publish to `aistudio-<env>-monitoring-alarms`, which has a *confirmed* subscription for the same address. Imported by ARN — no cross-stack dependency, no cycle. |
| **Dead-letter telemetry** | `recordIfHeadedForDlq()` writes an `agent_failures` row on a record's final attempt. The two deferral paths returned early without recording — which is why 50 messages died leaving 2 rows. |
| **Token alert** | `totalAgentTokens` summed cache reads → 3,485 warnings in 30 days. Renamed `alertableAgentTokens` and cache reads excluded. |
| **Runtime id** | `AGENTCORE_RUNTIME_ID` now passed to the router; 1,345 needless SSM lookups in 30 days. |
| **Retained locks** | The warning now names `ownerEmail`/`spaceName`, not just a hash. Semantics unchanged. |

### The token numbers

| | p50 | p90 | max |
|---|---|---|---|
| As measured (incl. cache) | 153,409 | 1,083,781 | 14.2M |
| Real input + output | **597** | 5,277 | 42,572 |

Threshold is 100,000. Cache reads are large by design and bill at ~a tenth of
input, so the alert was firing on most turns. It now means what it says.

## The test gap this exposed

`infra/lambdas/agent-router` has **131 bun:test tests that ran in no gate**:
root jest ignores `infra/` except one triage path, infra's `lambdas` project
matches only `**/__tests__/**`, and jest can't parse `bun:test` anyway. The
Lambda handling every Chat message was untested in CI.

It caught **two regressions in this very PR** — the lock-lease signature and
the token total — that lint, typecheck and 5,817 root tests all passed. Added
`test:lambda:router` and wired it into `ci.yml`.

## Verification

- 9 new CDK tests. **Mutation-tested**: restoring the single-topic wiring fails 8 of 9.
- Resource-cycle guard passes with the imported topic (`cdk synth` alone misses cycles).
- 131/131 router, 5,817 root, lint + typecheck clean.
- `agent-platform-mcp-key.test.ts` has one pre-existing failure — identical on a stashed tree, unrelated.

## Deliberately not done

The 50 dead messages are **extracted and reported, not redriven**. Replaying
days-old turns re-runs their side effects (mail, Drive writes, Chat posts) and
several had already partially executed. They expire on SQS's 14-day retention.
