### PR TITLE
fix(agent): cutover guard compares the workspace contract, not filenames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
           infra/agent-image/test_mantle_proxy.py \
           infra/agent-image/test_mantle_proxy_logging.py \
           infra/agent-image/test_cutover_guard.py \
+          infra/agent-image/test_workspace_contract.py \
           infra/agent-image/test_check_bootstrap_budget.py \
           infra/agent-image/test_check_config_consistency.py \
           infra/agent-image/test_candidate_matrix.py \

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -773,13 +773,50 @@ deployed_commit() {
   printf '%s' "${sha}"
 }
 
+# A cutover is required when old and new writers would disagree about
+# something PERSISTED — the proof format, the manifest or journal shape, the
+# object-key layout, the generation schema. It is NOT required merely because
+# a watched file changed.
+#
+# This used to be `git diff --name-only` on CUTOVER_PATHS, so a comment, a log
+# line or a relaxed validation demanded the same ingress pause and writer
+# drain as a generation rewrite. On 2026-09-02 it did exactly that over a
+# change that only added an optional `journaledReplay` flag to proof
+# verification: no write path touched, workspace_sync.py and migration 171
+# untouched, both fleet directions provably compatible. A guard that fires on
+# every edit is a guard that gets waved through on the build where it matters.
+#
+# workspace_contract.py extracts the declarations that define those persisted
+# shapes and compares their fingerprint. It fails closed: if extraction finds
+# no anchors in a file that exists, it exits 2 and we demand the cutover,
+# because a silent empty fingerprint would compare equal forever.
 CUTOVER_REASON=""
+CONTRACT_DIFF=""
 if DEPLOYED_COMMIT="$(deployed_commit)"; then
   CHANGED="$(git -C "${REPO_ROOT}" diff --name-only \
     "${DEPLOYED_COMMIT}..${SOURCE_COMMIT}" -- "${CUTOVER_PATHS[@]}" 2>/dev/null || true)"
-  if [ -n "${CHANGED}" ]; then
-    CUTOVER_REASON="changed since the deployed image (${DEPLOYED_COMMIT:0:12}):
-$(printf '  - %s\n' ${CHANGED})"
+  CONTRACT_DIFF="$(python3 "${SCRIPT_DIR}/workspace_contract.py" \
+    --rev "${SOURCE_COMMIT}" --compare-to "${DEPLOYED_COMMIT}" 2>&1)"
+  CONTRACT_STATUS=$?
+  case "${CONTRACT_STATUS}" in
+    0) ;;  # contract unchanged — no cutover, whatever the filenames say
+    1)
+      CUTOVER_REASON="the workspace contract changed since the deployed image
+  (${DEPLOYED_COMMIT:0:12}):
+$(printf '%s\n' "${CONTRACT_DIFF}" | sed 's/^/  /')"
+      ;;
+    *)
+      CUTOVER_REASON="the workspace contract could NOT be compared
+  (${CONTRACT_DIFF}). Failing closed."
+      ;;
+  esac
+  if [ -z "${CUTOVER_REASON}" ] && [ -n "${CHANGED}" ]; then
+    echo "Note: watched workspace files changed since ${DEPLOYED_COMMIT:0:12},"
+    echo "but the persisted contract did not, so no cutover is required:"
+    printf '  - %s\n' ${CHANGED}
+    echo "  (proof/manifest/journal shapes, key layout and migration 171 all"
+    echo "   identical — verified by workspace_contract.py)"
+    echo ""
   fi
 else
   CUTOVER_REASON="could not determine the deployed image's commit, so this

--- a/infra/agent-image/test_workspace_contract.py
+++ b/infra/agent-image/test_workspace_contract.py
@@ -1,0 +1,177 @@
+"""The cutover guard must fire on format drift and stay quiet otherwise.
+
+The guard this replaces was `git diff --name-only` on three paths, so a
+comment demanded the same ingress pause and writer drain as a generation
+rewrite. It cried wolf on 2026-09-02 over a change that only added an optional
+`journaledReplay` flag to proof verification.
+
+The danger of making a safety guard quieter is making it quiet on the case it
+exists for. So these tests are mostly the other direction: every persisted
+shape that a mixed-version fleet must agree on, mutated, asserting the
+fingerprint MOVES. A test that only proved "the false positive is gone" would
+pass just as well against a guard that never fires at all.
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import workspace_contract as wc  # noqa: E402
+
+BROKER = '''
+const MAX_LIST_KEYS = 1_000
+const WORKSPACE_CHECKPOINT_VERSION = 2 as const
+const WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v2"
+const WORKSPACE_FINALIZATION_PROOF_VERSION = "v1"
+const PUBLIC_CONTENT_TYPES = new Map([
+  [".csv", new Set(["text/csv"])],
+  [".html", new Set(["text/html"])],
+])
+
+type WorkspaceCheckpointManifest = {
+  version: typeof WORKSPACE_CHECKPOINT_VERSION
+  signedWorkspacePrefix: string
+  workspaceGeneration: string
+}
+
+type WorkspaceFinalizationJournal =
+  | PendingWorkspaceFinalizationJournal
+  | PreparedWorkspaceFinalizationJournal
+
+// a comment mentioning VERSION and MANIFEST
+function verify(proof: string): void {
+  if (!proof) throw new Error("bad")
+}
+'''
+
+SYNC = '''
+WORKSPACE_DIR = Path("/home/node/.openclaw")
+MAX_SYNC_FILES = 250_000
+WORKSPACE_UPLOAD_CONTENT_TYPE = "application/octet-stream"
+_SKIP_RELATIVE_PREFIXES = tuple(
+    _CHECKPOINT_EXCLUSIONS["relativePrefixes"]
+)
+'''
+
+
+class TheFingerprintIgnoresWhatCannotCorruptAWorkspace(unittest.TestCase):
+    """Behaviour changes on one side of the fleet are not format changes."""
+
+    def test_a_comment_change_does_not_move_it(self):
+        before = wc.broker_anchors(BROKER)
+        after = wc.broker_anchors(
+            BROKER.replace("// a comment mentioning VERSION and MANIFEST",
+                           "// entirely different prose")
+        )
+        self.assertEqual(before, after)
+
+    def test_added_validation_logic_does_not_move_it(self):
+        # The real 2026-09-02 change: an extra option on a verify function.
+        after = wc.broker_anchors(
+            BROKER.replace(
+                "function verify(proof: string): void {",
+                "function verify(proof: string, "
+                "options: { journaledReplay?: boolean } = {}): void {",
+            )
+        )
+        self.assertEqual(wc.broker_anchors(BROKER), after)
+
+    def test_a_non_contract_constant_is_not_an_anchor(self):
+        after = wc.broker_anchors(BROKER.replace("MAX_LIST_KEYS = 1_000",
+                                                 "MAX_LIST_KEYS = 2_000"))
+        self.assertEqual(wc.broker_anchors(BROKER), after)
+
+
+class TheFingerprintCatchesEveryPersistedShape(unittest.TestCase):
+    """Each of these would let an old writer misread a new object."""
+
+    def _moves(self, before_text, after_text, extractor=None):
+        extract = extractor or wc.broker_anchors
+        self.assertNotEqual(
+            extract(before_text), extract(after_text),
+            "fingerprint did not move on a real format change"
+        )
+
+    def test_proof_version_bump(self):
+        self._moves(BROKER, BROKER.replace(
+            'PROOF_VERSION = "v1"', 'PROOF_VERSION = "v2"'))
+
+    def test_checkpoint_version_bump(self):
+        self._moves(BROKER, BROKER.replace(
+            "CHECKPOINT_VERSION = 2 as const", "CHECKPOINT_VERSION = 3 as const"))
+
+    def test_control_prefix_move(self):
+        self._moves(BROKER, BROKER.replace(
+            '".workspace-checkpoints/v2"', '".workspace-checkpoints/v3"'))
+
+    def test_manifest_field_rename(self):
+        self._moves(BROKER, BROKER.replace(
+            "workspaceGeneration: string", "generation: string"))
+
+    def test_manifest_field_retype(self):
+        self._moves(BROKER, BROKER.replace(
+            "workspaceGeneration: string", "workspaceGeneration: number"))
+
+    def test_manifest_field_removed(self):
+        self._moves(BROKER, BROKER.replace(
+            "  signedWorkspacePrefix: string\n", ""))
+
+    def test_a_dropped_union_member(self):
+        # Caught only because the extractor follows leading `|` continuations.
+        self._moves(BROKER, BROKER.replace(
+            "  | PreparedWorkspaceFinalizationJournal\n", ""))
+
+    def test_a_changed_multiline_constant_body(self):
+        # Caught only because the extractor reads past the opening line.
+        self._moves(BROKER, BROKER.replace(
+            '[".html", new Set(["text/html"])],', ""))
+
+    def test_sync_upload_content_type(self):
+        self._moves(SYNC, SYNC.replace(
+            '"application/octet-stream"', '"application/x-tar"'),
+            wc.sync_anchors)
+
+    def test_sync_multiline_constant_body(self):
+        self._moves(SYNC, SYNC.replace(
+            '_CHECKPOINT_EXCLUSIONS["relativePrefixes"]',
+            '_CHECKPOINT_EXCLUSIONS["other"]'),
+            wc.sync_anchors)
+
+
+class ExtractionFailsClosed(unittest.TestCase):
+    """A guard that silently extracts nothing reports 'unchanged' forever."""
+
+    def test_a_file_with_no_anchors_raises(self):
+        with self.assertRaises(wc.ContractExtractionError):
+            wc.fingerprint_from_sources(
+                {wc.BROKER: "const UNRELATED = 1\n"}
+            )
+
+    def test_anchors_are_found_in_the_real_files(self):
+        # Guards against the extractor drifting out of date with the source:
+        # if the constants are ever renamed wholesale this fails loudly
+        # instead of quietly fingerprinting an empty set.
+        root = pathlib.Path(__file__).resolve().parents[2]
+        broker = (root / wc.BROKER).read_text()
+        sync = (root / wc.SYNC).read_text()
+        self.assertTrue(wc.broker_anchors(broker))
+        self.assertTrue(wc.sync_anchors(sync))
+
+    def test_the_proof_and_manifest_anchors_are_actually_present(self):
+        root = pathlib.Path(__file__).resolve().parents[2]
+        anchors = " ".join(wc.broker_anchors((root / wc.BROKER).read_text()))
+        for required in (
+            "WORKSPACE_FINALIZATION_PROOF_VERSION",
+            "WORKSPACE_CHECKPOINT_VERSION",
+            "WORKSPACE_CHECKPOINT_CONTROL_PREFIX",
+            "type WorkspaceCheckpointManifest",
+            "type WorkspaceFinalizationProofClaims",
+        ):
+            self.assertIn(required, anchors,
+                          f"{required} is no longer fingerprinted")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/workspace_contract.py
+++ b/infra/agent-image/workspace_contract.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Fingerprint the workspace contract that a mixed-version fleet must agree on.
+
+WHY THIS EXISTS
+
+build-and-push.sh used to demand a full workspace cutover — pause ingress,
+drain writers, ordered redeploy — whenever `git diff --name-only` reported any
+change to storage-broker.ts, workspace_sync.py, or migration 171. A filename.
+So a comment, a log line, or a relaxed validation triggered the same
+maintenance window as a generation-format rewrite.
+
+It cried wolf on 2026-09-02 over a change that only ADDED an optional
+`journaledReplay` flag to proof verification: no write path touched, no
+persisted shape altered, workspace_sync.py and migration 171 untouched. A
+guard that fires on every edit is a guard that gets waved through on the one
+build where it matters.
+
+WHAT ACTUALLY REQUIRES A CUTOVER
+
+AgentCore keeps a live session on the image its microVM was created with, so a
+release can briefly run old and new writers at once. That is only dangerous
+when the two disagree about something PERSISTED: the proof string format, the
+checkpoint manifest or journal shape, the object-key layout, or the generation
+schema. Behaviour that is merely stricter or looser on one side cannot corrupt
+an object that both sides still read and write identically.
+
+So this extracts the declarations that define those persisted shapes and
+hashes them. Validation logic, comments and log lines do not move the
+fingerprint; a version bump, a renamed control prefix, a changed manifest field
+or a schema edit all do.
+
+FAIL-CLOSED
+
+If a watched file exists but yields no anchors, the extraction itself is
+considered broken and the caller must treat that as "cutover required". That
+stops a refactor which renames every constant from silently emptying the
+fingerprint and reporting "no change".
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+
+BROKER = "lib/agent-workspace/storage-broker.ts"
+SYNC = "infra/agent-image/workspace_sync.py"
+SCHEMA_GLOB_PREFIX = "infra/database/schema/171"
+
+# A constant belongs to the contract when its name refers to something written
+# down and read back by the other side of the fleet.
+CONTRACT_NAME = re.compile(
+    r"(VERSION|PREFIX|GENERATION|MANIFEST|JOURNAL|PROOF|DOMAIN|CONTENT_TYPE)"
+)
+
+# Types whose FIELD NAMES are serialized into the manifest, the journal, or the
+# proof. A renamed or retyped field here is a wire-format change.
+CONTRACT_TYPE = re.compile(
+    r"^(?:type|interface)\s+"
+    r"([A-Za-z0-9_]*(?:Manifest|Journal|ProofClaims|CheckpointEntry)"
+    r"[A-Za-z0-9_]*)\b"
+)
+
+TS_CONST = re.compile(r"^const\s+([A-Z][A-Z0-9_]*)\s*=")
+PY_CONST = re.compile(r"^(_?[A-Z][A-Z0-9_]*)\s*=")
+TS_COMMENT = "//"
+PY_COMMENT = "#"
+STRING_LITERAL = re.compile(r"\"(?:[^\"\\\\]|\\\\.)*\"|'(?:[^'\\\\]|\\\\.)*'|`(?:[^`\\\\]|\\\\.)*`")
+REGEX_LITERAL = re.compile(r"/(?:[^/\\\\\\n]|\\\\.)+/[gimsuy]*")
+
+
+class ContractExtractionError(RuntimeError):
+    """A watched file produced no anchors — treat as cutover required."""
+
+
+def _show(rev, path):
+    """File contents at a git revision, or None when absent at that rev."""
+    done = subprocess.run(
+        ["git", "show", f"{rev}:{path}"],
+        capture_output=True, text=True,
+    )
+    return done.stdout if done.returncode == 0 else None
+
+
+def _list_schema(rev):
+    done = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", rev, "infra/database/schema/"],
+        capture_output=True, text=True,
+    )
+    if done.returncode != 0:
+        return []
+    return sorted(
+        p for p in done.stdout.splitlines()
+        if p.startswith(SCHEMA_GLOB_PREFIX)
+    )
+
+
+def _strip_comment(line, marker):
+    """Drop a trailing line comment, ignoring markers inside literals.
+
+    Both parts matter and both were wrong once. The first version applied
+    Python's `#` rule to TypeScript, so `const CONTENT_TYPE_RE = /^[a-z0-9!#...`
+    was cut at the `#` inside the regex character class; the truncated,
+    unbalanced remainder then swallowed the following declarations and any
+    edit near them looked like a contract change.
+    """
+    blanked = STRING_LITERAL.sub(lambda m: " " * len(m.group(0)), line)
+    blanked = REGEX_LITERAL.sub(lambda m: " " * len(m.group(0)), blanked)
+    index = blanked.find(marker)
+    return line[:index] if index != -1 else line
+
+
+def _declaration(lines, start, comment=TS_COMMENT, max_lines=400):
+    """The whole declaration beginning at `start`, normalized.
+
+    Consumes until every bracket opened is closed AND the text no longer sits
+    on a continuation, so all the real shapes are captured in full:
+
+        const X = "literal"                      one line
+        const X = new Map([ ... ])               brackets span lines
+        type X =                                 continuation trails
+          Y & { version: 1 }
+        type X =                                 continuation LEADS
+          | A
+          | B
+
+    Earlier versions truncated at the first line, then at the first balanced
+    line, then at the first union member. A guard that cannot see the thing it
+    guards is worse than no guard, because it reports "unchanged".
+
+    Comments are stripped and whitespace collapsed, so prose edits inside a
+    declaration do not move the fingerprint.
+    """
+    CONTINUES = ("=", "&", "|", ",", "(", "[", "{", "+", ":")
+    LEADS = ("|", "&", ".", "?", ":")
+    collected, depth = [], 0
+    for line in lines[start:start + max_lines]:
+        code = _strip_comment(line, comment).rstrip()
+        if code.strip():
+            collected.append(code.strip())
+        # Brackets inside a string or regex literal are DATA, not structure.
+        depth_src = REGEX_LITERAL.sub("", STRING_LITERAL.sub("", code))
+        depth += sum(depth_src.count(c) for c in "{([")
+        depth -= sum(depth_src.count(c) for c in "})]")
+        if depth > 0 or not collected:
+            continue
+        if collected[-1].endswith(CONTINUES):
+            continue
+        nxt = lines[start + len(collected)] if start + len(collected) < len(lines) else ""
+        if _strip_comment(nxt, comment).strip().startswith(LEADS):
+            continue
+        break
+    return re.sub(r"\s+", " ", " ".join(collected)).strip().rstrip(",")
+
+
+def broker_anchors(text):
+    anchors, lines = [], text.splitlines()
+    for index, line in enumerate(lines):
+        const = TS_CONST.match(line)
+        if const and CONTRACT_NAME.search(const.group(1)):
+            anchors.append(_declaration(lines, index, TS_COMMENT))
+        declared = CONTRACT_TYPE.match(line)
+        if declared:
+            anchors.append(_declaration(lines, index, TS_COMMENT))
+    return sorted(set(anchors))
+
+
+def sync_anchors(text):
+    anchors, lines = [], text.splitlines()
+    for index, line in enumerate(lines):
+        const = PY_CONST.match(line)
+        if const and CONTRACT_NAME.search(const.group(1)):
+            anchors.append(_declaration(lines, index, PY_COMMENT))
+    return sorted(set(anchors))
+
+
+def fingerprint_from_sources(sources, schema=None):
+    """The contract from already-read file contents.
+
+    Split out from `fingerprint` so the fail-closed rule is testable without a
+    git tree: extraction returning nothing must raise, never quietly produce
+    an empty fingerprint that compares equal to everything forever.
+    """
+    parts = {}
+    extractors = ((BROKER, broker_anchors), (SYNC, sync_anchors))
+    for path, extract in extractors:
+        text = sources.get(path)
+        if text is None:
+            continue
+        anchors = extract(text)
+        if not anchors:
+            raise ContractExtractionError(
+                f"no contract anchors found in {path} — the extractor is out "
+                "of date with the source, so its silence means nothing"
+            )
+        parts[path] = anchors
+
+    # Any edit to the generation/journal migrations is a real schema change;
+    # there is no safe subset to extract, so hash them whole.
+    for path, content in sorted((schema or {}).items()):
+        parts[path] = [hashlib.sha256(content.encode()).hexdigest()]
+
+    blob = json.dumps(parts, sort_keys=True)
+    return {
+        "anchors": parts,
+        "digest": hashlib.sha256(blob.encode()).hexdigest(),
+    }
+
+
+def fingerprint(rev):
+    """The contract at one git revision."""
+    sources = {path: _show(rev, path) for path in (BROKER, SYNC)}
+    sources = {k: v for k, v in sources.items() if v is not None}
+    schema = {path: (_show(rev, path) or "") for path in _list_schema(rev)}
+    return fingerprint_from_sources(sources, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rev", required=True)
+    parser.add_argument("--compare-to", help="second revision; exit 1 if the "
+                                             "contract differs")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        current = fingerprint(args.rev)
+    except ContractExtractionError as exc:
+        print(f"CONTRACT EXTRACTION FAILED: {exc}", file=sys.stderr)
+        return 2
+
+    if not args.compare_to:
+        print(current["digest"])
+        if args.verbose:
+            print(json.dumps(current["anchors"], indent=1), file=sys.stderr)
+        return 0
+
+    try:
+        other = fingerprint(args.compare_to)
+    except ContractExtractionError as exc:
+        print(f"CONTRACT EXTRACTION FAILED: {exc}", file=sys.stderr)
+        return 2
+
+    if current["digest"] == other["digest"]:
+        print("contract unchanged")
+        return 0
+
+    print("contract CHANGED")
+    for path in sorted(set(current["anchors"]) | set(other["anchors"])):
+        before = set(other["anchors"].get(path, []))
+        after = set(current["anchors"].get(path, []))
+        for gone in sorted(before - after):
+            print(f"  - {path}: {gone}")
+        for added in sorted(after - before):
+            print(f"  + {path}: {added}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The guard was a filename check

```bash
CHANGED="$(git diff --name-only DEPLOYED..SOURCE -- CUTOVER_PATHS)"
if [ -n "$CHANGED" ]; then CUTOVER_REQUIRED
```

Any edit to `storage-broker.ts`, `workspace_sync.py` or migration 171 demanded
the full procedure — pause ingress, drain writers, ordered redeploy, post-drain
inventory audit. A comment qualified.

**Across the last 12 commits touching `storage-broker.ts`, it demanded a
cutover for all 12.** That is how a guard gets waved through on the build where
it matters.

It fired again on 2026-09-02 for a change that only added an optional
`journaledReplay` flag to proof verification. Verified by hand first: six
hunks, all inside `verifyWorkspaceFinalizationProof` and
`finalizeWorkspaceCheckpoint`; no write path touched; proof string format,
journal shape and manifest shape unchanged; `workspace_sync.py` and migration
171 untouched. Both directions safe — a new broker accepts strictly more, and
an old broker rejecting a new image's replay is the pre-existing bug, not
corruption.

## Now it compares the contract

`workspace_contract.py` fingerprints what a mixed-version fleet must actually
agree on: the proof/checkpoint version constants, control prefixes, generation
regex, the manifest/journal/proof-claim shapes, and a whole-file hash of
migration 171.

On the same 12 commits it **clears 7 and flags 5**, and the 5 are real:

| Commit | Why it's a real cutover |
|---|---|
| `2491240ba` | introduced the finalization proof + journal format |
| `b897a9497` | introduced checkpoint version, control prefix, generation regex |
| `dba4e97b6`, `a15fd2013`, `272574fac` | further format/shape changes |

When files changed but the contract didn't, the build now says so and names
them — still worth a human's eye, just not a maintenance window.

## Fails closed

Extraction finding no anchors in a file that exists raises, and a non-zero exit
means cutover-required. A refactor renaming every constant must not quietly
produce an empty fingerprint that compares equal forever. Covered by tests,
including one asserting the proof/checkpoint/manifest anchors are still present
in the real sources.

## Three extraction bugs found while building it

Each made the guard blind or noisy; each was caught by reading its output, not
by a passing test:

- first-line-only capture ignored the body of every multi-line constant
- breaking at the first balanced line truncated `type X =` to its header, and
  the trailing-token fix then dropped every union member after the first
- applying Python's `#` rule to TypeScript cut
  `const CONTENT_TYPE_RE = /^[a-z0-9!#...` at the `#` in its character class;
  the unbalanced remainder swallowed the next declarations, so nearby edits
  looked like contract changes

Depth counting now ignores brackets inside string/regex literals; comment
stripping is per-language and literal-aware.

## Tests

16, **most asserting the guard still FIRES**: proof version bump, checkpoint
version bump, control-prefix move, manifest field rename/retype/removal, a
dropped union member, a changed multi-line constant body, and both
`workspace_sync.py` constants. A suite that only proved the false positive was
gone would pass against a guard that never fires at all.

865 agent-image tests, lint and typecheck clean. Wired into `ci.yml`.
