### PR TITLE
fix(agent): act on the dead-letter telemetry review findings

### DIFF
--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -40,6 +40,7 @@ const {
   parseDeferredChatDeliveryRecord,
   markPromotedTurnRecoveredWithDependencies,
   btwSlashCommandId,
+  recordIfHeadedForDlq,
 } = agentRouterTestHelpers
 
 type OwnerHuman = Parameters<typeof invokeOwnerAgentWithDependencies>[0]
@@ -2317,5 +2318,119 @@ describe("settling a promoted turn's harness failure row", () => {
         }
       )
     ).resolves.toBeUndefined()
+  })
+})
+
+describe("dead-letter telemetry", () => {
+  const RECORD = (attributes: Record<string, string>, body = "{}") => ({
+    messageId: "msg-1",
+    receiptHandle: "rh",
+    body,
+    attributes,
+    messageAttributes: {},
+    md5OfBody: "",
+    eventSource: "aws:sqs",
+    eventSourceARN: "arn",
+    awsRegion: "us-east-1",
+  }) as unknown as Parameters<typeof recordIfHeadedForDlq>[0]
+
+  const capture = () => {
+    const rows: Record<string, unknown>[] = []
+    const errors: Record<string, unknown>[] = []
+    return {
+      rows,
+      errors,
+      log: {
+        ...createLogger({ action: "test" }),
+        error: (_m: string, meta: Record<string, unknown> = {}) => {
+          errors.push(meta)
+        },
+      },
+      deps: { recordFailure: async (p: Record<string, unknown>) => { rows.push(p) } },
+    }
+  }
+
+  test("says nothing before the final attempt", async () => {
+    const c = capture()
+    await recordIfHeadedForDlq(
+      RECORD({ ApproximateReceiveCount: "1" }),
+      new Error("boom"),
+      c.log,
+      c.deps,
+    )
+    expect(c.rows).toEqual([])
+    expect(c.errors).toEqual([])
+  })
+
+  test("records on the attempt that dead-letters", async () => {
+    const c = capture()
+    await recordIfHeadedForDlq(
+      RECORD({ ApproximateReceiveCount: "3" }),
+      new Error("boom"),
+      c.log,
+      c.deps,
+    )
+    expect(c.rows).toHaveLength(1)
+    expect(c.rows[0].errorClass).toBe("ChatTurnDeadLettered")
+  })
+
+  test("records when the receive count is missing", async () => {
+    // Unknown must mean RECORD. Defaulting to '1' meant a record with no
+    // attributes dead-lettered in silence, which is the bug this exists for.
+    const c = capture()
+    await recordIfHeadedForDlq(RECORD({}), new Error("boom"), c.log, c.deps)
+    expect(c.rows).toHaveLength(1)
+  })
+
+  test("names WHO lost the message", async () => {
+    // A row that cannot answer "whose turn died?" still leaves someone
+    // decoding SQS bodies by hand.
+    const chatEvent = {
+      type: "MESSAGE",
+      eventTime: "2026-09-02T00:00:00Z",
+      message: {
+        name: "spaces/AAA/messages/1",
+        sender: { email: "someone@psd401.net", displayName: "Someone" },
+        text: "hi",
+      },
+      space: { name: "spaces/AAA", type: "DM" },
+    }
+    const body = JSON.stringify({
+      message: { data: Buffer.from(JSON.stringify(chatEvent)).toString("base64") },
+    })
+    const c = capture()
+    await recordIfHeadedForDlq(
+      RECORD({ ApproximateReceiveCount: "3" }, body),
+      new Error("boom"),
+      c.log,
+      c.deps,
+    )
+    expect(c.rows[0].userId).toBe("someone@psd401.net")
+    expect(c.rows[0].sessionId).toBe("spaces/AAA")
+  })
+
+  test("still records when the body cannot be parsed", async () => {
+    const c = capture()
+    await recordIfHeadedForDlq(
+      RECORD({ ApproximateReceiveCount: "3" }, "not json"),
+      new Error("boom"),
+      c.log,
+      c.deps,
+    )
+    expect(c.rows).toHaveLength(1)
+    expect(c.rows[0].userId).toBeNull()
+  })
+
+  test("a telemetry failure never propagates", async () => {
+    // Best-effort by design: losing the row must not change how the record
+    // is handled.
+    const c = capture()
+    await recordIfHeadedForDlq(
+      RECORD({ ApproximateReceiveCount: "3" }),
+      new Error("boom"),
+      c.log,
+      { recordFailure: async () => { throw new Error("pool exhausted") } },
+    )
+    expect(c.errors.length).toBeGreaterThan(0)
   })
 })

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -544,10 +544,18 @@ const CHAT_DELIVERY_RETRY_VISIBILITY_SECONDS = 60;
 const WORKSPACE_DEFER_ATTRIBUTE = 'PsdWorkspaceDeferV1';
 const WORKSPACE_DEFER_MAX_ATTEMPTS = 180;
 const WORKSPACE_DEFER_MAX_AGE_SECONDS = 3 * 60 * 60;
-// Mirrors the CDK redrive policy on the router queue (maxReceiveCount: 3).
-// Used only to decide whether THIS attempt is the one that sends a record to
-// the dead-letter queue.
-const ROUTER_QUEUE_MAX_RECEIVE_COUNT = 3;
+// The queue's own redrive limit, supplied by the stack that sets it. Used to
+// decide whether THIS attempt is the one that dead-letters the record.
+//
+// This was a hardcoded 3 duplicating `maxReceiveCount: 3` in
+// agent-platform-stack.ts with nothing linking them: raising the stack's value
+// would have made the Lambda emit a false "dead-lettered" row on every attempt
+// from the third onward, and lowering it would have stopped the row being
+// written at all. Every other queue setting already arrives by env var.
+const ROUTER_QUEUE_MAX_RECEIVE_COUNT = parseInt(
+  process.env.ROUTER_QUEUE_MAX_RECEIVE_COUNT || '3',
+  10
+);
 const CHAT_DELIVERY_ENVELOPE_KIND = 'agent-chat-delivery-v1';
 const MAX_CHAT_DELIVERY_ENVELOPE_BYTES = 32 * 1024;
 
@@ -4310,12 +4318,11 @@ export async function handler(
         const messageId = event.Records[idx].messageId;
         if (result.reason instanceof ChatDeliveryRetryError) {
           batchItemFailures.push({ itemIdentifier: messageId });
-          await recordIfHeadedForDlq(
-            event.Records[idx],
-            result.reason,
-            log
-          );
           try {
+            // Shorten visibility BEFORE the telemetry write. This branch
+            // exists to retry promptly, and recordFailure touches the
+            // database — putting it first coupled the retry's latency to
+            // pool health, which this codebase already models as exhaustible.
             await deferChatDeliveryRetry(event.Records[idx], log);
           } catch (error) {
             log.error(
@@ -4328,6 +4335,11 @@ export async function handler(
               }
             );
           }
+          await recordIfHeadedForDlq(
+            event.Records[idx],
+            result.reason,
+            log
+          );
           return;
         }
         if (result.reason instanceof WorkspaceTurnDeferredError) {
@@ -4386,37 +4398,77 @@ export async function handler(
  * attempt is identifiable before the redrive happens. Best-effort by design:
  * a failure to write telemetry must never change how the record is handled.
  */
+/**
+ * Who a dead-lettering record belonged to.
+ *
+ * Without this the failure row says a Chat turn died and nothing else, so
+ * answering "who was affected this week?" still means decoding SQS bodies by
+ * hand — the work this telemetry exists to remove.
+ *
+ * Best-effort: a body we cannot parse must still produce a row, because an
+ * unparseable body is itself a reason a record dead-letters and losing the row
+ * would hide it.
+ */
+async function deadLetterIdentity(
+  record: SQSRecord,
+  log: ReturnType<typeof createLogger>
+): Promise<{ userId: string | null; sessionId: string | null }> {
+  try {
+    const chatEvent = await parseChatEventRecord(record, log);
+    return {
+      userId: chatEvent.message?.sender?.email ?? null,
+      sessionId: chatEvent.space?.name ?? null,
+    };
+  } catch {
+    return { userId: null, sessionId: null };
+  }
+}
+
 async function recordIfHeadedForDlq(
   record: SQSRecord,
   reason: unknown,
-  log: ReturnType<typeof createLogger>
+  log: ReturnType<typeof createLogger>,
+  dependencies: { recordFailure: typeof recordFailure } = { recordFailure }
 ): Promise<void> {
-  const receiveCount = parseInt(
-    record.attributes?.ApproximateReceiveCount ?? '1',
-    10
-  );
-  if (!Number.isFinite(receiveCount)) return;
-  if (receiveCount < ROUTER_QUEUE_MAX_RECEIVE_COUNT) return;
+  const raw = record.attributes?.ApproximateReceiveCount;
+  const receiveCount = parseInt(raw ?? '', 10);
+  // A missing or unparseable count used to default to 1, i.e. "not the last
+  // attempt", so a record with no attributes dead-lettered with no row and no
+  // log — failing silent inside the function written to end silent failure.
+  // Unknown now means RECORD: a spare row costs nothing, a missing one is the
+  // bug. Only a count we can read AND that is below the threshold skips.
+  if (Number.isFinite(receiveCount) &&
+      receiveCount < ROUTER_QUEUE_MAX_RECEIVE_COUNT) {
+    return;
+  }
+  const attempts = Number.isFinite(receiveCount) ? receiveCount : null;
   const classified = classifyError(reason);
+
+  const { userId, sessionId } = await deadLetterIdentity(record, log);
+
   log.error('Chat turn exhausted its retries and is being dead-lettered', {
     messageId: record.messageId,
-    receiveCount,
+    receiveCount: attempts,
+    userId: userId ? sanitizeEmailForLog(userId) : null,
+    spaceName: sessionId,
     errorClass: classified.errorClass,
     error: classified.message,
   });
   try {
-    await recordFailure(
+    await dependencies.recordFailure(
       {
         source: 'router',
         severity: 'error',
+        userId,
+        sessionId,
         errorClass: 'ChatTurnDeadLettered',
         errorMessage:
-          `Chat turn dead-lettered after ${receiveCount} attempts: ` +
-          classified.message,
+          `Chat turn dead-lettered after ${attempts ?? 'an unknown number of'} ` +
+          `attempts: ${classified.message}`,
         stackExcerpt: classified.stack,
         context: {
           messageId: record.messageId,
-          receiveCount,
+          receiveCount: attempts,
           underlyingErrorClass: classified.errorClass,
         },
       },
@@ -5705,6 +5757,7 @@ export const agentRouterTestHelpers = {
   cardClickMessageText,
   parseAgentCoreResult,
   alertableAgentTokens,
+  recordIfHeadedForDlq,
   tryAcquireSessionLock,
   invokeWithSessionLockLease,
   jobPromotionIdentity,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -113,6 +113,14 @@ const RETIRED_BUNDLED_SKILL_NAMES = ['psd-classified-evaluation'] as const;
  * - Aurora cluster via imported ARNs
  * - Guardrails via imported ARN
  */
+/**
+ * Router queue redrive limit. Owned here and passed to the Lambda, which uses
+ * it to tell a retry from the final attempt. Two copies of this number meant
+ * changing one silently mis-reported (or stopped reporting) dead-lettered
+ * Chat turns.
+ */
+const ROUTER_QUEUE_MAX_RECEIVE_COUNT = 3;
+
 class AgentPlatformBuildResources {
   ecrRepository!: ecr.Repository;
   workspaceBucket!: s3.Bucket;
@@ -181,11 +189,23 @@ class AgentPlatformBuildResources {
  * a confirmed subscriber. A site that wires only the dedicated topic is a site
  * that can go quiet without anyone noticing.
  */
-function notifyAgentAlarm(
+export function notifyAgentAlarm(
   alarm: cloudwatch.Alarm,
   resources: AgentPlatformBuildResources,
 ): void {
-  for (const topic of resources.agentAlarmTargets ?? []) {
+  // `?? []` here used to make an alarm created before the targets exist
+  // silently receive NO actions: it synthesized, deployed, and notified
+  // nobody — the precise failure this whole area was rewritten to end. The
+  // list always contains the shared monitoring topic, so empty can only mean
+  // "called too early". Fail at synth instead of in production.
+  if (!resources.agentAlarmTargets?.length) {
+    throw new Error(
+      `notifyAgentAlarm called before agentAlarmTargets was populated ` +
+      `(alarm: ${alarm.node.id}). Alarm wiring must run after ` +
+      `createOAuthSecretsAndAlarmInfrastructure.`,
+    );
+  }
+  for (const topic of resources.agentAlarmTargets) {
     alarm.addAlarmAction(new cloudwatchActions.SnsAction(topic));
   }
 }
@@ -1036,6 +1056,39 @@ export class AgentPlatformStack extends cdk.Stack {
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
     notifyAgentAlarm(agentAsyncDlqAlarm, resources);
+
+    // A CloudWatch alarm whose SNS publish fails reports nothing anywhere —
+    // the alarm still shows ALARM, the mail never arrives, and the only trace
+    // is this metric. That is the same undetectable delivery gap that let the
+    // router DLQ alarm go unheard for 36 days, so watch the shared topic for
+    // it. Deliberately on the SHARED topic: it is the one target every agent
+    // alarm now depends on, and it is imported, so nothing else here would
+    // notice it disappearing or being renamed.
+    const alarmDeliveryFailures = new cloudwatch.Alarm(
+      this,
+      'AgentAlarmDeliveryFailures',
+      {
+        alarmName: `psd-agent-alarm-delivery-failures-${environment}`,
+        alarmDescription:
+          'Agent alarm notifications are failing to publish — alarms are ' +
+          'firing but nobody is being told',
+        metric: new cloudwatch.Metric({
+          namespace: 'AWS/SNS',
+          metricName: 'NumberOfNotificationsFailed',
+          dimensionsMap: {
+            TopicName: `aistudio-${environment}-monitoring-alarms`,
+          },
+          period: cdk.Duration.minutes(15),
+          statistic: 'Sum',
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      },
+    );
+    notifyAgentAlarm(alarmDeliveryFailures, resources);
   }
 
   private createBedrockKeyManager(
@@ -3146,7 +3199,7 @@ export class AgentPlatformStack extends cdk.Stack {
         // record by the router. Keep ordinary malformed/permanent failures on
         // the standard three-receive path so they reach the DLQ before the
         // four-day source retention expires.
-        maxReceiveCount: 3,
+        maxReceiveCount: ROUTER_QUEUE_MAX_RECEIVE_COUNT,
       },
     });
     cdk.Tags.of(resources.routerQueue).add('Environment', environment);
@@ -3270,6 +3323,10 @@ export class AgentPlatformStack extends cdk.Stack {
         DATABASE_NAME: props.databaseName || 'aistudio',
         GOOGLE_CREDENTIALS_SECRET_ARN: resources.googleCredentialsSecret.secretArn,
         TOKEN_LIMIT_PER_INTERACTION: '100000',
+        // The Lambda decides whether an attempt is the one that dead-letters a
+        // record; it must read that limit from the queue that enforces it
+        // rather than keep its own copy.
+        ROUTER_QUEUE_MAX_RECEIVE_COUNT: String(ROUTER_QUEUE_MAX_RECEIVE_COUNT),
         // Pass the runtime id directly rather than making every cold start pay
         // an SSM GetParameter. The router's own comment claimed the id "is not
         // known at CDK deploy time", but the SSM parameter a few hundred lines

--- a/infra/test/agent-alarm-delivery.test.ts
+++ b/infra/test/agent-alarm-delivery.test.ts
@@ -25,7 +25,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { AgentPlatformStack } from '../lib/agent-platform-stack';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import { AgentPlatformStack, notifyAgentAlarm } from '../lib/agent-platform-stack';
 import { EnvironmentConfig } from '../lib/constructs';
 
 const TEST_ACCOUNT = '123456789012';
@@ -33,7 +34,23 @@ const REGION = 'us-east-1';
 const REAL_VPC_KEY =
   'vpc-provider:account=390844780692:filter.tag:Name=aistudio-dev-vpc:region=us-east-1:returnAsymmetricSubnets=true';
 
+// Each synth builds the whole AgentPlatformStack (~2s). There are only a few
+// distinct configurations under test but one call per test, so memoise them.
+const TEMPLATE_CACHE = new Map<string, Template>();
+
 function buildTemplate(
+  environment: 'dev' | 'prod',
+  alertEmail?: string
+): Template {
+  const cacheKey = `${environment}:${alertEmail ?? 'none'}`;
+  const cached = TEMPLATE_CACHE.get(cacheKey);
+  if (cached) return cached;
+  const built = synthTemplate(environment, alertEmail);
+  TEMPLATE_CACHE.set(cacheKey, built);
+  return built;
+}
+
+function synthTemplate(
   environment: 'dev' | 'prod',
   alertEmail?: string
 ): Template {
@@ -172,6 +189,42 @@ describe('agent alarm delivery', () => {
     const dlq = routerDlqAlarm('prod');
     expect(dlq).toBeDefined();
     expect(reachesSharedTopic(dlq!, 'prod')).toBe(true);
+  });
+
+  it('watches for its own notification-delivery failures', () => {
+    // A publish that fails leaves the alarm in ALARM and tells nobody; this
+    // metric is the only trace, so it needs an alarm of its own.
+    const template = buildTemplate('prod', 'alerts@psd401.net');
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'psd-agent-alarm-delivery-failures-prod',
+      MetricName: 'NumberOfNotificationsFailed',
+    });
+    const delivery = alarmsWithActions(template).find(
+      alarm => alarm.name === 'psd-agent-alarm-delivery-failures-prod'
+    );
+    expect(delivery).toBeDefined();
+    expect(reachesSharedTopic(delivery!, 'prod')).toBe(true);
+  });
+
+  it('refuses to wire an alarm before the targets exist', () => {
+    // The previous `?? []` made this case a silent no-op: the alarm
+    // synthesized, deployed, and notified nobody. Empty can only mean "called
+    // too early", because the shared topic is always present, so it must fail
+    // at synth rather than in production.
+    const stack = new cdk.Stack(new cdk.App(), 'T', {
+      env: { account: TEST_ACCOUNT, region: REGION },
+    });
+    const alarm = new cloudwatch.Alarm(stack, 'A', {
+      metric: new cloudwatch.Metric({ namespace: 'X', metricName: 'Y' }),
+      threshold: 1,
+      evaluationPeriods: 1,
+    });
+    expect(() =>
+      notifyAgentAlarm(alarm, { agentAlarmTargets: [] } as never)
+    ).toThrow(/before agentAlarmTargets was populated/);
+    expect(() =>
+      notifyAgentAlarm(alarm, {} as never)
+    ).toThrow(/before agentAlarmTargets was populated/);
   });
 
   it('passes the AgentCore runtime id to the router without an SSM lookup', () => {


### PR DESCRIPTION
Eight of the nine findings from the review of #1716.

## The one that mattered

`recordIfHeadedForDlq` wrote a row saying a Chat turn died and nothing about
**whose** — so "who was affected this week?" still meant decoding SQS bodies by
hand, the exact work the telemetry exists to remove. It now records `userId`
and the space, best-effort: an unparseable body still produces a row, because
an unparseable body is itself a reason a record dead-letters.

## The rest

| Finding | Fix |
|---|---|
| Missing receive count defaulted to "not last attempt" | Unknown now means **record**. Only a readable count below the limit skips. |
| `maxReceiveCount` duplicated in Lambda and CDK | Stack owns it, passes `ROUTER_QUEUE_MAX_RECEIVE_COUNT` like every other queue setting |
| `notifyAgentAlarm`'s `?? []` silently no-opped | Throws at synth — empty can only mean "called too early" |
| Nothing watched for publish failures | New alarm on `NumberOfNotificationsFailed` for the shared topic |
| DB write ahead of the retry it delays | `deferChatDeliveryRetry` goes first |
| CDK suite re-synthed per test (~33s) | Memoised by environment + alertEmail |
| No tests for the new function | Six, plus one for the synth guard |

## Tests

`recordIfHeadedForDlq` had none and wasn't exported. Six now: quiet before the
final attempt, records on it, records when the count is missing, names the
user, still records when the body won't parse, never lets a telemetry failure
propagate.

**Mutation-tested** — dropping the userId capture, re-silencing the missing
count, or skipping the write each fail. The synth guard had no test either, so
removing it broke nothing; it has one now, and removing the guard fails it.

## Not done — your call

Finding 6. `AIStudio-{dev,prod}-secrets-alerts`, `aistudio-dev-security-alerts`
and `psd-agent-alarms-dev` all still report `SubscriptionsConfirmed=0` — the
same orphaned-subscription state that left the router DLQ alarm mute for 36
days, and secrets/security alerts are higher-stakes than agent alarms. Fixing
the class rather than this instance means touching `secrets-manager-stack` and
`access-analyzer-stack`, which is a separate change.

## Verification

137 router, 12 CDK, 5,817 root, 865 agent-image tests; lint and typecheck
clean. `cdk synth` passes — 17 alarms, all reaching the shared topic, the
delivery-failure alarm present, and the redrive limit in the router's env.

**No new agent images needed** — this is Lambda and CDK only.
