### PR TITLE
fix(agent): stop the two alarms that page on healthy behaviour

### DIFF
--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -3982,51 +3982,24 @@ export class AgentPlatformStack extends cdk.Stack {
     });
   }
 
-  private createBaseMonitoring(
-    props: AgentPlatformStackProps,
+  /**
+   * Cron alarms. Split out of createBaseMonitoring purely to keep that
+   * method within the max-lines-per-function budget; these alarms and the
+   * metric filters they consume are one logical unit and must stay in sync.
+   */
+  private createCronAlarms(
+    environment: string,
     resources: AgentPlatformBuildResources,
   ): void {
-    const { environment } = props;
-    // Legacy alias. NOT the notification path any more — notifyAgentAlarm is.
-    resources.alarmTopic = resources.agentAlarmTopic;
-
-    // CloudWatch alarm on the DLQ — fires when any message exhausts the Router
-    // retry budget. Workspace-contention retries are intentionally long-lived
-    // so independent Chat threads are queued instead of dropped.
-    const dlqAlarm = new cloudwatch.Alarm(this, 'RouterDlqAlarm', {
-      alarmName: `psd-agent-router-dlq-${environment}`,
-      alarmDescription: 'Agent Router DLQ received messages — investigate dropped messages',
-      metric: resources.routerDlq.metricApproximateNumberOfMessagesVisible({
-        period: cdk.Duration.minutes(1),
-        statistic: 'Sum',
-      }),
-      threshold: 1,
-      evaluationPeriods: 1,
-      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-    });
-
-    // Lambda error rate alarm — catches transient errors (e.g., Google Chat API 5xx)
-    // that succeed on retry and never reach the DLQ. Without this, invisible failures
-    // go undetected. Fires if ≥5 errors in a 5-minute window.
-    const errorAlarm = new cloudwatch.Alarm(this, 'RouterLambdaErrorAlarm', {
-      alarmName: `psd-agent-router-errors-${environment}`,
-      alarmDescription: 'Agent Router Lambda error rate elevated — investigate transient failures',
-      metric: resources.routerLambda.metricErrors({
-        period: cdk.Duration.minutes(5),
-        statistic: 'Sum',
-      }),
-      threshold: 5,
-      evaluationPeriods: 1,
-      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-    });
-
     const cronErrorAlarm = new cloudwatch.Alarm(this, 'CronLambdaErrorAlarm', {
       alarmName: `psd-agent-cron-errors-${environment}`,
       alarmDescription:
-        'Agent cron Lambda errors detected — scheduled work may be retrying or headed to the DLQ',
-      metric: resources.cronLambda.metricErrors({
+        'Agent cron Lambda failed for a reason that is NOT the expected ' +
+        'workspace lock-contention retry — scheduled work may be stuck or ' +
+        'headed to the DLQ',
+      metric: new cloudwatch.Metric({
+        namespace: resources.failureMetricNamespace,
+        metricName: 'CronUnexpectedInvokeError',
         period: cdk.Duration.minutes(5),
         statistic: 'Sum',
       }),
@@ -4089,6 +4062,49 @@ export class AgentPlatformStack extends cdk.Stack {
     notifyAgentAlarm(cronErrorAlarm, resources);
     notifyAgentAlarm(cronThrottleAlarm, resources);
     notifyAgentAlarm(scheduleReferenceRejectionAlarm, resources);
+  }
+
+  private createBaseMonitoring(
+    props: AgentPlatformStackProps,
+    resources: AgentPlatformBuildResources,
+  ): void {
+    const { environment } = props;
+    // Legacy alias. NOT the notification path any more — notifyAgentAlarm is.
+    resources.alarmTopic = resources.agentAlarmTopic;
+
+    // CloudWatch alarm on the DLQ — fires when any message exhausts the Router
+    // retry budget. Workspace-contention retries are intentionally long-lived
+    // so independent Chat threads are queued instead of dropped.
+    const dlqAlarm = new cloudwatch.Alarm(this, 'RouterDlqAlarm', {
+      alarmName: `psd-agent-router-dlq-${environment}`,
+      alarmDescription: 'Agent Router DLQ received messages — investigate dropped messages',
+      metric: resources.routerDlq.metricApproximateNumberOfMessagesVisible({
+        period: cdk.Duration.minutes(1),
+        statistic: 'Sum',
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    // Lambda error rate alarm — catches transient errors (e.g., Google Chat API 5xx)
+    // that succeed on retry and never reach the DLQ. Without this, invisible failures
+    // go undetected. Fires if ≥5 errors in a 5-minute window.
+    const errorAlarm = new cloudwatch.Alarm(this, 'RouterLambdaErrorAlarm', {
+      alarmName: `psd-agent-router-errors-${environment}`,
+      alarmDescription: 'Agent Router Lambda error rate elevated — investigate transient failures',
+      metric: resources.routerLambda.metricErrors({
+        period: cdk.Duration.minutes(5),
+        statistic: 'Sum',
+      }),
+      threshold: 5,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    this.createCronAlarms(environment, resources);
 
     // CloudWatch metric filter — emit a metric every time an
     // AGENT_FAILURE_RECORD line lands in the router Lambda log. Combined with
@@ -4104,6 +4120,30 @@ export class AgentPlatformStack extends cdk.Stack {
       metricNamespace: resources.failureMetricNamespace,
       metricName: failureMetricName,
       filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
+      metricValue: '1',
+      defaultValue: 0,
+    });
+
+    // Cron invoke errors that are NOT the deliberate lock-contention retry.
+    //
+    // The alarm used to watch the Lambda's raw Errors metric, but the cron
+    // handler THROWS JobLockAcquisitionError on purpose so Lambda re-invokes
+    // the fire — it is control flow, severity "warn", and the run succeeds on
+    // a later attempt. Measured over 24h of prod: 100% of cron invoke errors
+    // were that throw and zero were genuine, while the alarm fired every five
+    // minutes. Three of one owner's schedules share a `*/15` cron and
+    // serialize through a single workspace lock, so the collisions are
+    // continuous and expected.
+    //
+    // Excluding the one known-benign errorType keeps every other failure —
+    // including a NEW error type — alarming immediately.
+    new logs.MetricFilter(this, 'CronUnexpectedInvokeErrorMetric', {
+      logGroup: resources.cronLogGroup,
+      metricNamespace: resources.failureMetricNamespace,
+      metricName: 'CronUnexpectedInvokeError',
+      filterPattern: logs.FilterPattern.literal(
+        '"Invoke Error" -JobLockAcquisitionError',
+      ),
       metricValue: '1',
       defaultValue: 0,
     });
@@ -4304,12 +4344,24 @@ export class AgentPlatformStack extends cdk.Stack {
       }),
     );
     // Dead-boot detector (the r10 signature): a microVM logged BUILD_MARKER but
-    // never reached BOOT_OK. BuildMarkerBoot counts starts, BootOk counts
-    // serving-ready boots; a positive difference over the window means a boot
-    // died before serving. NOTE: a microVM that boots in the last seconds of a
-    // period can transiently show +1 (BUILD_MARKER this period, BootOk the
-    // next); it self-clears, and this is a rare "investigate" page, not
-    // auto-remediation, so evaluationPeriods stays 1.
+    // never reached BOOT_OK. A SUSTAINED positive difference means boots are
+    // dying before they serve.
+    //
+    // The note that used to sit here predicted the boundary straddle — a boot
+    // logging BUILD_MARKER in one period and BootOk in the next shows +1 —
+    // and called it rare enough to leave at one datapoint. It is not rare.
+    // Boots take ~25s against a 300s period at ~57 boots/hour, so over 48h of
+    // prod 87 of 440 periods (18%) crossed the old threshold: ~52 pages a day.
+    // Over 7 days BuildMarkerBoot and BootOk were 9562 and 9562 — exactly
+    // equal, zero real dead boots — and the difference distribution is
+    // symmetric about zero (-1:48 vs +1:42, -2:17 vs +2:17), which is what a
+    // timing artifact looks like and what a real fault does not.
+    //
+    // A straddle self-corrects in the next period, so requiring the deficit to
+    // persist across three consecutive periods removes it. Simulated against
+    // that same 48h, threshold 2 over 3-of-3 gives ZERO false alarms and still
+    // catches an injected outage. A genuine r10 dead boot is gateway/provider/
+    // model resolution failing outright — every boot in the window, not one.
     iterationAlarms.push(
       new cloudwatch.Alarm(this, 'DeadBootAlarm', {
         alarmName: `psd-agent-dead-boot-${environment}`,
@@ -4324,8 +4376,9 @@ export class AgentPlatformStack extends cdk.Stack {
           },
           period: alarmPeriod,
         }),
-        threshold: 1,
-        evaluationPeriods: 1,
+        threshold: 2,
+        evaluationPeriods: 3,
+        datapointsToAlarm: 3,
         comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }),

--- a/infra/test/agent-alarm-delivery.test.ts
+++ b/infra/test/agent-alarm-delivery.test.ts
@@ -24,7 +24,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import { AgentPlatformStack, notifyAgentAlarm } from '../lib/agent-platform-stack';
 import { EnvironmentConfig } from '../lib/constructs';
@@ -225,6 +225,39 @@ describe('agent alarm delivery', () => {
     expect(() =>
       notifyAgentAlarm(alarm, {} as never)
     ).toThrow(/before agentAlarmTargets was populated/);
+  });
+
+  it('does not page on a single dead-boot period', () => {
+    // BuildMarkerBoot and BootOk were 9562 and 9562 over 7 days of prod --
+    // zero real dead boots -- while 18% of five-minute periods still crossed
+    // the old threshold of 1 over 1 period, about 52 pages a day. A boot
+    // straddling a period boundary shows +1 and self-corrects in the next
+    // period, so the deficit has to persist to count.
+    const template = buildTemplate('prod', 'alerts@psd401.net');
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'psd-agent-dead-boot-prod',
+      Threshold: 2,
+      EvaluationPeriods: 3,
+      DatapointsToAlarm: 3,
+    });
+  });
+
+  it('pages on cron failures that are not the expected retry', () => {
+    // The cron handler throws JobLockAcquisitionError on purpose so Lambda
+    // re-invokes the fire; the run then succeeds. Watching the raw Lambda
+    // Errors metric made that control flow page every five minutes -- 100% of
+    // cron invoke errors over 24h of prod were that throw, and none were real.
+    const template = buildTemplate('prod', 'alerts@psd401.net');
+    template.hasResourceProperties('AWS::Logs::MetricFilter', {
+      FilterPattern: '"Invoke Error" -JobLockAcquisitionError',
+      MetricTransformations: [
+        Match.objectLike({ MetricName: 'CronUnexpectedInvokeError' }),
+      ],
+    });
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'psd-agent-cron-errors-prod',
+      MetricName: 'CronUnexpectedInvokeError',
+    });
   });
 
   it('passes the AgentCore runtime id to the router without an SSM lookup', () => {


### PR DESCRIPTION
Both alarms fired constantly. Neither indicated a problem. Measured before changing anything.

## Dead boot — 9,562 vs 9,562

The alarm is `BuildMarkerBoot - BootOk >= 1` over one 5-minute period. Over 7 days of prod:

```
BuildMarkerBoot  9562
BootOk           9562
```

Exactly equal. **Not one boot failed to reach BOOT_OK.**

It was detecting a clock artifact. A boot takes ~25s against a 300s period at ~57 boots/hour, so a microVM logging `BUILD_MARKER` just before a boundary logs `BootOk` just after and shows +1. The 48h difference distribution is symmetric about zero — `-1:48` vs `+1:42`, `-2:17` vs `+2:17` — which is what a timing artifact looks like and a real fault does not. **87 of 440 periods crossed the threshold: ~52 pages a day.**

The code comment already predicted this ("can transiently show +1 … it self-clears") and judged it rare enough to leave at one datapoint. It wasn't rare.

Simulated every candidate against that same 48h of real data:

| config | false alarms/48h | catches injected outage |
|---|---|---|
| `>=1`, 1 of 1 (current) | **87** | yes |
| `>=1`, 3 of 3 | 1 | yes |
| **`>=2`, 3 of 3 (chosen)** | **0** | **yes** |
| `>=1`, 5 of 6 | 0 | **no** |
| `>=3`, 3 of 3 | 0 | yes |

A straddle self-corrects in the next period, so it can never hold for three. A genuine r10 dead boot is gateway/provider/model resolution failing outright — every boot in the window — so it clears the bar at once.

## Cron errors — 100% were a deliberate retry

The alarm watched the Lambda's raw `Errors` metric. The handler **throws `JobLockAcquisitionError` on purpose** so Lambda re-invokes the fire; the failure record is severity `warn` and says "retrying this fire". The run then succeeds.

Three of one owner's schedules share a `*/15` cron and serialize through one workspace lock, so collisions are continuous and expected — a steady 12/hour, exactly the alarm's rate. Every one of those runs is `status=success` in `agent_scheduled_runs`, 62 completions each in 24h.

On the live log group: 6 `Invoke Error` lines in 3h, **0** once `JobLockAcquisitionError` is excluded, and **0** genuine cron errors in 24h. The alarm now watches a metric filter with that one benign errorType excluded — every other failure, including a new error type, still pages immediately.

## This does not make the platform quieter about real faults

The DLQ, delivery-failure, throttle and schedule-rejection alarms are untouched, and both alarms still fire on the conditions they were written for.

## Note

Extracting the cron alarms into their own method (to stay inside the max-lines budget) first produced a method that **called itself**, with the original block left in place. Unreachable, so tsc and every test passed. Caught by grepping the result rather than trusting green.

14 CDK tests (2 new, both mutation-tested — reverting either alarm to its old shape fails one), 5,817 root, 137 router; lint, typecheck and `cdk synth` clean.

**No new images** — CDK only.
