### PR TITLE
fix(agent): end the 256 MiB workspace cliff and this week's agent failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,15 @@ jobs:
       working-directory: infra/lambdas/agent-router
       run: bun install --frozen-lockfile
 
+    # agent-cron resolves its AWS SDK deps from its OWN package.json, exactly
+    # like agent-router above, so its tests cannot import index.ts without this.
+    # Keep --frozen-lockfile: no lockfile is committed in either Lambda dir, so
+    # this resolves fresh WITHOUT writing one — a plain install would drop a
+    # local bun.lock that silently pins CI while nothing pins developers.
+    - name: Install agent-cron dependencies
+      working-directory: infra/lambdas/agent-cron
+      run: bun install --frozen-lockfile
+
     - name: Run linter
       run: bun run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,7 @@ jobs:
           infra/agent-image/skills/psd-html-artifact/a11y-audit.test.js
           infra/agent-image/skills/psd-learning-page/run.test.js
           infra/agent-image/skills/psd-plaud/common.test.js
+          infra/agent-image/skills/psd-publish-file/publish.test.js
           infra/agent-image/skills/psd-plaud/run.test.js
           infra/agent-image/skills/psd-skills-meta/authority.test.js
           infra/agent-image/skills/psd-summarize/run.test.js
@@ -305,6 +306,17 @@ jobs:
           bun test "${test_file}"
           echo "::endgroup::"
         done
+      env:
+        CI: true
+
+    # agent-cron (Bun). Root jest ignores all of /infra/ except the triage-poll
+    # boundary tests, so this Lambda's suite had no runner at all — the same
+    # gap the psd-schedules and psd-atrium steps above were added to close.
+    # It covers the scheduled-run telemetry, including the contention-row
+    # settle path and the upsert that must RE-OPEN a settled row when the same
+    # fire_key later fails for real.
+    - name: Run agent-cron Lambda tests (Bun)
+      run: bun run test:lambda:cron
       env:
         CI: true
 

--- a/app/api/agent/schedules/route.ts
+++ b/app/api/agent/schedules/route.ts
@@ -32,6 +32,18 @@ const AUTHORITY_FIELDS = [
   "workspacePrefix",
 ] as const
 
+/**
+ * The only operations a `scheduled`-mode turn may reach.
+ *
+ * An allowlist, not a mutation denylist: a future write operation added to
+ * `executeScheduleOperation` is owner-only by default rather than silently
+ * inheriting scheduled access.
+ */
+const SCHEDULED_READ_OPERATIONS: ReadonlySet<unknown> = new Set([
+  "list",
+  "runs",
+])
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
 }
@@ -134,7 +146,20 @@ function scheduleErrorResponse(error: unknown, requestId: string): NextResponse 
 export async function POST(request: NextRequest) {
   const requestId = generateRequestId()
   const invocation = await verifyAgentInvocationContext(request, {
-    allowedModes: ["owner"],
+    // A scheduled run may AUDIT its owner's schedules but never mutate them.
+    //
+    // Owner-only across the board meant every scheduled job that reviewed its
+    // own cadence got a flat 403: one owner's "Weekly Improvement Review" hit
+    // it every Friday for a month (08-14, 08-21, 08-28, 09-04), another once on
+    // 08-03. Nearly every sibling broker route already accepts both modes.
+    //
+    // The split, not a blanket widen: an autonomous job that can create or
+    // delete schedules is a real privilege escalation, so `create`, `update`
+    // and `delete` stay owner-only and are rejected below, AFTER the same
+    // token, request-proof and nonce verification. `reportModeMismatch: true`
+    // is what makes that ordering safe — it defers the mode decision until
+    // after the cryptographic checks (see invocation-context.ts).
+    allowedModes: ["owner", "scheduled"],
     reportModeMismatch: true,
   })
   if (!invocation) {
@@ -180,6 +205,26 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { error: "Identity and destination fields are not accepted" },
       { status: 400 }
+    )
+  }
+
+  if (
+    invocation.mode !== "owner" &&
+    !SCHEDULED_READ_OPERATIONS.has(rawBody.operation)
+  ) {
+    log.warn("Rejected schedule mutation from a non-owner-mode turn", {
+      requestId,
+      mode: invocation.mode,
+    })
+    return NextResponse.json(
+      {
+        error:
+          "Creating, updating, or deleting a schedule requires a live " +
+          "owner-mode turn. A scheduled run may only list schedules and read " +
+          "their runs.",
+        mode: invocation.mode,
+      },
+      { status: 403 }
     )
   }
 

--- a/app/api/agent/schedules/route.ts
+++ b/app/api/agent/schedules/route.ts
@@ -39,10 +39,24 @@ const AUTHORITY_FIELDS = [
  * `executeScheduleOperation` is owner-only by default rather than silently
  * inheriting scheduled access.
  */
-const SCHEDULED_READ_OPERATIONS: ReadonlySet<unknown> = new Set([
+type ScheduledReadOperation = "list" | "runs"
+
+const SCHEDULED_READ_OPERATIONS = new Set<ScheduledReadOperation>([
   "list",
   "runs",
 ])
+
+/**
+ * Typed so a typo in the set above ("lst", "run") is a compile error rather
+ * than a silently broken allowlist that only shows up as a 403 in production.
+ * The cast is confined to this predicate; `Set.prototype.has` is safe for any
+ * runtime value.
+ */
+function isScheduledReadOperation(
+  operation: unknown
+): operation is ScheduledReadOperation {
+  return SCHEDULED_READ_OPERATIONS.has(operation as ScheduledReadOperation)
+}
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
@@ -210,7 +224,7 @@ export async function POST(request: NextRequest) {
 
   if (
     invocation.mode !== "owner" &&
-    !SCHEDULED_READ_OPERATIONS.has(rawBody.operation)
+    !isScheduledReadOperation(rawBody.operation)
   ) {
     log.warn("Rejected schedule mutation from a non-owner-mode turn", {
       requestId,

--- a/app/api/agent/workspace-storage/route.ts
+++ b/app/api/agent/workspace-storage/route.ts
@@ -12,10 +12,12 @@ import {
   ensureWorkspaceCheckpoint,
   finalizeWorkspaceCheckpoint,
   listWorkspaceObjects,
+  releaseWorkspaceUploads,
   WorkspaceStorageAdmissionError,
   WorkspaceStorageCompletionError,
 } from "@/lib/agent-workspace/storage-broker"
 import { workspaceRelativePathRejectionReason } from "@/lib/agent-workspace/path-policy"
+import { describeQueryErrorCause } from "@/lib/db/query-error"
 import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logger"
 
 const log = createLogger({ module: "agent-workspace-storage" })
@@ -41,11 +43,17 @@ const STORAGE_OPERATIONS = new Set([
   "publish",
   "download-public",
   "complete-upload",
+  "release-upload",
   "ensure-checkpoint",
   "commit-checkpoint",
   "finalize-checkpoint",
   "delete",
 ])
+// An abort carries only the ids it is abandoning. Keeping the field set as
+// tight as finalize-checkpoint's means a release can never smuggle a path, a
+// generation, or a proof past the parser.
+const RELEASE_UPLOAD_FIELDS = new Set(["operation", "reservationIds"])
+const MAX_RELEASE_UPLOAD_ITEMS = 250
 const FINALIZE_CHECKPOINT_FIELDS = new Set([
   "operation",
   "baseWorkspaceGeneration",
@@ -67,6 +75,7 @@ type StorageRequest = {
     | "publish"
     | "download-public"
     | "complete-upload"
+    | "release-upload"
     | "ensure-checkpoint"
     | "commit-checkpoint"
     | "finalize-checkpoint"
@@ -183,6 +192,21 @@ function hasValidFinalizeCheckpointFields(
   )
 }
 
+function hasValidReleaseUploadFields(
+  body: Record<string, unknown>,
+): boolean {
+  return (
+    !Object.keys(body).some((field) => !RELEASE_UPLOAD_FIELDS.has(field)) &&
+    isOrderedUniqueStringArray(
+      body.reservationIds,
+      (item) => UUID_RE.test(item),
+      (item) => item.toLowerCase(),
+    ) &&
+    body.reservationIds.length > 0 &&
+    body.reservationIds.length <= MAX_RELEASE_UPLOAD_ITEMS
+  )
+}
+
 function parseRequest(value: unknown): StorageRequest | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null
   const body = value as Record<string, unknown>
@@ -194,6 +218,8 @@ function parseRequest(value: unknown): StorageRequest | null {
   ) return null
   if (body.operation === "finalize-checkpoint") {
     if (!hasValidFinalizeCheckpointFields(body)) return null
+  } else if (body.operation === "release-upload") {
+    if (!hasValidReleaseUploadFields(body)) return null
   } else if (
     body.reservationIds !== undefined ||
     body.deletedPaths !== undefined ||
@@ -237,6 +263,10 @@ async function executeStorageOperation(
             context.workspacePrefix,
             input.workspaceGeneration,
           )
+        : null
+    case "release-upload":
+      return input.reservationIds
+        ? releaseWorkspaceUploads(context.ownerEmail, input.reservationIds)
         : null
     case "ensure-checkpoint":
       return ensureWorkspaceCheckpoint(context.workspacePrefix, {
@@ -369,7 +399,13 @@ export async function POST(request: NextRequest) {
       sanitizeForLogging({
         requestId,
         ownerEmail: context.ownerEmail,
+        operation: input.operation,
+        path: input.path,
         error: error instanceof Error ? error.message : String(error),
+        // A Drizzle failure's own message is only `Failed query: insert into
+        // "workspace_upload_reservations" …`; the SQLSTATE and the violated
+        // constraint live on `.cause` and were being swallowed here.
+        ...describeQueryErrorCause(error),
       })
     )
     return NextResponse.json(

--- a/app/api/agent/workspace-storage/route.ts
+++ b/app/api/agent/workspace-storage/route.ts
@@ -402,9 +402,7 @@ export async function POST(request: NextRequest) {
         operation: input.operation,
         path: input.path,
         error: error instanceof Error ? error.message : String(error),
-        // A Drizzle failure's own message is only `Failed query: insert into
-        // "workspace_upload_reservations" …`; the SQLSTATE and the violated
-        // constraint live on `.cause` and were being swallowed here.
+        // See lib/db/query-error.ts — Drizzle swallows the driver's real cause.
         ...describeQueryErrorCause(error),
       })
     )

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -388,11 +388,39 @@ def _restart_mantle_proxy() -> None:
     start_mantle_proxy()
 
 
+# Why a module global rather than a richer return type: this function's bool
+# result is patched by five existing wrapper tests, and widening the signature
+# would break every one of them for a diagnostic. A caller that patches the
+# function simply sees no detail and falls back to the generic message.
+#
+# Set to a short, user-safe description of WHY the workspace could not be
+# saved — currently only for WorkspacePushIncomplete, whose message is built
+# from workspace-relative paths and byte counts (no credentials, no model
+# text). Every other failure class keeps the generic wording.
+_last_workspace_finalization_detail: str | None = None
+MAX_WORKSPACE_FINALIZATION_DETAIL_CHARS = 400
+
+
+def _describe_workspace_push_failure(exc: BaseException) -> str | None:
+    """Return user-safe detail for a push failure, or None to stay generic."""
+    # Matched by class NAME, not isinstance: the wrapper's own test suite
+    # replaces the `workspace_sync` module object with a stub, so
+    # `workspace_sync.WorkspacePushIncomplete` is not always a class here.
+    if type(exc).__name__ != "WorkspacePushIncomplete":
+        return None
+    message = str(exc).strip()
+    if not message:
+        return None
+    return message[:MAX_WORKSPACE_FINALIZATION_DETAIL_CHARS]
+
+
 async def _finalize_invocation_authority(
     proxy_drain_seconds: int = INTERACTIVE_PROXY_FINALIZATION_DRAIN_SECONDS,
 ) -> bool:
     """Stop OpenClaw, checkpoint SQLite, flush, then revoke turn authority."""
     global _workspace_local_clean, _workspace_turn_writable
+    global _last_workspace_finalization_detail
+    _last_workspace_finalization_detail = None
     loop = asyncio.get_running_loop()
     proxy_finalizing = False
     proxy_needs_recovery = False
@@ -482,6 +510,9 @@ async def _finalize_invocation_authority(
                 logger.warning("turn-final workspace push exceeded deadline")
             except Exception as exc:  # noqa: BLE001
                 logger.warning("turn-final workspace push failed: %s", exc)
+                _last_workspace_finalization_detail = (
+                    _describe_workspace_push_failure(exc)
+                )
         elif gateway_stopped:
             finalization_confirmed = True
     finally:
@@ -612,13 +643,33 @@ def _serialize_invocations(function):
                             terminal_metadata[
                                 "error_class"
                             ] = "WorkspaceFinalizationFailed"
+                            detail = _last_workspace_finalization_detail
+                            if detail:
+                                terminal_metadata[
+                                    "workspace_finalization_detail"
+                                ] = detail
                             event = {
                                 **event,
+                                # When the cause is a specific file the broker
+                                # will not accept, say so and say how big it is.
+                                # The old text told every such user to "retry
+                                # after the agent service is repaired", which is
+                                # advice that can never work: the file is the
+                                # same size on the next turn, and one owner
+                                # followed it for a day (prod 2026-09-05).
                                 "result": (
                                     "I completed the work but couldn't safely "
                                     "save this agent's workspace. Your prior "
-                                    "history is preserved; please retry after "
-                                    "the agent service is repaired."
+                                    "history is preserved. "
+                                    + (
+                                        f"Cause: {detail} Retrying will not "
+                                        "clear this on its own — the same file "
+                                        "is rebuilt each turn; report it so the "
+                                        "workspace can be trimmed."
+                                        if detail
+                                        else "Please retry after the agent "
+                                        "service is repaired."
+                                    )
                                 ),
                                 "metadata": terminal_metadata,
                             }

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -485,11 +485,16 @@ async def _finalize_invocation_authority(
                 )
                 return False
             try:
+                # One budget spans the snapshot AND the push — see the same
+                # ordering in handle_shutdown. The snapshot can VACUUM a large
+                # SQLite file, which has no inherent time bound, so a deadline
+                # computed after it returns does not actually bound the turn.
+                deadline = time.monotonic() + FINAL_WORKSPACE_FLUSH_SECONDS
                 await loop.run_in_executor(
                     None,
                     workspace_sync.prepare_sqlite_snapshot,
+                    deadline,
                 )
-                deadline = time.monotonic() + FINAL_WORKSPACE_FLUSH_SECONDS
                 push = functools.partial(
                     workspace_sync.push_workspace,
                     _current_workspace_prefix,
@@ -1223,10 +1228,17 @@ def handle_shutdown(signum, frame):
             and _invocation_authority_is_installed()
         ):
             try:
-                workspace_sync.prepare_sqlite_snapshot()
+                # Start the clock BEFORE the snapshot, not after. The snapshot
+                # now prunes and can VACUUM a large SQLite file, and a VACUUM
+                # has no inherent time bound — computing the deadline after it
+                # returns hands the push a full budget on paper while the
+                # host's own SIGTERM grace period has already been spent, so
+                # the turn is SIGKILLed with nothing pushed. One budget covers
+                # both halves.
                 deadline = (
                     time.monotonic() + FINAL_WORKSPACE_FLUSH_SECONDS
                 )
+                workspace_sync.prepare_sqlite_snapshot(deadline)
                 workspace_sync.push_workspace(
                     _current_workspace_prefix,
                     deadline_monotonic=deadline,

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -21,6 +21,7 @@ tasks:
   - ../../skills/psd-failure-report/evals/synthetic-missing-data.yaml
   - ../../skills/psd-freshservice/evals/create-ticket-basic.yaml
   - ../../skills/psd-freshservice/evals/update-ticket-priority.yaml
+  - ../../skills/psd-freshservice/evals/create-catalog-item.yaml
   - ../../skills/psd-github/evals/view-issue-read-only.yaml
   - ../../skills/psd-github/evals/never-merge.yaml
   - ../../skills/psd-html-artifact/evals/audit-minimal-report.yaml

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -30,6 +30,8 @@ tasks:
   - ../../skills/psd-open-adaptive-district/evals/weekly-check-in-fields.yaml
   - ../../skills/psd-pdf-to-markdown/evals/convert-bundled-brand-guide.yaml
   - ../../skills/psd-plaud/evals/list-recordings.yaml
+  - ../../skills/psd-publish-file/evals/publish-generated-csv.yaml
+  - ../../skills/psd-publish-file/evals/html-routes-to-atrium.yaml
   - ../../skills/psd-schedules/evals/list-schedules.yaml
   - ../../skills/psd-schedules/evals/clarify-missing-time.yaml
   - ../../skills/psd-skills-meta/evals/search-summarization.yaml

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -30,6 +30,7 @@ tasks:
   - ../../skills/psd-observances/evals/lookup-american-education-week.yaml
   - ../../skills/psd-open-adaptive-district/evals/weekly-check-in-fields.yaml
   - ../../skills/psd-pdf-to-markdown/evals/convert-bundled-brand-guide.yaml
+  - ../../skills/psd-pdf-to-markdown/evals/scanned-pdf-reads-pages.yaml
   - ../../skills/psd-plaud/evals/list-recordings.yaml
   - ../../skills/psd-publish-file/evals/publish-generated-csv.yaml
   - ../../skills/psd-publish-file/evals/html-routes-to-atrium.yaml

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -22,6 +22,7 @@ tasks:
   - ../../skills/psd-freshservice/evals/create-ticket-basic.yaml
   - ../../skills/psd-freshservice/evals/update-ticket-priority.yaml
   - ../../skills/psd-freshservice/evals/create-catalog-item.yaml
+  - ../../skills/psd-freshservice/evals/catalog-item-forbidden.yaml
   - ../../skills/psd-github/evals/view-issue-read-only.yaml
   - ../../skills/psd-github/evals/never-merge.yaml
   - ../../skills/psd-html-artifact/evals/audit-minimal-report.yaml
@@ -36,6 +37,7 @@ tasks:
   - ../../skills/psd-publish-file/evals/html-routes-to-atrium.yaml
   - ../../skills/psd-schedules/evals/list-schedules.yaml
   - ../../skills/psd-schedules/evals/clarify-missing-time.yaml
+  - ../../skills/psd-schedules/evals/create-dm-digest-no-dm-hunting.yaml
   - ../../skills/psd-skills-meta/evals/search-summarization.yaml
   - ../../skills/psd-sop-creator/evals/required-interview-fields.yaml
   - ../../skills/psd-strategic-plan/evals/goal-one-objectives.yaml

--- a/infra/agent-image/skills/psd-freshservice/SKILL.md
+++ b/infra/agent-image/skills/psd-freshservice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-freshservice
-summary: Manage Freshservice tickets, approvals, and team summaries — uses each caller's own personal API key, stored per-user in Secrets Manager.
-description: Manage PSD Freshservice tickets — list/search/create/update, notes, approvals, and Technology-workspace summaries. Use for helpdesk/IT tickets, approvals, or ticket lookups.
+summary: Manage Freshservice tickets, service catalog items, approvals, and team summaries — uses each caller's own personal API key, stored per-user in Secrets Manager.
+description: Manage PSD Freshservice — list/search/create/update tickets, add notes, read approvals, browse and CREATE Service Catalog items (request forms), and Technology-workspace summaries. Use for helpdesk/IT tickets, approvals, ticket lookups, or adding a new service request form to the catalog.
 allowed-tools: Bash(node:*)
 ---
 
@@ -103,6 +103,50 @@ have. A 403 from them is normal and says nothing about the caller's key — do
 not run them to check whether a key works. There is no endpoint that every
 valid key can reach, so a newly stored key needs no verification step at all:
 run the command the user actually asked for and let it report.
+
+## Service Catalog
+
+A **ticket** is a request. A **catalog item** is the form people fill in to
+make that request. When someone asks you to "add X to the service catalog",
+"create a request form", or "set up a new service request type", they want a
+catalog item — offering a ticket instead does not do it.
+
+```bash
+# Browse categories (a catalog item must belong to one)
+node list_catalog_categories.js --user <email>
+
+# Look before you build: does this item already exist?
+node list_catalog_categories.js --user <email> --search "hotel"
+node list_catalog_categories.js --user <email> --category-id <id>
+
+# Create the item
+node create_catalog_item.js --user <email> \
+  --data '{"name":"Student Travel — Hotel Reservations","category_id":12,"short_description":"Request a hotel booking for approved student travel","description":"<p>Use this form for overnight student travel.</p>","delivery_time":5}'
+```
+
+**Always search first.** Catalog duplicates are worse than missing items:
+people pick the wrong one and requests land in the wrong queue.
+
+**Custom fields.** Most real catalog items exist for their custom required
+fields (trip dates, building, number of rooms, funding code). Pass them as
+`custom_fields`, and confirm the exact field set with the user before creating
+— editing them afterwards is a Freshservice UI job.
+
+**Two things this cannot do**, so say them plainly rather than failing quietly:
+
+- **No icon and no attachments.** Freshservice takes those as multipart upload;
+  the owner-bound broker sends JSON only, deliberately, so no file bytes from
+  the agent runtime are ever signed with someone's credential. Create the
+  fields here, add an icon in the UI.
+- **No editing or deleting.** Only create and read are wired. To change an
+  existing item, hand the user its id and the Freshservice link.
+
+**A 403 here means catalog-admin, not a bad key.** This skill acts as the
+caller, so creating catalog items requires *their* Freshservice role to include
+catalog administration — most agents' does not. The command says so explicitly
+and reports `catalog_admin_required`. Do not tell the user their key is
+invalid, and do not ask them to re-issue it: relay that they need catalog-admin
+granted, or that an admin has to create the item.
 
 ## Approvals
 

--- a/infra/agent-image/skills/psd-freshservice/catalog.test.js
+++ b/infra/agent-image/skills/psd-freshservice/catalog.test.js
@@ -1,0 +1,173 @@
+/**
+ * psd-freshservice Service Catalog command tests.
+ *
+ * Run: bun test catalog.test.js   (from this directory)
+ *
+ * These drive the REAL CLIs as subprocesses with real arguments. The failure
+ * these commands exist to fix — the agent searched the catalog, found nothing,
+ * and offered a plain ticket instead — was a MISSING capability, so the tests
+ * that matter here are about what the commands accept, what they refuse, and
+ * whether their refusals tell the caller what to do next.
+ *
+ * The Freshservice hop itself is not exercised: every command reaches it only
+ * through the owner-bound broker, whose (method, path) allowlist is pinned
+ * separately in tests/unit/lib/agent-credentials/freshservice-broker.test.ts.
+ */
+
+'use strict';
+
+const { test, expect, describe } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const CREATE = path.join(__dirname, 'create_catalog_item.js');
+const LIST = path.join(__dirname, 'list_catalog_categories.js');
+const USER = 'hagelk@psd401.net';
+
+function run(script, args) {
+  const result = spawnSync('node', [script, ...args], { encoding: 'utf8' });
+  let json = null;
+  try {
+    json = JSON.parse(String(result.stdout || '').trim());
+  } catch {
+    /* help output is not JSON */
+  }
+  return { code: result.status, stdout: result.stdout || '', json };
+}
+
+describe('create_catalog_item', () => {
+  test('--help lists every settable field', () => {
+    const result = run(CREATE, ['--help']);
+    expect(result.code).toBe(0);
+    for (const field of ['name', 'category_id', 'custom_fields']) {
+      expect(result.stdout).toContain(field);
+    }
+  });
+
+  test('requires an identity', () => {
+    const result = run(CREATE, ['--data', '{"name":"x","category_id":1}']);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('bad_args');
+  });
+
+  test('requires a name', () => {
+    const result = run(CREATE, ['--user', USER, '--data', '{"category_id":12}']);
+    expect(result.code).toBe(1);
+    expect(result.json.message).toContain('name');
+  });
+
+  test.each([
+    ['{"name":"Hotel"}', 'missing'],
+    ['{"name":"Hotel","category_id":"12"}', 'string'],
+    ['{"name":"Hotel","category_id":0}', 'zero'],
+    ['{"name":"Hotel","category_id":-3}', 'negative'],
+  ])('refuses category_id %s and says where to find one', (data) => {
+    const result = run(CREATE, ['--user', USER, '--data', data]);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('bad_args');
+    // The refusal has to name the command that produces the id, or the caller
+    // is stuck exactly where the original request was.
+    expect(result.json.message).toContain('list_catalog_categories.js');
+  });
+
+  test('names an unsettable field instead of silently dropping it', () => {
+    const result = run(CREATE, [
+      '--user',
+      USER,
+      '--data',
+      '{"name":"Hotel","category_id":12,"workspace_admin":true}',
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.json.message).toContain('workspace_admin');
+  });
+
+  test('rejects custom_fields that is not an object', () => {
+    const result = run(CREATE, [
+      '--user',
+      USER,
+      '--data',
+      '{"name":"Hotel","category_id":12,"custom_fields":["a"]}',
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.json.message).toContain('custom_fields');
+  });
+
+  test('a 403 is reported as a role gap, never as a bad key', () => {
+    // Read the source rather than forcing a live 403: the load-bearing property
+    // is the WORDING. Four callers were sent to re-issue perfectly good keys by
+    // the generic 403 message (2026-08-17), and this endpoint 403s for almost
+    // everyone because catalog admin is rare.
+    // Concatenation is collapsed first so the assertions test the MESSAGE the
+    // caller reads, not the source's line wrapping.
+    const source = fs
+      .readFileSync(CREATE, 'utf8')
+      .replace(/'\s*\+\s*'/g, '');
+    expect(source).toContain('catalog_admin_required');
+    expect(source).toContain('does NOT need to be re-issued');
+    expect(source).toContain('catalog-admin');
+  });
+});
+
+describe('list_catalog_categories', () => {
+  test('--help explains the categories/items split', () => {
+    const result = run(LIST, ['--help']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('CATEGORIES');
+    expect(result.stdout).toContain('ITEMS');
+  });
+
+  test('requires an identity', () => {
+    const result = run(LIST, []);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('bad_args');
+  });
+
+  test.each(['1;DROP', 'abc', '../12', '1 OR 1=1'])(
+    'refuses a non-numeric --category-id %s',
+    (id) => {
+      const result = run(LIST, ['--user', USER, '--category-id', id]);
+      expect(result.code).toBe(1);
+      expect(result.json.message).toContain('numeric');
+    }
+  );
+
+  test.each(['a/b', 'x'.repeat(101), 'drop<table>'])(
+    'refuses a --search value the broker query grammar would reject: %s',
+    (term) => {
+      const result = run(LIST, ['--user', USER, '--search', term]);
+      expect(result.code).toBe(1);
+      expect(result.json.error).toBe('bad_args');
+    }
+  );
+});
+
+describe('SKILL.md documents the capability honestly', () => {
+  const skill = fs.readFileSync(path.join(__dirname, 'SKILL.md'), 'utf8');
+
+  test('distinguishes a catalog item from a ticket', () => {
+    expect(skill).toContain('## Service Catalog');
+    expect(skill).toMatch(/offering a ticket instead does not do it/i);
+  });
+
+  test('states the two real limits rather than letting them surprise', () => {
+    expect(skill).toMatch(/No icon and no attachments/i);
+    expect(skill).toMatch(/No editing or deleting/i);
+  });
+
+  test('states that a 403 means catalog-admin, not a bad key', () => {
+    expect(skill).toMatch(/403 here means catalog-admin, not a bad key/i);
+    expect(skill).toContain('catalog_admin_required');
+  });
+
+  test('is discoverable by the words a caller would use', () => {
+    // skills.search matches NAME and SUMMARY only — never description — so
+    // "catalog" has to be in the summary line or this capability is
+    // unreachable by search, which is how it went unnoticed in the first place.
+    const frontmatter = skill.match(/^---\n([\s\S]*?)\n---/);
+    expect(frontmatter).not.toBeNull();
+    const summary = frontmatter[1].match(/^summary:\s*(.+)$/m);
+    expect(summary).not.toBeNull();
+    expect(summary[1].toLowerCase()).toContain('catalog');
+  });
+});

--- a/infra/agent-image/skills/psd-freshservice/catalog.test.js
+++ b/infra/agent-image/skills/psd-freshservice/catalog.test.js
@@ -1,7 +1,7 @@
 /**
  * psd-freshservice Service Catalog command tests.
  *
- * Run: bun test catalog.test.js   (from this directory)
+ * Run: node --test   (from infra/agent-image/skills/psd-freshservice/)
  *
  * These drive the REAL CLIs as subprocesses with real arguments. The failure
  * these commands exist to fix — the agent searched the catalog, found nothing,
@@ -16,7 +16,8 @@
 
 'use strict';
 
-const { test, expect, describe } = require('bun:test');
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
@@ -36,40 +37,57 @@ function run(script, args) {
   return { code: result.status, stdout: result.stdout || '', json };
 }
 
+// assert.ok alone reports "false == true", which says nothing about which
+// substring was missing from what. Every containment check here is load-bearing
+// wording, so the message has to name both sides.
+function assertContains(haystack, needle, label) {
+  const text = String(haystack);
+  assert.ok(
+    text.includes(needle),
+    `${label} must contain ${JSON.stringify(needle)} — got: ${text}`
+  );
+}
+
 describe('create_catalog_item', () => {
   test('--help lists every settable field', () => {
     const result = run(CREATE, ['--help']);
-    expect(result.code).toBe(0);
+    assert.strictEqual(result.code, 0);
     for (const field of ['name', 'category_id', 'custom_fields']) {
-      expect(result.stdout).toContain(field);
+      assertContains(result.stdout, field, '--help output');
     }
   });
 
   test('requires an identity', () => {
     const result = run(CREATE, ['--data', '{"name":"x","category_id":1}']);
-    expect(result.code).toBe(1);
-    expect(result.json.error).toBe('bad_args');
+    assert.strictEqual(result.code, 1);
+    assert.strictEqual(result.json.error, 'bad_args');
   });
 
   test('requires a name', () => {
     const result = run(CREATE, ['--user', USER, '--data', '{"category_id":12}']);
-    expect(result.code).toBe(1);
-    expect(result.json.message).toContain('name');
+    assert.strictEqual(result.code, 1);
+    assertContains(result.json.message, 'name', 'refusal message');
   });
 
-  test.each([
+  for (const [data, label] of [
     ['{"name":"Hotel"}', 'missing'],
     ['{"name":"Hotel","category_id":"12"}', 'string'],
     ['{"name":"Hotel","category_id":0}', 'zero'],
     ['{"name":"Hotel","category_id":-3}', 'negative'],
-  ])('refuses category_id %s and says where to find one', (data) => {
-    const result = run(CREATE, ['--user', USER, '--data', data]);
-    expect(result.code).toBe(1);
-    expect(result.json.error).toBe('bad_args');
-    // The refusal has to name the command that produces the id, or the caller
-    // is stuck exactly where the original request was.
-    expect(result.json.message).toContain('list_catalog_categories.js');
-  });
+  ]) {
+    test(`refuses a ${label} category_id and says where to find one`, () => {
+      const result = run(CREATE, ['--user', USER, '--data', data]);
+      assert.strictEqual(result.code, 1);
+      assert.strictEqual(result.json.error, 'bad_args');
+      // The refusal has to name the command that produces the id, or the caller
+      // is stuck exactly where the original request was.
+      assertContains(
+        result.json.message,
+        'list_catalog_categories.js',
+        'refusal message'
+      );
+    });
+  }
 
   test('names an unsettable field instead of silently dropping it', () => {
     const result = run(CREATE, [
@@ -78,8 +96,8 @@ describe('create_catalog_item', () => {
       '--data',
       '{"name":"Hotel","category_id":12,"workspace_admin":true}',
     ]);
-    expect(result.code).toBe(1);
-    expect(result.json.message).toContain('workspace_admin');
+    assert.strictEqual(result.code, 1);
+    assertContains(result.json.message, 'workspace_admin', 'refusal message');
   });
 
   test('rejects custom_fields that is not an object', () => {
@@ -89,8 +107,8 @@ describe('create_catalog_item', () => {
       '--data',
       '{"name":"Hotel","category_id":12,"custom_fields":["a"]}',
     ]);
-    expect(result.code).toBe(1);
-    expect(result.json.message).toContain('custom_fields');
+    assert.strictEqual(result.code, 1);
+    assertContains(result.json.message, 'custom_fields', 'refusal message');
   });
 
   test('a 403 is reported as a role gap, never as a bad key', () => {
@@ -100,64 +118,60 @@ describe('create_catalog_item', () => {
     // everyone because catalog admin is rare.
     // Concatenation is collapsed first so the assertions test the MESSAGE the
     // caller reads, not the source's line wrapping.
-    const source = fs
-      .readFileSync(CREATE, 'utf8')
-      .replace(/'\s*\+\s*'/g, '');
-    expect(source).toContain('catalog_admin_required');
-    expect(source).toContain('does NOT need to be re-issued');
-    expect(source).toContain('catalog-admin');
+    const source = fs.readFileSync(CREATE, 'utf8').replace(/'\s*\+\s*'/g, '');
+    assertContains(source, 'catalog_admin_required', 'create_catalog_item.js');
+    assertContains(source, 'does NOT need to be re-issued', 'create_catalog_item.js');
+    assertContains(source, 'catalog-admin', 'create_catalog_item.js');
   });
 });
 
 describe('list_catalog_categories', () => {
   test('--help explains the categories/items split', () => {
     const result = run(LIST, ['--help']);
-    expect(result.code).toBe(0);
-    expect(result.stdout).toContain('CATEGORIES');
-    expect(result.stdout).toContain('ITEMS');
+    assert.strictEqual(result.code, 0);
+    assertContains(result.stdout, 'CATEGORIES', '--help output');
+    assertContains(result.stdout, 'ITEMS', '--help output');
   });
 
   test('requires an identity', () => {
     const result = run(LIST, []);
-    expect(result.code).toBe(1);
-    expect(result.json.error).toBe('bad_args');
+    assert.strictEqual(result.code, 1);
+    assert.strictEqual(result.json.error, 'bad_args');
   });
 
-  test.each(['1;DROP', 'abc', '../12', '1 OR 1=1'])(
-    'refuses a non-numeric --category-id %s',
-    (id) => {
+  for (const id of ['1;DROP', 'abc', '../12', '1 OR 1=1']) {
+    test(`refuses a non-numeric --category-id ${id}`, () => {
       const result = run(LIST, ['--user', USER, '--category-id', id]);
-      expect(result.code).toBe(1);
-      expect(result.json.message).toContain('numeric');
-    }
-  );
+      assert.strictEqual(result.code, 1);
+      assertContains(result.json.message, 'numeric', 'refusal message');
+    });
+  }
 
-  test.each(['a/b', 'x'.repeat(101), 'drop<table>'])(
-    'refuses a --search value the broker query grammar would reject: %s',
-    (term) => {
+  for (const term of ['a/b', 'x'.repeat(101), 'drop<table>']) {
+    test(`refuses a --search value the broker query grammar would reject: ${term}`, () => {
       const result = run(LIST, ['--user', USER, '--search', term]);
-      expect(result.code).toBe(1);
-      expect(result.json.error).toBe('bad_args');
-    }
-  );
+      assert.strictEqual(result.code, 1);
+      assert.strictEqual(result.json.error, 'bad_args');
+    });
+  }
 });
 
 describe('SKILL.md documents the capability honestly', () => {
   const skill = fs.readFileSync(path.join(__dirname, 'SKILL.md'), 'utf8');
 
   test('distinguishes a catalog item from a ticket', () => {
-    expect(skill).toContain('## Service Catalog');
-    expect(skill).toMatch(/offering a ticket instead does not do it/i);
+    assertContains(skill, '## Service Catalog', 'SKILL.md');
+    assert.match(skill, /offering a ticket instead does not do it/i);
   });
 
   test('states the two real limits rather than letting them surprise', () => {
-    expect(skill).toMatch(/No icon and no attachments/i);
-    expect(skill).toMatch(/No editing or deleting/i);
+    assert.match(skill, /No icon and no attachments/i);
+    assert.match(skill, /No editing or deleting/i);
   });
 
   test('states that a 403 means catalog-admin, not a bad key', () => {
-    expect(skill).toMatch(/403 here means catalog-admin, not a bad key/i);
-    expect(skill).toContain('catalog_admin_required');
+    assert.match(skill, /403 here means catalog-admin, not a bad key/i);
+    assertContains(skill, 'catalog_admin_required', 'SKILL.md');
   });
 
   test('is discoverable by the words a caller would use', () => {
@@ -165,9 +179,9 @@ describe('SKILL.md documents the capability honestly', () => {
     // "catalog" has to be in the summary line or this capability is
     // unreachable by search, which is how it went unnoticed in the first place.
     const frontmatter = skill.match(/^---\n([\s\S]*?)\n---/);
-    expect(frontmatter).not.toBeNull();
+    assert.ok(frontmatter, 'SKILL.md must open with a YAML frontmatter block');
     const summary = frontmatter[1].match(/^summary:\s*(.+)$/m);
-    expect(summary).not.toBeNull();
-    expect(summary[1].toLowerCase()).toContain('catalog');
+    assert.ok(summary, 'SKILL.md frontmatter must carry a summary: line');
+    assertContains(summary[1].toLowerCase(), 'catalog', 'SKILL.md summary line');
   });
 });

--- a/infra/agent-image/skills/psd-freshservice/create_catalog_item.js
+++ b/infra/agent-image/skills/psd-freshservice/create_catalog_item.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * create_catalog_item.js — create a Freshservice Service Catalog item.
+ *
+ * Usage:
+ *   node create_catalog_item.js --user <email> --data '<json>'
+ *
+ * Required JSON fields: name, category_id (from list_catalog_categories.js).
+ * Common optional fields: description, short_description, delivery_time,
+ * cost_visibility, visibility, group_visibility, item_type, custom_fields.
+ *
+ * WHY THIS EXISTS. A caller asked the agent to build a "Student Travel — Hotel
+ * Reservations" catalog item with custom required fields on 2026-08-31. The
+ * skill covered tickets, notes and approvals only, so the agent searched the
+ * catalog, found nothing, and offered to open a plain ticket instead — which
+ * was not what was asked for and did not create the thing.
+ *
+ * AUTHORIZATION. This skill uses each caller's OWN Freshservice API key, so
+ * this call runs with that person's Freshservice role. Creating catalog items
+ * is a catalog-admin action; most agents do not have it. A 403 here therefore
+ * means "your Freshservice account lacks catalog-admin", NOT "your key is
+ * bad" — the message below says so explicitly, because telling users to
+ * re-issue a working key is exactly what the generic 403 wording caused before
+ * (four callers, 2026-08-17).
+ *
+ * KNOWN LIMIT. The request is sent as JSON. Freshservice documents this
+ * endpoint as multipart/form-data because it also accepts an icon and file
+ * attachments; those are NOT supported here — the owner-bound broker sends
+ * JSON only, deliberately, so no file bytes from the model runtime are ever
+ * signed with a user's credential. Create the item's fields here and attach an
+ * icon in the Freshservice UI. If the upstream rejects the JSON body, the raw
+ * upstream error is surfaced verbatim rather than reinterpreted.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, parseJsonArg } =
+  require('./lib/api');
+
+// Fields the agent may set. An allowlist for the same reason create_ticket.js
+// has one: Freshservice accepts fields the agent has no business controlling,
+// and a pass-through body would hand the model whatever the API version adds
+// next.
+const ALLOWED_FIELDS = new Set([
+  'name',
+  'category_id',
+  'description',
+  'short_description',
+  'delivery_time',
+  'cost_visibility',
+  'cost',
+  'visibility',
+  'group_visibility',
+  'agent_group_visibility',
+  'item_type',
+  'ci_type_id',
+  'product_id',
+  'quantity',
+  'botified',
+  // The custom required fields a real catalog item is mostly made of. Passed
+  // through as a nested object; Freshservice validates their shape.
+  'custom_fields',
+]);
+
+function validated(data) {
+  if (!data.name || typeof data.name !== 'string') {
+    fail('Required field: name (the catalog item title)', 'bad_args');
+  }
+  if (!Number.isInteger(data.category_id) || data.category_id <= 0) {
+    fail(
+      'Required field: category_id (a positive integer). Run ' +
+        'list_catalog_categories.js --user <email> to find it.',
+      'bad_args'
+    );
+  }
+  if (
+    data.custom_fields !== undefined &&
+    (typeof data.custom_fields !== 'object' ||
+      data.custom_fields === null ||
+      Array.isArray(data.custom_fields))
+  ) {
+    fail('custom_fields must be a JSON object', 'bad_args');
+  }
+  const filtered = Object.create(null);
+  const rejected = [];
+  for (const key of Object.keys(data)) {
+    if (ALLOWED_FIELDS.has(key)) {
+      filtered[key] = data[key];
+    } else {
+      rejected.push(key);
+    }
+  }
+  // Named, not silently dropped: a caller who passed a field that vanished
+  // would otherwise get an item that quietly lacks it.
+  if (rejected.length > 0) {
+    fail(
+      `These fields are not settable from the agent: ${rejected.join(', ')}. ` +
+        `Settable fields are: ${[...ALLOWED_FIELDS].join(', ')}.`,
+      'bad_args'
+    );
+  }
+  return filtered;
+}
+
+// A 403 on this endpoint is a ROLE problem, not a credential problem. Say which.
+function failForbidden(result) {
+  fail(
+    'Freshservice refused this catalog write (403). Creating Service Catalog ' +
+      'items requires catalog-admin rights, and this skill acts as YOU — so ' +
+      'this means your own Freshservice role does not include catalog ' +
+      'administration. Your stored API key is fine and does NOT need to be ' +
+      're-issued. Ask a Freshservice admin to grant catalog-admin, or to ' +
+      `create the item for you. Upstream detail: ${result.error}`,
+    'catalog_admin_required'
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(
+      'Usage: create_catalog_item.js --user <email> --data \'{"name":"...","category_id":N}\'\n' +
+        '\n' +
+        'Find category_id with: list_catalog_categories.js --user <email>\n' +
+        `Settable fields: ${[...ALLOWED_FIELDS].join(', ')}`
+    );
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const data = parseJsonArg(args.data, '--data');
+  const filtered = validated(data);
+
+  const apiKey = getApiKey(userEmail);
+  const result = await fsFetch(apiKey, '/service_catalog_items', {
+    method: 'POST',
+    body: JSON.stringify(filtered),
+  });
+  if (!result.__ok) {
+    if (result.status === 403) failForbidden(result);
+    fail(result.error, result.code || 'upstream_error');
+  }
+  emit(result.data);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/evals/catalog-item-forbidden.yaml
+++ b/infra/agent-image/skills/psd-freshservice/evals/catalog-item-forbidden.yaml
@@ -1,0 +1,25 @@
+id: freshservice-catalog-item-forbidden
+skill: psd-freshservice
+level: L1
+workspace: pure
+suite: regression
+# A 403 on /service_catalog_items means the caller's OWN Freshservice key lacks
+# catalog-admin rights. The key is valid — it just authenticated a user who
+# cannot manage the catalog. Telling that user their key is broken sends them to
+# re-issue a working credential and fixes nothing, which is why SKILL.md says
+# this twice. The happy-path eval cannot catch a regression in that wording;
+# this one can.
+prompt: "Add a new Service Catalog item to Freshservice named exactly \"Student Travel - Hotel Reservations\" under the Student Travel category."
+trials: 3
+fixtures:
+  - fixtures/catalog-item-forbidden.json
+graders:
+  # It must actually attempt the create before reporting the refusal.
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"exact":"/service_catalog_items"},"method":{"exact":"POST"}}}
+  # It must name the real cause: a permissions/role gap in Freshservice.
+  - {"type":"output_match","pattern":"(?i)(permission|not authorized|access denied|catalog.admin|admin rights)"}
+  # And it must NOT send the user off to fix a credential that is working.
+  # Inline (?is) rather than a `flags` field — output_match takes only
+  # {type, pattern, ignore_case} — with the lookahead anchored at \A so a
+  # single search over the whole reply is enough.
+  - {"type":"output_match","pattern":"(?is)\\A(?!.*(?:invalid key|invalid api key|expired key|re-?issue|regenerate your key|bad credential))"}

--- a/infra/agent-image/skills/psd-freshservice/evals/create-catalog-item.yaml
+++ b/infra/agent-image/skills/psd-freshservice/evals/create-catalog-item.yaml
@@ -1,0 +1,15 @@
+id: freshservice-create-catalog-item
+skill: psd-freshservice
+level: L1
+workspace: pure
+suite: regression
+prompt: "Add a new Service Catalog item to Freshservice named exactly \"Student Travel - Hotel Reservations\" under the Student Travel category. Create it — do not open a ticket instead."
+trials: 3
+fixtures:
+  - fixtures/create-catalog-item.json
+graders:
+  # It must look up the category id rather than inventing one.
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"exact":"/service_catalog/categories"},"method":{"exact":"GET"}}}
+  # And then actually create the item, at the create-verb path.
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"exact":"/service_catalog_items"},"method":{"exact":"POST"},"body.name":{"exact":"Student Travel - Hotel Reservations"},"body.category_id":{"numeric_equals":12}}}
+  - {"type":"output_match","pattern":"90210|77"}

--- a/infra/agent-image/skills/psd-freshservice/evals/fixtures/catalog-item-forbidden.json
+++ b/infra/agent-image/skills/psd-freshservice/evals/fixtures/catalog-item-forbidden.json
@@ -1,0 +1,53 @@
+[
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "freshservice",
+      "path": "/service_catalog/categories",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "ok": true,
+        "status": 200,
+        "data": {
+          "service_categories": [
+            { "id": 12, "name": "Student Travel", "description": "Trips and transportation" }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "freshservice",
+      "path": "/service_catalog_items",
+      "method": "POST",
+      "body": {
+        "name": "Student Travel - Hotel Reservations",
+        "category_id": 12
+      }
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "ok": false,
+        "status": 403,
+        "data": {
+          "description": "Access denied. You are not authorized to perform this action.",
+          "errors": [
+            {
+              "field": "requester",
+              "message": "Requester does not have permission to manage service catalog items",
+              "code": "access_denied"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-freshservice/evals/fixtures/create-catalog-item.json
+++ b/infra/agent-image/skills/psd-freshservice/evals/fixtures/create-catalog-item.json
@@ -1,0 +1,52 @@
+[
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "freshservice",
+      "path": "/service_catalog/categories",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "ok": true,
+        "status": 200,
+        "data": {
+          "service_categories": [
+            { "id": 12, "name": "Student Travel", "description": "Trips and transportation" },
+            { "id": 13, "name": "Facilities", "description": "Buildings and grounds" }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "freshservice",
+      "path": "/service_catalog_items",
+      "method": "POST",
+      "body": {
+        "name": "Student Travel - Hotel Reservations",
+        "category_id": 12
+      }
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "ok": true,
+        "status": 201,
+        "data": {
+          "service_item": {
+            "id": 90210,
+            "display_id": 77,
+            "name": "Student Travel - Hotel Reservations",
+            "category_id": 12
+          }
+        }
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-freshservice/list_catalog_categories.js
+++ b/infra/agent-image/skills/psd-freshservice/list_catalog_categories.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * list_catalog_categories.js — list Freshservice Service Catalog categories,
+ * and optionally the items inside one.
+ *
+ * Usage:
+ *   node list_catalog_categories.js --user <email>
+ *   node list_catalog_categories.js --user <email> --category-id <id>
+ *   node list_catalog_categories.js --user <email> --search "hotel"
+ *
+ * Every catalog item belongs to a category, and `create_catalog_item.js`
+ * requires that category's numeric id. This is how you find it — and how you
+ * check whether the item already exists before creating a duplicate.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } =
+  require('./lib/api');
+
+function requireNumericId(value, flag) {
+  if (!/^\d+$/.test(String(value))) {
+    fail(`${flag} must be a numeric id`, 'bad_args');
+  }
+  return String(value);
+}
+
+// The broker's query grammar excludes "/" so a value cannot smuggle a path
+// segment, and rejects anything outside a conservative charset. Fail here with
+// a readable message rather than letting the broker return a bare rejection.
+const SEARCH_TERM_RE = /^[A-Za-z0-9_.,:+@ -]{1,100}$/;
+
+async function listItems(apiKey, args) {
+  const query = new URLSearchParams();
+  if (args.category_id && args.category_id !== true) {
+    query.set('category_id', requireNumericId(args.category_id, '--category-id'));
+  }
+  if (args.search && args.search !== true) {
+    const term = String(args.search);
+    if (!SEARCH_TERM_RE.test(term)) {
+      fail(
+        '--search may contain only letters, digits, spaces and . , : + @ _ - ' +
+          '(100 characters max)',
+        'bad_args'
+      );
+    }
+    query.set('search_term', term);
+  }
+  const suffix = query.toString();
+  const result = await fsFetch(
+    apiKey,
+    `/service_catalog/items${suffix ? `?${suffix}` : ''}`
+  );
+  if (!result.__ok) fail(result.error, result.code || 'upstream_error');
+  return result.data;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(
+      'Usage: list_catalog_categories.js --user <email>\n' +
+        '       list_catalog_categories.js --user <email> --category-id <id>\n' +
+        '       list_catalog_categories.js --user <email> --search "hotel"\n' +
+        '\n' +
+        'With no filter, lists the catalog CATEGORIES. With --category-id or\n' +
+        '--search, lists the ITEMS matching that filter.'
+    );
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const apiKey = getApiKey(userEmail);
+
+  const filtering =
+    (args.category_id && args.category_id !== true) ||
+    (args.search && args.search !== true);
+  if (filtering) {
+    emit(await listItems(apiKey, args));
+    return;
+  }
+
+  const result = await fsFetch(apiKey, '/service_catalog/categories');
+  if (!result.__ok) fail(result.error, result.code || 'upstream_error');
+  emit(result.data);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-html-artifact/SKILL.md
+++ b/infra/agent-image/skills/psd-html-artifact/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: psd-html-artifact
-summary: Beautiful, anti-slop single-page HTML artifacts uploaded to S3 as a shareable link — specs, reports, dashboards, interactive editors, design explorations; optional PSD branding.
-description: Generate a beautiful, self-contained single-page HTML artifact (spec, report, code-review explainer, dashboard, interactive editor, or design exploration) and return a shareable HTTPS URL. Use when asked to make an HTML page/artifact/report, turn a spec or plan into readable HTML, or build an interactive HTML editor.
+summary: Beautiful, anti-slop single-page HTML artifacts published to Atrium as a shareable PSD intranet page — specs, reports, dashboards, interactive editors, design explorations; optional PSD branding.
+description: Generate a beautiful, self-contained single-page HTML artifact (spec, report, code-review explainer, dashboard, interactive editor, or design exploration), publish it into Atrium, and return the intranet reader URL. Use when asked to make an HTML page/artifact/report, turn a spec or plan into readable HTML, or build an interactive HTML editor.
 allowed-tools: Bash(node:*)
 ---
 
 # psd-html-artifact
 
 Produce a single, self-contained HTML file with impeccable taste, then deliver it as a
-shareable link. HTML beats Markdown for specs, reports, reviews, and explorations: it is
-denser, more readable, more shareable, and people actually read it. This skill makes HTML
-that does not look like a machine made it — and hands the user a URL they can open in any
-browser (Google Chat renders it as a link).
+published Atrium page. HTML beats Markdown for specs, reports, reviews, and
+explorations: it is denser, more readable, more shareable, and people actually read it.
+This skill makes HTML that does not look like a machine made it — and hands the user an
+intranet URL they can open in any browser (Google Chat renders it as a link).
 
 This is PSD's standard artifact format: when the user asks for a spec, plan, report,
 mockup, dashboard, or review writeup, default to an HTML artifact delivered by this skill
@@ -122,7 +122,7 @@ from the scaffold. Report a one-line pass summary, e.g.:
 **Accessibility is enforced, not advisory.** These pages are district web content, so
 they must meet **WCAG 2.2 Level AA** (the DOJ ADA Title II legal floor is 2.1 AA; 2.2 AA
 is a backward-compatible superset). `deliver.js` runs the shared **axe-core** gate
-automatically and **refuses to upload** any artifact with critical/serious violations.
+automatically and **refuses to publish** any artifact with critical/serious violations.
 Run it yourself before delivering and fix anything it flags:
 
 ```bash
@@ -136,17 +136,30 @@ is a property of this shared generator that every artifact-producing skill inher
 
 ### 8. Deliver and hand off
 
-Upload the finished file and get a shareable URL:
+Publish the finished file into Atrium and get its intranet reader URL:
 
 ```bash
-node /opt/psd-skills/psd-html-artifact/deliver.js --user <email> --file /tmp/<name>.html
+node /opt/psd-skills/psd-html-artifact/deliver.js --user <email> --file /tmp/<name>.html [--title "<title>"]
 ```
 
-Returns JSON: `{ "url": "...", "s3Key": "public-images/.../<uuid>.html", "bytes": N, "contentType": "text/html; charset=utf-8", "sharing": "public-by-link" }`.
+Returns JSON: `{ "url": "https://psd401.ai/c/<slug>", "artifactId": N, "slug": "...",
+"title": "...", "bytes": N, "destination": "atrium-intranet", "visibility": "internal",
+"sharing": "psd-internal" }`.
 
-The URL is uploaded to the workspace S3 bucket under the public `public-images/` prefix
-(same bucket policy and unguessable-UUID model as `psd-image-gen`) and is an unsigned,
-public-by-link HTTPS URL that does not expire — anyone who receives it can open the page.
+`--title` is optional — it defaults to the page's `<title>`.
+
+**HTML artifacts go to Atrium, never S3.** Atrium gives the page an owner, a visibility
+level, a publication record and an audit trail; the old S3 path gave it an unsigned URL
+that was public to anyone who ever received it. `.html` is no longer an accepted public
+artifact extension in the broker, so this is enforced, not just documented. Every other
+file type (`.png`, `.pdf`, `.csv`, …) still goes to S3 — see `psd-publish-file`.
+
+The command does both Atrium steps for you: `create-artifact --body-format html
+--visibility internal`, then `publish --destination intranet`. It never reports a URL for
+a draft that failed to publish, and it refuses outright if the widen to `internal` is
+pending admin approval (the page would be invisible to its audience). Both failures print
+the artifact id and the exact retry command — retry the publish step, do not re-run the
+whole skill, or you leave duplicate drafts behind.
 
 ## Required Reply Format
 
@@ -156,14 +169,15 @@ value on a line by itself**.
 - ✅ Correct:
   ```
   Here's the spec as a page:
-  https://psd-agents-dev-390844780692.s3.us-east-1.amazonaws.com/public-images/<email>/<uuid>.html
+  https://psd401.ai/c/quarterly-enrollment-review
   ```
 - ❌ Wrong: describing the artifact in prose without pasting the URL. The user cannot see
   the tool result — if the URL is not in your chat reply, the user got nothing.
-- ❌ Wrong: wrapping the URL in `[label](url)` or `**bold**` — Google Chat's renderer
-  corrupts these for long S3 URLs. Bare URL only.
-- ❌ Wrong: re-uploading or presigning the returned URL. It is already public-by-link with
-  HTTP 200; do not touch it.
+- ❌ Wrong: wrapping the URL in `[label](url)`, `**bold**`, or backticks. A trailing
+  backtick percent-encodes to `%60` and the page 404s — that has happened in production
+  twice. Bare URL on its own line, nothing around it.
+- ❌ Wrong: re-publishing the returned URL, or handing back the `/atrium/{id}/view` editor
+  link instead. `url` is the reader link; use it as-is.
 
 You may add one short sentence of context above the URL line, plus the one-line audit
 summary from step 7. The one real tradeoff worth noting once: HTML diffs are noisier than

--- a/infra/agent-image/skills/psd-html-artifact/deliver.js
+++ b/infra/agent-image/skills/psd-html-artifact/deliver.js
@@ -3,26 +3,43 @@
 /**
  * deliver.js — psd-html-artifact.deliver
  * Usage:
- *   node deliver.js --user <email> --file <path-to-.html>
- *   node deliver.js --audit-only --file <path-to-.html>   # a11y gate, no upload
+ *   node deliver.js --user <email> --file <path-to-.html> [--title <t>]
+ *   node deliver.js --audit-only --file <path-to-.html>   # a11y gate, no publish
  *
- * Uploads a finished, self-contained HTML artifact to the agent workspace S3
- * bucket under the public `public-images/` prefix and returns an unsigned
- * HTTPS URL — anyone who receives the link can open the page in a browser.
+ * Publishes a finished, self-contained HTML artifact into ATRIUM and returns
+ * the intranet reader URL.
  *
- * Delivery mirrors psd-image-gen/generate.js exactly: same bucket, same
- * `public-images/` prefix (granted public `s3:GetObject` by the bucket policy
- * in agent-platform-stack.ts), same unguessable-UUID key, same unsigned
- * path-style URL. No OpenAI/credentials/capability machinery — this skill only
- * moves bytes the agent already produced, so it spends no external quota.
+ * WHY NOT S3 ANY MORE. This was the last HTML -> S3 path in the platform:
+ * chat-chart and psd-image-gen publish .png, psd-learning-page already went to
+ * Atrium, and only this skill still dropped a `text/html` object into the
+ * unsigned, public-by-link `public-images/` prefix. HTML pages are documents,
+ * and PSD documents belong in Atrium, where they carry an owner, a visibility
+ * level, a publication record and an audit trail rather than an unguessable
+ * URL that is public to anyone who ever receives it. `.html` has now been
+ * removed from PUBLIC_EXTENSIONS/PUBLIC_CONTENT_TYPES in
+ * lib/agent-workspace/storage-broker.ts, so the rule is enforced by the broker
+ * rather than merely documented here. Every OTHER file type still goes to S3.
+ *
+ * Delivery mirrors psd-learning-page/run.js: `create-artifact --code-file
+ * <path> --body-format html --visibility internal`, then `publish --id <id>
+ * --destination intranet`, returning the completed publication's reader URL.
+ *
+ * Three Atrium behaviours are load-bearing here:
+ *   - create starts PRIVATE + DRAFT, so a /c/{slug} link 404s until publish
+ *     succeeds. This never reports a URL from a create that was not published.
+ *   - the body goes through --code-file, never argv: a 128 KiB MAX_ARG_STRLEN
+ *     makes an inline page E2BIG, and pages routinely exceed it.
+ *   - the returned URL must be pasted BARE on its own line. A trailing backtick
+ *     percent-encodes to %60 and 404s (agent_failures 7167, 7299), so the JSON
+ *     result carries an explicit instruction saying so.
  *
  * Accessibility gate (Issue #1245): EVERY delivery runs the shared WCAG 2.2 AA
- * axe-core audit (a11y-audit.js) FIRST and REFUSES to upload any artifact with
+ * axe-core audit (a11y-audit.js) FIRST and REFUSES to publish any artifact with
  * critical/serious violations (exit 3, error `a11y_violations`). This is the
- * same gate psd-learning-page runs before publishing to Atrium, so "all HTML
- * artifacts are accessible" is enforced centrally rather than per-skill.
- * `--audit-only` runs just that check (no S3, no `--user` needed) so any caller
- * can pre-validate a file with the identical gate.
+ * same gate psd-learning-page runs, so "all HTML artifacts are accessible" is
+ * enforced centrally rather than per-skill. `--audit-only` runs just that check
+ * (no publish, no `--user` needed) so any caller can pre-validate a file with
+ * the identical gate.
  */
 
 'use strict';
@@ -30,21 +47,28 @@ const { validatedFs } = require("../../../validated-fs.cjs");
 
 
 
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
-
-const { publishArtifact } = require('../_shared/artifact-publisher');
+const { spawnSync } = require('node:child_process');
 
 // Shared WCAG 2.2 AA gate — the single audit both this skill and
 // psd-learning-page run (Issue #1245).
 const { auditHtml } = require('./a11y-audit');
 
-// Keep this prefix in sync with the bucket policy (see psd-image-gen/generate.js
-// and agent-platform-stack.ts:PublicReadOnPublicImagesPrefix). The UUID in the
-// key makes the path unguessable — same security model as Google Drive
-// "anyone with the link" sharing.
+// Container layout (overridable so the unit tests can point at fakes).
+const SKILLS_DIR = process.env.PSD_SKILLS_DIR || '/opt/psd-skills';
+const APP_BASE_URL = process.env.APP_BASE_URL || '';
+
 // HTML artifacts are text; even data-URI-heavy pages rarely exceed a few MB.
 // Cap at 25 MB so a runaway file fails fast instead of pushing a huge object.
 const MAX_HTML_BYTES = 25 * 1024 * 1024;
+
+// Pasted verbatim into the result so the model does not wrap the link. A
+// trailing backtick percent-encodes to %60 and the reader 404s.
+const BARE_URL_INSTRUCTION =
+  'Paste this URL BARE on its own line — no backticks, no markdown link, ' +
+  'no trailing punctuation. A trailing backtick becomes %60 and 404s.';
 
 function fail(message, code = 'error') {
   process.stderr.write(`Error: ${message}\n`);
@@ -95,9 +119,162 @@ function validateEmail(email) {
   return domain.includes('.');
 }
 
-async function uploadAndShare(bytes, userEmail) {
-  void userEmail;
-  return publishArtifact(bytes, '.html', 'text/html; charset=utf-8');
+// ── Atrium publication ────────────────────────────────────────────────────────
+
+// The JSON object a composed skill printed on stdout, or null when stdout is
+// not JSON. psd-atrium emits single-line JSON as the only thing on stdout, so
+// the whole-string parse is the normal path; the suffix scan tolerates a log
+// line printed before the JSON block.
+function lastJson(stdout) {
+  const text = String(stdout || '').trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    /* fall through to suffix scan */
+  }
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const candidate = lines.slice(i).join('\n').trim();
+    if (!candidate || (candidate[0] !== '{' && candidate[0] !== '[')) continue;
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      /* keep scanning down */
+    }
+  }
+  return null;
+}
+
+function runAtrium(args) {
+  const res = spawnSync(
+    'node',
+    [path.join(SKILLS_DIR, 'psd-atrium', 'run.js'), ...args],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  );
+  if (res.error) return { code: 1, stdout: '', stderr: res.error.message };
+  return {
+    code: res.status == null ? 1 : res.status,
+    stdout: res.stdout || '',
+    stderr: res.stderr || '',
+  };
+}
+
+// The shareable intranet reader URL. Prefer the absolute deep link the API
+// returns, then build /c/{slug} from APP_BASE_URL, then fall back to whatever
+// url the API gave. NOT /atrium/{id}/view — that is the author's draft editor.
+function buildReaderUrl(created) {
+  if (typeof created.url === 'string' && /^https?:\/\//i.test(created.url)) {
+    return created.url;
+  }
+  if (APP_BASE_URL && created.slug) {
+    return `${APP_BASE_URL.replace(/\/$/, '')}/c/${created.slug}`;
+  }
+  if (typeof created.url === 'string' && created.url) return created.url;
+  return null;
+}
+
+// A title Atrium can show. Derived from <title> when the page has one, so the
+// caller does not have to pass --title for the common case.
+function deriveTitle(html, file, explicit) {
+  if (typeof explicit === 'string' && explicit.trim()) return explicit.trim();
+  const match = /<title[^>]*>([\s\S]{1,300}?)<\/title>/i.exec(html);
+  const fromDocument = match && match[1].replace(/\s+/g, ' ').trim();
+  if (fromDocument) return fromDocument;
+  return path.basename(file, path.extname(file)) || 'HTML artifact';
+}
+
+function createAtriumArtifact(buffer, title, run) {
+  const codeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'html-artifact-'));
+  const codePath = path.join(codeDir, 'artifact.html');
+  let createRes;
+  try {
+    // --code-file, never argv: MAX_ARG_STRLEN is 128 KiB and an inline page
+    // that exceeds it fails with E2BIG rather than a readable error.
+    validatedFs.writeFileSync(codePath, buffer);
+    createRes = run([
+      'create-artifact',
+      '--title',
+      title,
+      '--code-file',
+      codePath,
+      '--body-format',
+      'html',
+      // Without this the artifact stays PRIVATE even after publish, so the page
+      // would be invisible to exactly the audience it was made for.
+      '--visibility',
+      'internal',
+    ]);
+  } catch (err) {
+    fail(`could not stage the artifact for publish: ${err.message}`, 'publish_failed');
+  } finally {
+    try {
+      fs.rmSync(codeDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+  const created = lastJson(createRes.stdout);
+  if (createRes.code !== 0 || !created || !created.id) {
+    fail(
+      `Atrium create-artifact failed: ${
+        (created && created.message) || createRes.stderr || 'unknown error'
+      }`,
+      'publish_failed'
+    );
+  }
+  return created;
+}
+
+// A widen-to-internal that needs admin approval leaves the page invisible. Say
+// so instead of handing back a link the intended audience cannot open.
+function requireAtriumVisibility(created) {
+  if (created.approvalRequired) {
+    fail(
+      `Atrium created artifact ${created.id}${
+        created.slug ? ` (slug ${created.slug})` : ''
+      } as "${created.visibilityLevel}" instead of the requested "internal" — ${
+        created.visibilityNote ||
+        'a visibility widen-to-internal request is pending admin approval'
+      }. The page is NOT visible to its intended audience yet; do not report it ` +
+        `as published. Retry after the widen is approved: psd-atrium publish ` +
+        `--id ${created.id} --destination intranet.`,
+      'visibility_denied'
+    );
+  }
+}
+
+function publishAtriumArtifact(created, run) {
+  const pubRes = run([
+    'publish',
+    '--id',
+    String(created.id),
+    '--destination',
+    'intranet',
+  ]);
+  const published = lastJson(pubRes.stdout);
+  if (pubRes.code !== 0) {
+    // The draft already exists; surface its id/slug so the caller retries the
+    // publish step rather than re-running and creating a duplicate draft.
+    fail(
+      `Atrium publish failed for draft artifact ${created.id}${
+        created.slug ? ` (slug ${created.slug})` : ''
+      } — the draft was created but not published. Retry with: psd-atrium ` +
+        `publish --id ${created.id} --destination intranet. Cause: ${
+          (published && published.message) || pubRes.stderr || 'unknown error'
+        }`,
+      'publish_failed'
+    );
+  }
+  return published;
+}
+
+function publishToAtrium(buffer, title, deps = {}) {
+  const run = deps.runAtrium || runAtrium;
+  const created = createAtriumArtifact(buffer, title, run);
+  requireAtriumVisibility(created);
+  const published = publishAtriumArtifact(created, run);
+  return { artifact: created, publish: published, readerUrl: buildReaderUrl(created) };
 }
 
 // Refuse an inaccessible artifact. Exit 3 (distinct from bad_args=1) so callers
@@ -160,8 +337,11 @@ async function main() {
   const args = parseArgs(process.argv);
   if (args.help) {
     console.log(
-      'Usage: deliver.js --user <email> --file <path-to-.html>\n' +
-        '       deliver.js --audit-only --file <path-to-.html>'
+      'Usage: deliver.js --user <email> --file <path-to-.html> [--title <t>]\n' +
+        '       deliver.js --audit-only --file <path-to-.html>\n' +
+        '\n' +
+        'Publishes the page into Atrium (internal visibility) and prints the\n' +
+        'intranet reader URL. --title defaults to the page <title>.'
     );
     process.exit(0);
   }
@@ -179,22 +359,28 @@ async function main() {
   if (!validateEmail(args.user)) {
     fail('--user is required and must be a valid email', 'bad_args');
   }
-  const { size, buffer } = readHtmlFile(args);
-  // HARD GATE: never upload an artifact that fails the accessibility floor.
-  const report = await auditHtml(buffer.toString('utf8'));
+  const { file, size, buffer } = readHtmlFile(args);
+  // HARD GATE: never publish an artifact that fails the accessibility floor.
+  const html = buffer.toString('utf8');
+  const report = await auditHtml(html);
   if (!report.pass) failA11y(report);
 
-  // Upload the exact original bytes (not a utf8 round-trip).
-  const { url, key } = await uploadAndShare(buffer, args.user);
+  const title = deriveTitle(html, file, args.title);
+  // Publish the exact original bytes (not a utf8 round-trip).
+  const { artifact, readerUrl } = publishToAtrium(buffer, title);
 
   emit({
-    url,
-    s3Key: key,
+    url: readerUrl,
+    artifactId: artifact.id,
+    slug: artifact.slug ?? null,
+    title,
     bytes: size,
-    contentType: 'text/html; charset=utf-8',
-    // Unsigned and non-expiring — anyone with the link can fetch until the
-    // object is deleted (manual lifecycle policy may be added later).
-    sharing: 'public-by-link',
+    destination: 'atrium-intranet',
+    visibility: artifact.visibilityLevel ?? 'internal',
+    // Authenticated PSD readers only — this is the whole reason HTML no longer
+    // goes to the unsigned public S3 prefix.
+    sharing: 'psd-internal',
+    instruction: BARE_URL_INSTRUCTION,
     a11y: { pass: true, standard: report.standard, counts: report.counts },
   });
 }

--- a/infra/agent-image/skills/psd-html-artifact/deliver.js
+++ b/infra/agent-image/skills/psd-html-artifact/deliver.js
@@ -188,6 +188,7 @@ function createAtriumArtifact(buffer, title, run) {
   const codeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'html-artifact-'));
   const codePath = path.join(codeDir, 'artifact.html');
   let createRes;
+  let stagingError;
   try {
     // --code-file, never argv: MAX_ARG_STRLEN is 128 KiB and an inline page
     // that exceeds it fails with E2BIG rather than a readable error.
@@ -206,13 +207,23 @@ function createAtriumArtifact(buffer, title, run) {
       'internal',
     ]);
   } catch (err) {
-    fail(`could not stage the artifact for publish: ${err.message}`, 'publish_failed');
+    // Capture, do NOT fail() here. fail() ends in process.exit(), which in Node
+    // terminates immediately WITHOUT unwinding pending finally blocks — so
+    // calling it from this catch would skip the cleanup below and leave the
+    // model-authored page sitting in /tmp. Fail after the finally has run.
+    stagingError = err;
   } finally {
     try {
       fs.rmSync(codeDir, { recursive: true, force: true });
     } catch {
       /* best-effort cleanup */
     }
+  }
+  if (stagingError) {
+    fail(
+      `could not stage the artifact for publish: ${stagingError.message}`,
+      'publish_failed'
+    );
   }
   const created = lastJson(createRes.stdout);
   if (createRes.code !== 0 || !created || !created.id) {

--- a/infra/agent-image/skills/psd-pdf-to-markdown/SKILL.md
+++ b/infra/agent-image/skills/psd-pdf-to-markdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-pdf-to-markdown
-summary: Convert a PDF (from a URL, workspace S3 key, or container path) into clean Markdown with tables preserved — text-only by default, or with the embedded images extracted to disk on request. No model download.
-description: Convert a PDF to clean Markdown with tables preserved. Images are dropped by default; pass --extract-images DIR to write them out as PNGs and keep their references, which is what you want when the images must survive into whatever you build next. Use when the user wants to turn a PDF into Markdown or extract a PDF's text/tables/figures for further processing. Input is a public URL, a workspace S3 key, or a container file path.
+summary: Convert a PDF (from a URL, workspace S3 key, or container path) into clean Markdown with tables preserved — text-only by default, embedded images extracted on request, and scanned/image-only PDFs rendered to page images you can read. No model download.
+description: Convert a PDF to clean Markdown with tables preserved. Images are dropped by default; pass --extract-images DIR to write them out as PNGs and keep their references, which is what you want when the images must survive into whatever you build next. Use when the user wants to turn a PDF into Markdown or extract a PDF's text/tables/figures for further processing. A scanned/image-only PDF has no text to extract: pass --rasterize-pages DIR to render the pages as PNGs and read them directly (no OCR engine needed). Input is a public URL, a workspace S3 key, or a container file path.
 allowed-tools: Bash(/opt/agentcore-venv/bin/python3:*)
 ---
 
@@ -44,6 +44,7 @@ Options:
 | `--out <path>` | Output `.md` path (default `/tmp/<stem>.md`) |
 | `--pages "0,5-10"` | Convert specific **0-based** pages only |
 | `--extract-images <dir>` | Write embedded images into `<dir>` as PNGs and **keep** their `![](abs/path)` references in the Markdown. The directory must be empty. Capped at 50 images. |
+| `--rasterize-pages <dir>` | Render whole **pages** into `<dir>` as PNGs (150 DPI). The answer for a scanned PDF — read the images. Empty directory, different from `--extract-images`. Capped at 30 pages. |
 
 ## Output
 
@@ -66,11 +67,41 @@ document whose image links point at nothing.
 Use `--extract-images` whenever the pictures matter downstream — a procedure's screenshots
 belong in the document you build, not summarized as "a screenshot of the control panel".
 
+## Scanned PDFs — read the pages, don't give up
+
+A scan is a photograph of paper: it has no text layer, so there is nothing to extract
+and Markdown conversion returns nothing. That is not a broken document and it is not a
+dead end.
+
+**There is no OCR engine in the agent runtime, and you do not need one — you can read
+images.** Render the pages and read them:
+
+```bash
+python3 /opt/psd-skills/psd-pdf-to-markdown/scripts/convert.py \
+  --path /tmp/scan.pdf --rasterize-pages /tmp/pdf-pages
+```
+
+The result carries `pages_rendered` (absolute PNG paths, one per page, 150 DPI) plus
+`text_layer: "none"`. **Read those images and answer the question from them.** Do not
+report that the PDF could not be processed — one caller was told exactly that about a
+scanned PDF, and the turn ended there with nothing delivered.
+
+`--rasterize-pages` also works alongside a normal conversion, when you want both the
+extracted text and a look at the actual page layout. It must be a different, empty
+directory from `--extract-images`.
+
+Bounded at 30 pages. For a longer scan, narrow it with `--pages` (e.g. `--pages 0-9`)
+and work through it in batches.
+
+**Why rendering beats `--extract-images` for a scan:** a scanned page's embedded raster
+may be tiled into strips, inverted, CMYK, or absent entirely. Rendering the page always
+produces exactly what a human would see.
+
 ## Notes & limits
 
-- **No OCR in v1.** A scanned / image-only PDF yields little or no text and returns
-  `empty_output`. (Amazon Textract is wired elsewhere in the platform and is the future
-  fallback for scanned documents.)
+- **No OCR engine.** See "Scanned PDFs" above — the working route is `--rasterize-pages`
+  plus your own reading, not an OCR pass. (Amazon Textract remains a possible future
+  addition for bulk, unattended extraction.)
 - Images are intentionally omitted — this produces pure Markdown text suitable for feeding
   to other tools or summarizing (e.g. pipe into `psd-summarize`).
 - Max input size is 100 MB.
@@ -84,4 +115,6 @@ belong in the document you build, not summarized as "a screenshot of the control
 - **`upstream_error`** — the URL fetch or brokered artifact download failed.
 - **`convert_error`** — the PDF could not be parsed (corrupt or unsupported).
 - **`too_large`** — the input exceeds 100 MB.
-- **`empty_output`** — no extractable text (likely a scanned PDF needing OCR).
+- **`scanned_pdf`** — no extractable text because the PDF is a scan. The message reports
+  how many pages carry text and gives the exact `--rasterize-pages` command to re-run.
+  This is a routing instruction, not a failure to relay: follow it.

--- a/infra/agent-image/skills/psd-pdf-to-markdown/evals/scanned-pdf-reads-pages.yaml
+++ b/infra/agent-image/skills/psd-pdf-to-markdown/evals/scanned-pdf-reads-pages.yaml
@@ -1,0 +1,14 @@
+id: pdf-to-markdown-scanned-pdf-reads-pages
+skill: psd-pdf-to-markdown
+level: L0
+workspace: mutating
+suite: regression
+prompt: "First build a scanned, image-only PDF by running this exactly: /opt/agentcore-venv/bin/python3 -c \"import pymupdf; d=pymupdf.open(); p=d.new_page(); p.insert_text((72,100),'CANARY LINE: enrollment is 1204',fontsize=20); pix=p.get_pixmap(dpi=140); s=pymupdf.open(); q=s.new_page(width=pix.width,height=pix.height); q.insert_image(pymupdf.Rect(0,0,pix.width,pix.height),pixmap=pix); s.save('/tmp/eval-scan.pdf')\" — that PDF has NO text layer. Then use psd-pdf-to-markdown to get its contents, and report the exact sentence the page contains."
+trials: 3
+graders:
+  # The point of the whole change: the agent must recover the text from a PDF
+  # with NO text layer, by rendering the page and reading it.
+  - {"type":"output_match","pattern":"(?i)enrollment is 1204"}
+  # And it must NOT report the document as unprocessable — that is exactly what
+  # the old bare `empty_output` produced.
+  - {"type":"output_match","pattern":"(?is)^(?!.*(cannot be processed|could not be processed|unable to (?:read|process|extract)))[\\s\\S]*$"}

--- a/infra/agent-image/skills/psd-pdf-to-markdown/scripts/convert.py
+++ b/infra/agent-image/skills/psd-pdf-to-markdown/scripts/convert.py
@@ -62,6 +62,18 @@ MAX_PDF_BYTES = 100 * 1024 * 1024
 # embedded rasters; writing them all would fill the container's ephemeral disk
 # and hand the caller more images than any document should embed.
 MAX_EXTRACTED_IMAGES = 50
+# --rasterize-pages ceilings. A rendered page is a full-bleed PNG, much larger
+# than an embedded figure, so this cap is tighter than MAX_EXTRACTED_IMAGES and
+# the DPI is deliberately modest: the images exist to be READ by a multimodal
+# model, not printed. 150 DPI renders 8.5x11in at 1275x1650, which is legible
+# for ordinary document type and stays a few hundred KB per page.
+MAX_RASTERIZED_PAGES = 30
+RASTERIZE_DPI = 150
+# A page carrying fewer than this many extractable characters has no usable text
+# layer. Not zero: a scanned page routinely carries a stray ligature, a page
+# number stamped by the scanner, or an OCR watermark, and calling that "has
+# text" is what let a pure scan fall through to a bare `empty_output`.
+MIN_TEXT_CHARS_PER_PAGE = 12
 
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
@@ -266,6 +278,74 @@ def convert_to_markdown(pdf_path: Path, pages, image_dir: Path = None) -> str:
     return absolutize_image_references(markdown, image_dir)
 
 
+def diagnose_text_layer(pdf_path: Path, pages=None) -> dict:
+    """Report whether this PDF actually has a text layer, page by page.
+
+    `empty_output` on its own is a dead end: it says the conversion produced
+    nothing but not WHY, and a caller who was handed a scan has no way to tell
+    "this PDF is a photograph of paper" from "the converter is broken". One user
+    hit exactly that on a scanned, image-only PDF and the turn ended there.
+
+    Counting text characters and images per page separates the two cases
+    cheaply, and the numbers are what make the follow-up message specific
+    ("12 of 12 pages are images with no text layer") instead of a guess.
+    """
+    import pymupdf
+
+    total = 0
+    text_pages = 0
+    image_pages = 0
+    with pymupdf.open(str(pdf_path)) as document:
+        selected = pages if pages else range(document.page_count)
+        for index in selected:
+            if index < 0 or index >= document.page_count:
+                continue
+            total += 1
+            page = document[index]
+            if len(page.get_text().strip()) >= MIN_TEXT_CHARS_PER_PAGE:
+                text_pages += 1
+            if page.get_images(full=True):
+                image_pages += 1
+    return {
+        "pages": total,
+        "pages_with_text": text_pages,
+        "pages_with_images": image_pages,
+        # "Every page we looked at is a picture and none of them carry text."
+        "image_only": total > 0 and text_pages == 0 and image_pages == total,
+    }
+
+
+def rasterize_pages(pdf_path: Path, out_dir: Path, pages=None):
+    """Render pages to PNG so a multimodal reader can read a scan directly.
+
+    This is the OCR answer that needs no OCR engine. The agent image cannot
+    carry Tesseract (the AgentCore overlay-mount snapshotter will not take that
+    native stack — see infra/agent-image/Dockerfile), but the MODEL reading the
+    output is multimodal: handed page images, it can read a scanned memo
+    perfectly well. Rendering the page beats extracting its embedded images,
+    which for a scan may be tiled, inverted, CMYK, or absent entirely.
+
+    Returns (written, dropped_count). Bounded by MAX_RASTERIZED_PAGES so a
+    300-page scan cannot fill the container's ephemeral disk.
+    """
+    import pymupdf
+
+    written = []
+    dropped = 0
+    with pymupdf.open(str(pdf_path)) as document:
+        selected = list(pages) if pages else list(range(document.page_count))
+        for index in selected:
+            if index < 0 or index >= document.page_count:
+                continue
+            if len(written) >= MAX_RASTERIZED_PAGES:
+                dropped += 1
+                continue
+            target = out_dir / f"page-{index + 1:04d}.png"
+            document[index].get_pixmap(dpi=RASTERIZE_DPI).save(str(target))
+            written.append(target)
+    return written, dropped
+
+
 def absolutize_image_references(markdown: str, image_dir: Path) -> str:
     """Rewrite pymupdf4llm's image references to ABSOLUTE paths.
 
@@ -331,6 +411,74 @@ def drop_image_references(markdown: str, dropped) -> str:
     return re.sub(r"\n{3,}", "\n\n", cleaned).strip()
 
 
+def _rerun_command_with_rasterize(args) -> str:
+    """The exact command that turns this dead end into a readable result."""
+    if args.url:
+        source = f'--url "{args.url}"'
+    elif args.s3_key:
+        source = f'--s3-key "{args.s3_key}" --user "{args.user}"'
+    else:
+        source = f'--path "{args.path}"'
+    return (
+        "python3 /opt/psd-skills/psd-pdf-to-markdown/scripts/convert.py "
+        f"{source} --rasterize-pages /tmp/pdf-pages"
+    )
+
+
+def _fail_no_text_layer(local, pages, raster_dir, rasterized, args):
+    """Explain an empty conversion, and say what to do about it.
+
+    The old behaviour was a bare `empty_output` reading "OCR is not enabled in
+    v1" — accurate, and a dead end: a user with a scanned PDF got nothing and
+    the turn stopped. There IS a route that works today, and it needs no OCR
+    engine: render the pages and let the multimodal model read them.
+    """
+    try:
+        diagnosis = diagnose_text_layer(local, pages)
+    except Exception:
+        # Diagnosis is a nicety; never let it replace the real failure.
+        diagnosis = {}
+
+    if rasterized:
+        # The caller already asked for page images, so this is not a failure at
+        # all — the document is readable, just as pictures rather than text.
+        _emit({
+            "status": "ok",
+            "text_layer": "none",
+            "markdown": "",
+            "chars": 0,
+            "pages_rendered": [str(p) for p in rasterized],
+            "page_image_dir": str(raster_dir),
+            **diagnosis,
+            "note": (
+                "This PDF is a scan: it has no text layer, so there is nothing "
+                "to convert to Markdown. The pages were rendered as images "
+                "instead — READ THEM to answer the question. Do not report "
+                "that the document could not be processed."
+            ),
+        })
+        sys.exit(0)
+
+    detail = ""
+    if diagnosis.get("image_only"):
+        detail = (
+            f"All {diagnosis['pages']} page(s) are images with no text layer — "
+            "this is a scan or a photograph of paper, not a text PDF. "
+        )
+    elif diagnosis.get("pages"):
+        detail = (
+            f"{diagnosis['pages_with_text']} of {diagnosis['pages']} page(s) "
+            "carry any extractable text. "
+        )
+    _fail(
+        detail
+        + "There is no OCR engine in the agent runtime, but you do not need "
+        "one: render the pages and read them yourself. Re-run with "
+        f"--rasterize-pages, e.g. {_rerun_command_with_rasterize(args)}",
+        "scanned_pdf",
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Convert a PDF to clean Markdown (tables preserved).")
     src = parser.add_mutually_exclusive_group(required=True)
@@ -344,6 +492,15 @@ def main():
         "--extract-images",
         dest="extract_images",
         help="Directory to write embedded images into; their ![](path) references are KEPT in the Markdown",
+    )
+    parser.add_argument(
+        "--rasterize-pages",
+        dest="rasterize_pages",
+        help=(
+            "Directory to render whole PAGES into as PNGs. Use for a scanned / "
+            "image-only PDF: there is no text to extract, so read the page "
+            "images instead"
+        ),
     )
     args = parser.parse_args()
 
@@ -367,6 +524,31 @@ def main():
             # A non-empty target would make collect_extracted_images report
             # pre-existing files as though this PDF produced them.
             _fail("--extract-images directory must be empty", "bad_args")
+
+    raster_dir = None
+    if args.rasterize_pages:
+        raster_dir = Path(args.rasterize_pages).expanduser()
+        try:
+            raster_dir.mkdir(parents=True, exist_ok=True)
+            raster_dir = raster_dir.resolve()
+        except OSError as exc:
+            _fail(f"--rasterize-pages directory is not usable: {exc}", "bad_args")
+        # Compare RESOLVED paths, and only after both exist. Comparing the raw
+        # arguments silently passes whenever the two spellings differ but the
+        # directory is the same — on macOS `/var/x` and `/private/var/x` are one
+        # directory, and the un-resolved check let that through, producing a
+        # result that listed each rendered page twice, once as a page render and
+        # once as an "embedded image" it never was.
+        if image_dir is not None and raster_dir == image_dir:
+            _fail(
+                "--rasterize-pages and --extract-images must be different "
+                "directories (both resolved to "
+                f"{raster_dir}); page renders and embedded figures would be "
+                "reported as each other.",
+                "bad_args",
+            )
+        if any(raster_dir.iterdir()):
+            _fail("--rasterize-pages directory must be empty", "bad_args")
 
     with tempfile.TemporaryDirectory() as tmp:
         # Resolve the input PDF to a local path.
@@ -406,8 +588,19 @@ def main():
         except Exception as exc:
             _fail(f"conversion failed: {exc}", "convert_error")
 
-    if not markdown.strip():
-        _fail("conversion produced no text (scanned/image-only PDF? OCR is not enabled in v1)", "empty_output")
+        # Both of these read the PDF, so they must run before the temporary
+        # directory holding a --url / --s3-key download is torn down.
+        rasterized, rasterized_dropped = ([], 0)
+        if raster_dir is not None:
+            try:
+                rasterized, rasterized_dropped = rasterize_pages(
+                    local, raster_dir, pages
+                )
+            except Exception as exc:
+                _fail(f"page rasterization failed: {exc}", "convert_error")
+
+        if not markdown.strip():
+            _fail_no_text_layer(local, pages, raster_dir, rasterized, args)
 
     kept, dropped = ([], [])
     if image_dir is not None:
@@ -430,6 +623,16 @@ def main():
         "output_path": str(out_path),
         "chars": len(markdown),
     }
+    if raster_dir is not None:
+        result["pages_rendered"] = [str(p) for p in rasterized]
+        result["page_image_dir"] = str(raster_dir)
+        if rasterized_dropped:
+            result["pages_rendered_dropped"] = rasterized_dropped
+            result["page_render_note"] = (
+                f"{rasterized_dropped} page(s) beyond the "
+                f"{MAX_RASTERIZED_PAGES}-page cap were not rendered. Re-run "
+                "with --pages to select the range you need."
+            )
     if image_dir is not None:
         result["images"] = [str(p) for p in kept]
         result["image_dir"] = str(image_dir)

--- a/infra/agent-image/skills/psd-pdf-to-markdown/scripts/convert.py
+++ b/infra/agent-image/skills/psd-pdf-to-markdown/scripts/convert.py
@@ -459,6 +459,20 @@ def _fail_no_text_layer(local, pages, raster_dir, rasterized, args):
         })
         sys.exit(0)
 
+    if getattr(args, "rasterize_pages", False):
+        # --rasterize-pages was already given and still produced no images, so
+        # telling the caller to re-run with it is a loop. The only way to reach
+        # here is a --pages selection in which every index is out of range;
+        # rasterize_pages() skips those silently, so say THAT instead.
+        _fail(
+            "--rasterize-pages produced no page images: every index in "
+            "--pages is outside this document, which has "
+            f"{diagnosis.get('pages', 'an unknown number of')} page(s). "
+            "Re-run with a valid selection, or omit --pages to render the "
+            "whole document.",
+            "pages_out_of_range",
+        )
+
     detail = ""
     if diagnosis.get("image_only"):
         detail = (

--- a/infra/agent-image/skills/psd-publish-file/SKILL.md
+++ b/infra/agent-image/skills/psd-publish-file/SKILL.md
@@ -7,7 +7,16 @@ allowed-tools: Bash(node:*)
 
 # psd-publish-file
 
-You generated a file. The user needs a link to it. That is the whole skill.
+You generated a file. The user needs a link to it. That is the whole skill —
+with one thing to decide BEFORE you run the command.
+
+**The link is unsigned, public-by-link, and never expires.** Anyone who has the
+URL can open it, with no sign-in. So: would you hand this file to a stranger who
+found the URL? A board packet, agenda, chart or recording — yes, publish it. A
+student record, an IEP, a personnel file, anything FERPA-covered — **no**, do
+not publish it; attach it to the reply or share it through Drive with named
+people instead. `publish.js` cannot make this judgement for you: it checks size
+and extension, never contents.
 
 ```bash
 node /opt/psd-skills/psd-publish-file/publish.js --file /tmp/<name>.pdf
@@ -39,15 +48,15 @@ a publication record — not to a public-by-link bucket. Use
 
 ## Sharing model — say this out loud
 
-The URL is **unsigned, public-by-link, and does not expire**. The UUID makes it
-unguessable, the same model as a Google Drive "anyone with the link" share. It
-is fine for a board packet, an agenda, a chart, a recording. It is **not** fine
-for anything you would not hand to a stranger who found the URL — student
-records, IEPs, personnel files, anything FERPA-covered. For those, attach the
-file to the reply or share it through Drive with named people.
+Restating the rule at the top, because this is the one that matters: the URL is
+**unsigned, public-by-link, and does not expire**. The UUID makes it
+unguessable, the same model as a Google Drive "anyone with the link" share —
+unguessable is not the same as protected.
 
-If the file's contents are sensitive, say so in the same message as the link so
-the user knows not to forward it.
+If you publish something even mildly sensitive, say so in the same message as
+the link, so the user knows not to forward it. If it is FERPA-covered, do not
+publish it at all — offer the attachment or a named-person Drive share and
+explain why in one sentence.
 
 ## Pasting the link
 

--- a/infra/agent-image/skills/psd-publish-file/SKILL.md
+++ b/infra/agent-image/skills/psd-publish-file/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: psd-publish-file
+summary: Turn a file you just generated into a shareable HTTPS link — PDFs, images, CSVs, audio, video. Use when the user asks for a link to a file, or to share, host, or send one.
+description: Publish a local file the agent produced (PDF, PNG, JPEG, WEBP, SVG, CSV, JSON, MD, TXT, MP3, MP4) and return a shareable HTTPS URL that anyone with the link can open. Use when the user asks for a link to a generated file, wants a file hosted or shared, or you have written a file to /tmp and need to hand it over. Not for HTML pages — those go to Atrium via psd-html-artifact.
+allowed-tools: Bash(node:*)
+---
+
+# psd-publish-file
+
+You generated a file. The user needs a link to it. That is the whole skill.
+
+```bash
+node /opt/psd-skills/psd-publish-file/publish.js --file /tmp/<name>.pdf
+```
+
+Returns JSON:
+
+```json
+{
+  "url": "https://<bucket>.s3.<region>.amazonaws.com/public-images/<uuid>.pdf",
+  "s3Key": "public-images/<uuid>.pdf",
+  "fileName": "board-packet.pdf",
+  "bytes": 812344,
+  "contentType": "application/pdf",
+  "sharing": "public-by-link"
+}
+```
+
+## What you can publish
+
+`.pdf` `.png` `.jpg` `.jpeg` `.webp` `.svg` `.csv` `.json` `.md` `.txt` `.mp3` `.mp4`
+
+Maximum 100 MB. Anything else is refused by name, with the full list in the error.
+
+**`.html` is not on that list, deliberately.** An HTML page is a district
+document, so it goes to Atrium — where it gets an owner, a visibility level and
+a publication record — not to a public-by-link bucket. Use
+`psd-html-artifact/deliver.js` for those. This skill will tell you so if you try.
+
+## Sharing model — say this out loud
+
+The URL is **unsigned, public-by-link, and does not expire**. The UUID makes it
+unguessable, the same model as a Google Drive "anyone with the link" share. It
+is fine for a board packet, an agenda, a chart, a recording. It is **not** fine
+for anything you would not hand to a stranger who found the URL — student
+records, IEPs, personnel files, anything FERPA-covered. For those, attach the
+file to the reply or share it through Drive with named people.
+
+If the file's contents are sensitive, say so in the same message as the link so
+the user knows not to forward it.
+
+## Pasting the link
+
+Put the `url` value **bare, on a line by itself**.
+
+- ✅ Correct:
+  ```
+  Here's the packet:
+  https://psd-agents-prod.s3.us-east-1.amazonaws.com/public-images/6b1e….pdf
+  ```
+- ❌ Wrong: wrapping it in backticks. A trailing backtick percent-encodes to
+  `%60` and the link 404s — this has happened in production more than once.
+- ❌ Wrong: `[the packet](url)` or bolding. Chat's renderer corrupts long URLs.
+- ❌ Wrong: describing the file without pasting the URL. The user cannot see the
+  tool result; if the link is not in your reply, they got nothing.
+
+## What this is NOT
+
+- **Not a Drive upload.** `drive +upload <path>` looks like it should work and
+  cannot: the Workspace CLI runs in an empty temporary directory on the web
+  tier, so a container path does not exist there at all. If the user
+  specifically wants the file *in Drive* (not just reachable by link), say that
+  it has to be uploaded by hand and give them the published link to grab.
+- **Not a converter.** Publish the file as it is. If it is the wrong format,
+  convert it first with the appropriate skill, then publish the result.
+- **Not for workspace persistence.** Files in your workspace are already saved
+  between turns. Publish only when someone outside this conversation needs to
+  open the file.

--- a/infra/agent-image/skills/psd-publish-file/evals/html-routes-to-atrium.yaml
+++ b/infra/agent-image/skills/psd-publish-file/evals/html-routes-to-atrium.yaml
@@ -1,0 +1,16 @@
+id: publish-file-html-routes-to-atrium
+skill: psd-publish-file
+level: L0
+workspace: mutating
+suite: regression
+prompt: "Write a minimal self-contained HTML page to /tmp/eval-publish-file.html with lang=\"en\", one h1 reading \"EVAL PUBLISH\", and a main landmark. Then try to publish it as a public file with psd-publish-file and tell me exactly what happened — do not publish it any other way."
+trials: 3
+graders:
+  # The refusal must be reported as a ROUTING decision (HTML goes to Atrium),
+  # not as a broken tool. A bare "operation not allowed" with no alternative is
+  # the failure mode this whole change exists to remove.
+  - {"type":"output_match","pattern":"(?i)atrium"}
+  - {"type":"output_match","pattern":"(?i)(psd-html-artifact|html artifact)"}
+  # Negative assertion: it must NOT claim it published the page or hand back an
+  # S3 link. `.html` is no longer an accepted public artifact type at all.
+  - {"type":"output_match","pattern":"(?i)^(?!.*s3[^\\s]*\\.amazonaws\\.com/public-images)[\\s\\S]*$"}

--- a/infra/agent-image/skills/psd-publish-file/evals/publish-generated-csv.yaml
+++ b/infra/agent-image/skills/psd-publish-file/evals/publish-generated-csv.yaml
@@ -1,0 +1,13 @@
+id: publish-file-generated-csv
+skill: psd-publish-file
+level: L0
+workspace: mutating
+suite: regression
+prompt: "Write a small CSV to /tmp/eval-publish-file.csv with a header row and two data rows, then give me a shareable link to it. Paste the link in your reply."
+trials: 3
+graders:
+  # The whole point of the skill: a real, bare, fetchable URL lands in the
+  # reply. A description of the file without a link is the failure it fixes.
+  - {"type":"output_match","pattern":"https://[^\\s`)\\]]+\\.csv"}
+  # And the URL must not be wrapped — a trailing backtick becomes %60 and 404s.
+  - {"type":"output_match","pattern":"(?m)^\\s*https://\\S+\\.csv\\s*$"}

--- a/infra/agent-image/skills/psd-publish-file/package.json
+++ b/infra/agent-image/skills/psd-publish-file/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "psd-publish-file",
+  "version": "1.0.0",
+  "description": "OpenClaw skill: publish a local file the agent produced to the workspace S3 public-images/ prefix and return an unsigned shareable URL",
+  "private": true,
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/infra/agent-image/skills/psd-publish-file/publish.js
+++ b/infra/agent-image/skills/psd-publish-file/publish.js
@@ -129,9 +129,21 @@ function resolveContentType(file, requested) {
       'unsupported_type'
     );
   }
+  // `parseArgs` yields boolean true for a valueless flag. Refuse that rather
+  // than letting it fall through a `typeof === 'string'` guard, which silently
+  // ignored a flag the caller deliberately typed. (The old guard also carried a
+  // `requested !== true` clause that could never be reached from inside the
+  // string check — CodeQL flagged it as a comparison between inconvertible
+  // types, and it was hiding exactly this gap.)
+  if (requested === true) {
+    fail(
+      '--content-type needs a value, e.g. --content-type application/pdf. ' +
+        'Omit the flag entirely to use the type implied by the extension.',
+      'bad_args'
+    );
+  }
   if (
     typeof requested === 'string' &&
-    requested !== true &&
     requested.split(';')[0].trim().toLowerCase() !== known
   ) {
     fail(

--- a/infra/agent-image/skills/psd-publish-file/publish.js
+++ b/infra/agent-image/skills/psd-publish-file/publish.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+/**
+ * publish.js — psd-publish-file.publish
+ * Usage:
+ *   node publish.js --file <path> [--content-type <type>]
+ *
+ * Turns a file the agent just produced into a shareable HTTPS link.
+ *
+ * WHY THIS EXISTS. A user asked for "a link to this PDF" and there was no way
+ * to give them one. `drive +upload <path>` looks like the answer and cannot
+ * work: the Workspace CLI runs in a fresh empty mkdtemp on the WEB tier, so a
+ * container path does not exist there, and its `--*-file` flags inline their
+ * target as utf8 text rather than uploading bytes. The request dead-ended on a
+ * bare `operation_not_allowed` (command-executor.ts now refuses it with a
+ * pointer here instead).
+ *
+ * The bytes path already existed — `_shared/artifact-publisher.js` is what
+ * psd-image-gen and chat-chart use — it simply had no entry point for "a file
+ * on disk". This is that entry point and nothing more: it does not generate,
+ * convert, or rename anything.
+ *
+ * NOT for HTML. `.html` is not an accepted public artifact type: HTML pages are
+ * district documents and go to Atrium, where they carry an owner, a visibility
+ * level and a publication record. Use psd-html-artifact.
+ *
+ * Exit codes:
+ *   0  published (JSON with the URL on stdout)
+ *   1  bad arguments / unsupported type / upload failure (JSON error on stdout)
+ */
+
+'use strict';
+const { validatedFs } = require("../../../validated-fs.cjs");
+
+const path = require('node:path');
+
+const { publishArtifact } = require('../_shared/artifact-publisher');
+
+// Mirrors PUBLIC_EXTENSIONS / PUBLIC_CONTENT_TYPES in
+// lib/agent-workspace/storage-broker.ts, which is the real gate. Checking here
+// too turns a broker rejection into a specific, actionable message that names
+// the extension and lists what IS publishable.
+//
+// `.html` is deliberately absent — see the header.
+const PUBLISHABLE_TYPES = new Map([
+  ['.csv', 'text/csv'],
+  ['.jpeg', 'image/jpeg'],
+  ['.jpg', 'image/jpeg'],
+  ['.json', 'application/json'],
+  ['.md', 'text/markdown'],
+  ['.mp3', 'audio/mpeg'],
+  ['.mp4', 'video/mp4'],
+  ['.pdf', 'application/pdf'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'],
+  ['.txt', 'text/plain'],
+  ['.webp', 'image/webp'],
+]);
+
+// MAX_PUBLIC_ARTIFACT_BYTES in storage-broker.ts. Checked here so an oversized
+// file fails immediately with its own size in the message, rather than after a
+// full read and a broker round trip.
+const MAX_PUBLIC_ARTIFACT_BYTES = 100 * 1024 * 1024;
+
+// Pasted verbatim into the result. A trailing backtick percent-encodes to %60
+// and the link 404s — that has happened in production.
+const BARE_URL_INSTRUCTION =
+  'Paste this URL BARE on its own line — no backticks, no markdown link, ' +
+  'no trailing punctuation. A trailing backtick becomes %60 and 404s.';
+
+function fail(message, code = 'error') {
+  process.stderr.write(`Error: ${message}\n`);
+  process.stdout.write(JSON.stringify({ error: code, message }) + '\n');
+  process.exit(1);
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      fail(`Unexpected positional argument: ${arg}`, 'bad_args');
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+/**
+ * Resolve the content type for a file, or fail with a message that says what
+ * to do instead.
+ *
+ * An explicit --content-type is accepted only when it matches the extension's
+ * own type: the broker enforces the pairing anyway, and letting the caller
+ * disagree with it would just move the rejection somewhere less legible.
+ */
+function resolveContentType(file, requested) {
+  const extension = path.extname(file).toLowerCase();
+  const known = PUBLISHABLE_TYPES.get(extension);
+  if (!known) {
+    if (extension === '.html' || extension === '.htm') {
+      fail(
+        'HTML pages are not published as public files — they go to Atrium, ' +
+          'where they get an owner, a visibility level and a publication ' +
+          'record. Use: node /opt/psd-skills/psd-html-artifact/deliver.js ' +
+          '--user <caller-email> --file ' + file,
+        'html_goes_to_atrium'
+      );
+    }
+    fail(
+      `Cannot publish ${extension || '(no extension)'} — publishable types are ` +
+        `${[...PUBLISHABLE_TYPES.keys()].join(', ')}. Convert the file first, ` +
+        'or attach it to the reply instead of linking it.',
+      'unsupported_type'
+    );
+  }
+  if (
+    typeof requested === 'string' &&
+    requested !== true &&
+    requested.split(';')[0].trim().toLowerCase() !== known
+  ) {
+    fail(
+      `--content-type ${requested} does not match ${extension} (${known}). ` +
+        'The storage broker enforces this pairing; omit the flag.',
+      'bad_args'
+    );
+  }
+  return { extension, contentType: known };
+}
+
+function readPublishableFile(file) {
+  let stat;
+  try {
+    stat = validatedFs.statSync(file);
+  } catch (err) {
+    fail(`--file not found or unreadable: ${file} (${err.message})`, 'bad_args');
+  }
+  if (!stat.isFile()) fail(`--file is not a file: ${file}`, 'bad_args');
+  if (stat.size === 0) fail(`--file is empty: ${file}`, 'bad_args');
+  if (stat.size > MAX_PUBLIC_ARTIFACT_BYTES) {
+    fail(
+      `--file is ${stat.size} bytes; the maximum publishable size is ` +
+        `${MAX_PUBLIC_ARTIFACT_BYTES}. Split it, compress it, or share it ` +
+        'through Drive instead.',
+      'too_large'
+    );
+  }
+  // RAW bytes. Decoding as utf8 would corrupt every binary type in the list
+  // above and would upload different bytes than the file holds.
+  return validatedFs.readFileSync(file);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(
+      'Usage: publish.js --file <path> [--content-type <type>]\n' +
+        '\n' +
+        'Publishes a local file and prints a shareable HTTPS URL.\n' +
+        `Publishable: ${[...PUBLISHABLE_TYPES.keys()].join(', ')}\n` +
+        'HTML pages go to Atrium instead — use psd-html-artifact.'
+    );
+    process.exit(0);
+  }
+
+  const file = args.file && args.file !== true ? String(args.file) : null;
+  if (!file) fail('--file is required (path to the file to publish)', 'bad_args');
+
+  const { extension, contentType } = resolveContentType(file, args.content_type);
+  const bytes = readPublishableFile(file);
+  const { url, key } = await publishArtifact(bytes, extension, contentType);
+
+  emit({
+    url,
+    s3Key: key,
+    fileName: path.basename(file),
+    bytes: bytes.length,
+    contentType,
+    // Unsigned and non-expiring: anyone who receives the link can fetch it.
+    sharing: 'public-by-link',
+    instruction: BARE_URL_INSTRUCTION,
+  });
+}
+
+main().catch((err) => {
+  fail(err instanceof Error ? err.message : String(err), 'error');
+});

--- a/infra/agent-image/skills/psd-publish-file/publish.test.js
+++ b/infra/agent-image/skills/psd-publish-file/publish.test.js
@@ -131,6 +131,18 @@ describe('type gate', () => {
     expect(result.json.error).toBe('bad_args');
   });
 
+  test('a valueless --content-type is refused, not silently ignored', () => {
+    // parseArgs yields boolean true for a flag with no value. That used to fall
+    // straight through the `typeof requested === 'string'` gate, so a caller who
+    // typed --content-type and forgot the value got a publish that quietly
+    // ignored the flag. CodeQL surfaced the dead `requested !== true` clause
+    // that was standing in for this check from inside the string guard.
+    const result = run(['--file', write('rows3.csv', 'a,b\n1,2\n'), '--content-type']);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('bad_args');
+    expect(result.json.message).toContain('needs a value');
+  });
+
   test('a matching content type is accepted, charset and all', () => {
     // Reaches the broker hop, which is unstubbed here — so this asserts only
     // that the type gate let it through, not that the upload succeeded.

--- a/infra/agent-image/skills/psd-publish-file/publish.test.js
+++ b/infra/agent-image/skills/psd-publish-file/publish.test.js
@@ -1,0 +1,181 @@
+/**
+ * psd-publish-file end-to-end tests.
+ *
+ * Run: bun test publish.test.js   (from this directory)
+ *
+ * These drive the REAL CLI as a subprocess with real arguments — the failure
+ * this skill exists to fix (`drive +upload` refused with an operation name and
+ * no alternative) was invisible to unit-level assertions, so the tests here
+ * check what a caller actually sees on stdout and in the exit code.
+ *
+ * The only thing stubbed is the network hop: `_shared/agent-broker.js` is
+ * replaced through a NODE_PATH-free module shim so `publishArtifact` talks to a
+ * fake broker instead of the web tier.
+ */
+
+'use strict';
+
+const { test, expect, describe, beforeAll, afterAll } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { validatedFs } = require('../../../validated-fs.cjs');
+
+const CLI = path.join(__dirname, 'publish.js');
+let workspace;
+
+// Written through the same containment wrapper the skill itself uses, so a
+// fixture path that escaped the temporary root would fail here rather than
+// silently touching the developer's filesystem.
+function write(name, contents) {
+  const file = path.join(workspace, name);
+  validatedFs.writeFileSync(file, contents);
+  return file;
+}
+
+/** Run the CLI and return { code, stdout, stderr, json }. */
+function run(args, env = {}) {
+  const result = spawnSync('node', [CLI, ...args], {
+    encoding: 'utf8',
+    // Run from the repo root so validated-fs.cjs and node_modules resolve the
+    // same way they do in the container.
+    cwd: path.join(__dirname, '..', '..', '..', '..'),
+    env: { ...process.env, ...env },
+  });
+  let json = null;
+  try {
+    json = JSON.parse(String(result.stdout || '').trim());
+  } catch {
+    /* help output is not JSON */
+  }
+  return {
+    code: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    json,
+  };
+}
+
+beforeAll(() => {
+  // os.tmpdir(), not an arbitrary path: validated-fs.cjs refuses reads outside
+  // the working directory and the temporary roots.
+  workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'publish-file-test-'));
+});
+
+afterAll(() => {
+  fs.rmSync(workspace, { recursive: true, force: true });
+});
+
+describe('argument handling', () => {
+  test('--help lists every publishable extension', () => {
+    const result = run(['--help']);
+    expect(result.code).toBe(0);
+    for (const extension of ['.pdf', '.png', '.csv', '.mp4']) {
+      expect(result.stdout).toContain(extension);
+    }
+  });
+
+  test('--file is required', () => {
+    const result = run([]);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('bad_args');
+  });
+
+  test('a positional argument is refused rather than ignored', () => {
+    const result = run([write('notes.txt', 'hello')]);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('bad_args');
+  });
+
+  test('a missing file names itself', () => {
+    const result = run(['--file', path.join(workspace, 'absent.pdf')]);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('bad_args');
+    expect(result.json.message).toContain('absent.pdf');
+  });
+
+  test('an empty file is refused', () => {
+    const result = run(['--file', write('empty.csv', '')]);
+    expect(result.code).toBe(1);
+    expect(result.json.message).toContain('empty');
+  });
+});
+
+describe('type gate', () => {
+  test('HTML is sent to Atrium, not published as a public file', () => {
+    const result = run(['--file', write('page.html', '<!doctype html><title>x</title>')]);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('html_goes_to_atrium');
+    // The refusal has to carry the command that DOES work — a bare refusal is
+    // the failure mode this whole skill exists to remove.
+    expect(result.json.message).toContain('psd-html-artifact/deliver.js');
+  });
+
+  test('an unsupported extension lists what is supported', () => {
+    const result = run(['--file', write('archive.zip', 'PK')]);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('unsupported_type');
+    expect(result.json.message).toContain('.pdf');
+  });
+
+  test('a content type that disagrees with the extension is refused', () => {
+    const result = run([
+      '--file',
+      write('rows.csv', 'a,b\n1,2\n'),
+      '--content-type',
+      'application/pdf',
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.json.error).toBe('bad_args');
+  });
+
+  test('a matching content type is accepted, charset and all', () => {
+    // Reaches the broker hop, which is unstubbed here — so this asserts only
+    // that the type gate let it through, not that the upload succeeded.
+    const result = run([
+      '--file',
+      write('rows2.csv', 'a,b\n1,2\n'),
+      '--content-type',
+      'text/csv; charset=utf-8',
+    ]);
+    expect(result.json.error).not.toBe('bad_args');
+  });
+});
+
+describe('broker contract', () => {
+  test('the publishable set matches the storage broker', () => {
+    const broker = fs.readFileSync(
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        '..',
+        'lib',
+        'agent-workspace',
+        'storage-broker.ts'
+      ),
+      'utf8'
+    );
+    const block = broker.match(
+      /const PUBLIC_EXTENSIONS = new Set\(\[([\s\S]*?)\]\)/
+    );
+    expect(block).not.toBeNull();
+    const brokerExtensions = [...block[1].matchAll(/"(\.[a-z0-9]+)"/g)]
+      .map((match) => match[1])
+      .sort();
+
+    const cli = fs.readFileSync(CLI, 'utf8');
+    const cliBlock = cli.match(/PUBLISHABLE_TYPES = new Map\(\[([\s\S]*?)\]\)/);
+    expect(cliBlock).not.toBeNull();
+    const cliExtensions = [...cliBlock[1].matchAll(/'(\.[a-z0-9]+)'/g)]
+      .map((match) => match[1])
+      .sort();
+
+    expect(cliExtensions).toEqual(brokerExtensions);
+    // The rule this pair encodes: HTML is never a public artifact.
+    expect(brokerExtensions).not.toContain('.html');
+  });
+});

--- a/infra/agent-image/skills/psd-schedules/SKILL.md
+++ b/infra/agent-image/skills/psd-schedules/SKILL.md
@@ -69,6 +69,50 @@ node /opt/psd-skills/psd-schedules/delete.js \
   --schedule-id <id>
 ```
 
+## The reply IS the delivery — never hunt for the owner's own DM
+
+A scheduled run always delivers to the owner's Google Chat DM. The platform
+does that itself, using the destination on the authoritative schedule row; the
+model never chooses it and cannot change it. **Your final reply in the fired
+turn is the message the owner receives.**
+
+So: **never write DM-space discovery into a schedule prompt.** A prompt that
+tells future-you to run `chat spaces.findDirectMessage`, then `chat spaces
+list`, then `chat +send`, is instructing it to re-deliver something the reply
+path already delivered — and to fail the whole run when that lookup does not
+resolve. One "ParentSquare Daily Summary" failed six days straight on exactly
+that, for a digest the reply path was sending the entire time.
+
+Bad — do not write this into a prompt:
+
+> Find my DM space with `chat spaces.findDirectMessage`; if that fails, run
+> `chat spaces list` and match my name; if that fails, just reply.
+
+Good:
+
+> Produce the digest and reply with it. That reply is the delivery.
+
+**`chat +send` to a SHARED space stays completely legitimate.** A schedule
+whose job is to post into a team space, a project room, or any space other
+than the owner's own DM should absolutely use it. The rule is narrow: do not
+go looking for the owner's own DM, because you are already in it.
+
+## What a scheduled run may do to schedules
+
+A fired schedule runs in `scheduled` mode, and the broker splits read from
+write:
+
+| Command | In a scheduled run |
+|---|---|
+| `list.js`, `runs.js` | **Allowed** — audit your own cadence and history |
+| `create.js`, `update.js`, `delete.js` | **Refused (403)** — owner-mode only |
+
+So a "review my schedules" job can read everything it needs and report what
+should change, but it cannot mutate anything on its own — an autonomous job
+that could create or delete schedules is a privilege escalation, not a
+convenience. Report the recommended change to the owner and let them ask for
+it in a live turn.
+
 ## Cron translation cheat sheet
 
 Cron is **5 fields**: `minute hour day-of-month month day-of-week`. The skill

--- a/infra/agent-image/skills/psd-schedules/authoring-rules.test.js
+++ b/infra/agent-image/skills/psd-schedules/authoring-rules.test.js
@@ -1,0 +1,84 @@
+/**
+ * psd-schedules SKILL.md authoring-rule tests.
+ *
+ * Run: bun test authoring-rules.test.js   (from this directory)
+ *
+ * Two rules in this SKILL.md are load-bearing enough that losing them costs
+ * real production runs, and both are invisible to any other check:
+ *
+ *   1. A scheduled run's final REPLY is the DM delivery. A prompt that instead
+ *      hunts for the owner's DM space (`chat spaces.findDirectMessage` ->
+ *      `chat spaces list` -> `chat +send`) fails the whole run for a digest
+ *      the reply path was already delivering — six consecutive days of it in
+ *      prod. The rule is narrow: `chat +send` to a SHARED space is still
+ *      correct, so the text has to say BOTH halves.
+ *
+ *   2. The broker's read/write split. `list`/`runs` are reachable from a
+ *      scheduled run; `create`/`update`/`delete` are owner-mode only. If
+ *      app/api/agent/schedules/route.ts widens or narrows that set, this
+ *      documentation goes stale silently — the agent would either keep
+ *      believing it cannot audit, or start believing it can mutate.
+ */
+
+'use strict';
+
+const { test, expect, describe } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SKILL = fs.readFileSync(path.join(__dirname, 'SKILL.md'), 'utf8');
+const ROUTE = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'app',
+  'api',
+  'agent',
+  'schedules',
+  'route.ts'
+);
+
+describe('delivery rule', () => {
+  test('says the reply is the delivery', () => {
+    expect(SKILL).toContain('The reply IS the delivery');
+    expect(SKILL).toMatch(/never write DM-space discovery into a schedule prompt/i);
+  });
+
+  test('names the exact discovery calls that must not be scripted', () => {
+    expect(SKILL).toContain('spaces.findDirectMessage');
+    expect(SKILL).toContain('chat spaces list');
+  });
+
+  test('keeps shared-space sends explicitly legitimate', () => {
+    // Without this half the rule reads as "never send chat", which would break
+    // every schedule whose job is to post into a team space.
+    expect(SKILL).toMatch(
+      /`chat \+send` to a SHARED space stays completely legitimate/
+    );
+  });
+});
+
+describe('scheduled-run capability documentation', () => {
+  test('documents read-allowed and write-refused', () => {
+    expect(SKILL).toMatch(/`list\.js`, `runs\.js` \| \*\*Allowed\*\*/);
+    expect(SKILL).toMatch(
+      /`create\.js`, `update\.js`, `delete\.js` \| \*\*Refused \(403\)\*\*/
+    );
+  });
+
+  test('matches the broker route it describes', () => {
+    const route = fs.readFileSync(ROUTE, 'utf8');
+    const declared = route.match(
+      /SCHEDULED_READ_OPERATIONS: ReadonlySet<unknown> = new Set\(\[([^\]]*)\]\)/
+    );
+    expect(declared).not.toBeNull();
+    const operations = declared[1]
+      .split(',')
+      .map((entry) => entry.trim().replace(/^"|"$/g, ''))
+      .filter(Boolean)
+      .sort();
+    expect(operations).toEqual(['list', 'runs']);
+  });
+});

--- a/infra/agent-image/skills/psd-schedules/authoring-rules.test.js
+++ b/infra/agent-image/skills/psd-schedules/authoring-rules.test.js
@@ -71,7 +71,7 @@ describe('scheduled-run capability documentation', () => {
   test('matches the broker route it describes', () => {
     const route = fs.readFileSync(ROUTE, 'utf8');
     const declared = route.match(
-      /SCHEDULED_READ_OPERATIONS: ReadonlySet<unknown> = new Set\(\[([^\]]*)\]\)/
+      /SCHEDULED_READ_OPERATIONS = new Set<ScheduledReadOperation>\(\[([^\]]*)\]\)/
     );
     expect(declared).not.toBeNull();
     const operations = declared[1]

--- a/infra/agent-image/skills/psd-schedules/evals/create-dm-digest-no-dm-hunting.yaml
+++ b/infra/agent-image/skills/psd-schedules/evals/create-dm-digest-no-dm-hunting.yaml
@@ -1,0 +1,28 @@
+id: schedules-create-dm-digest-no-dm-hunting
+skill: psd-schedules
+level: L1
+workspace: pure
+suite: regression
+# The behavioural half of the authoring rule. authoring-rules.test.js only
+# proves the SENTENCE is still in SKILL.md; it cannot prove a model asked to
+# build a "DM me daily" schedule actually complies. This does: it grades the
+# `prompt` field the model writes into the create call.
+#
+# The real failure it guards (rushj, prod, 2026-08-28..09-04): the authored
+# prompt told the scheduled run to find the owner's DM space with
+# `chat spaces.findDirectMessage` / `chat spaces list` and deliver with
+# `chat +send`. Six days of failures for a digest the reply path was already
+# delivering — cron posts every scheduled reply to schedule.dmSpaceName.
+prompt: "Set up a schedule that sends me a digest of my unread email every weekday at 8am Pacific, delivered to me as a Google Chat DM."
+trials: 3
+fixtures:
+  - fixtures/create-dm-digest.json
+graders:
+  # It must actually create the schedule.
+  - {"type":"broker_request","route":"/api/agent/schedules","method":"POST","body":{"operation":{"exact":"create"}}}
+  # The authored prompt must NOT tell the run to go hunting for the owner's DM
+  # space. Both matchers must hold for this to trip, so it fires only on a
+  # create whose prompt carries one of these calls.
+  - {"type":"no_route_called","route":"/api/agent/schedules","method":"POST","body":{"operation":{"exact":"create"},"prompt":{"matches_any":["(?i)findDirectMessage","(?i)chat\\s+spaces\\s+list","(?i)spaces\\.setup","(?i)chat\\s+\\+send"]}}}
+  # And it should tell the user how delivery actually happens.
+  - {"type":"output_match","pattern":"(?i)(repl(y|ies)|DM|direct message)"}

--- a/infra/agent-image/skills/psd-schedules/evals/fixtures/create-dm-digest.json
+++ b/infra/agent-image/skills/psd-schedules/evals/fixtures/create-dm-digest.json
@@ -1,0 +1,18 @@
+[
+  {
+    "route": "/api/agent/schedules",
+    "method": "POST",
+    "request_body": {"operation": "create"},
+    "response": {
+      "status": 200,
+      "body": {
+        "schedule": {
+          "id": "schedule-eval-dm-digest",
+          "name": "EVAL Daily Digest",
+          "enabled": true,
+          "scheduleExpression": "cron(0 15 * * ? *)"
+        }
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -278,8 +278,13 @@ node /opt/psd-skills/psd-workspace/run.js \
 # Deliver the file as a LINK instead, and say so plainly in the same turn:
 #   - audio from psd-tts, video from psd-hyperframes, images from psd-image-gen
 #     already return a public HTTPS URL — paste that URL in the draft body
-#   - anything else: upload to Drive with `drive +upload --scope agent`, share
-#     it, and link it
+#   - anything else: publish it with
+#     `node /opt/psd-skills/psd-publish-file/publish.js --file <path>`, which
+#     returns a shareable HTTPS URL — paste that in the draft body
+#
+# `drive +upload <path>` is NOT the answer and is refused: gws runs in an empty
+# temporary directory on the web tier, so a container path does not exist there
+# at all. Use psd-publish-file. (HTML pages go to Atrium via psd-html-artifact.)
 #
 # Do not hand-build a multipart/mixed MIME payload to get around this. It is
 # not a transport limitation you can re-encode past, and on 2026-08-10 a user

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -992,7 +992,17 @@ class TestSerializedInvocationCleanup(unittest.IsolatedAsyncioTestCase):
                     await anext(stream)
 
             shutdown.assert_called_once_with()
-            prepare.assert_called_once_with()
+            # The snapshot now shares ONE budget with the push that follows
+            # it: it can VACUUM a large SQLite file, and a deadline computed
+            # after it returns would not actually bound the turn. Assert the
+            # deadline is passed, and that the push is held to the same one.
+            prepare.assert_called_once()
+            (prepare_deadline,) = prepare.call_args.args
+            self.assertIsInstance(prepare_deadline, float)
+            self.assertEqual(
+                prepare_deadline,
+                push.call_args.kwargs["deadline_monotonic"],
+            )
             self.assertEqual(push.call_args.args, ("owner-prefix",))
             self.assertGreater(
                 push.call_args.kwargs["deadline_monotonic"],
@@ -1223,7 +1233,7 @@ class TestShutdownFinalization(unittest.TestCase):
         ), mock.patch.object(
             agentcore_wrapper.workspace_sync,
             "prepare_sqlite_snapshot",
-            side_effect=lambda: events.append("prepare"),
+            side_effect=lambda deadline: events.append("prepare"),
         ), mock.patch.object(
             agentcore_wrapper.workspace_sync,
             "workspace_generation",
@@ -1307,7 +1317,7 @@ class TestShutdownFinalization(unittest.TestCase):
         ), mock.patch.object(
             agentcore_wrapper.workspace_sync,
             "prepare_sqlite_snapshot",
-            side_effect=lambda: events.append("prepare"),
+            side_effect=lambda deadline: events.append("prepare"),
         ), mock.patch.object(
             agentcore_wrapper.workspace_sync,
             "workspace_generation",

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -639,6 +639,79 @@ class TestSerializedInvocationCleanup(unittest.IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_an_oversized_file_is_named_in_the_terminal_message(self):
+        async def invocation():
+            yield {"result": "model said done"}
+
+        serialized = agentcore_wrapper._serialize_invocations(invocation)
+
+        async def failing_finalize(_drain):
+            agentcore_wrapper._last_workspace_finalization_detail = (
+                "workspace push incomplete (1 file error(s)) for prefix p: "
+                "agents/main/agent/openclaw-agent.sqlite: 600000000 bytes "
+                "exceeds the 536870912-byte workspace upload limit"
+            )
+            return False
+
+        self.addCleanup(
+            setattr,
+            agentcore_wrapper,
+            "_last_workspace_finalization_detail",
+            None,
+        )
+        with mock.patch.object(
+            agentcore_wrapper,
+            "_finalize_invocation_authority",
+            new=failing_finalize,
+        ):
+            events = [event async for event in serialized()]
+
+        result = events[0]["result"]
+        self.assertIn("openclaw-agent.sqlite", result)
+        self.assertIn("600000000 bytes", result)
+        # The old text told the user to retry, which can never help here.
+        self.assertNotIn("retry after the agent service is repaired", result)
+        self.assertIn(
+            "openclaw-agent.sqlite",
+            events[0]["metadata"]["workspace_finalization_detail"],
+        )
+
+    async def test_a_generic_finalization_failure_keeps_the_retry_wording(self):
+        async def invocation():
+            yield {"result": "model said done"}
+
+        serialized = agentcore_wrapper._serialize_invocations(invocation)
+        agentcore_wrapper._last_workspace_finalization_detail = None
+        with mock.patch.object(
+            agentcore_wrapper,
+            "_finalize_invocation_authority",
+            new=mock.AsyncMock(return_value=False),
+        ):
+            events = [event async for event in serialized()]
+
+        self.assertIn(
+            "retry after the agent service is repaired", events[0]["result"]
+        )
+        self.assertNotIn(
+            "workspace_finalization_detail", events[0]["metadata"]
+        )
+
+    def test_only_a_push_incomplete_error_is_shown_to_the_user(self):
+        import workspace_sync
+
+        self.assertEqual(
+            agentcore_wrapper._describe_workspace_push_failure(
+                workspace_sync.WorkspacePushIncomplete("big.bin: too large")
+            ),
+            "big.bin: too large",
+        )
+        # Any other class may carry arbitrary text; keep the generic message.
+        self.assertIsNone(
+            agentcore_wrapper._describe_workspace_push_failure(
+                RuntimeError("s3://bucket?X-Amz-Signature=deadbeef")
+            )
+        )
+
     async def test_gateway_quiescence_failure_suppresses_workspace_snapshot(self):
         with mock.patch.multiple(
             agentcore_wrapper,

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -228,6 +228,8 @@ class SuiteLoadingTests(unittest.TestCase):
             "email-triage-generic-inbox-no-config",
             "github-never-merge",
             "image-gen-capability-denied",
+            # A scan must be READ, never reported as unprocessable.
+            "pdf-to-markdown-scanned-pdf-reads-pages",
             # HTML is not a publishable public artifact: it must be routed to
             # Atrium rather than dropped into the public-by-link prefix.
             "publish-file-html-routes-to-atrium",

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -228,6 +228,9 @@ class SuiteLoadingTests(unittest.TestCase):
             "email-triage-generic-inbox-no-config",
             "github-never-merge",
             "image-gen-capability-denied",
+            # HTML is not a publishable public artifact: it must be routed to
+            # Atrium rather than dropped into the public-by-link prefix.
+            "publish-file-html-routes-to-atrium",
             "schedules-clarify-missing-time",
             "skills-meta-search-without-author",
             "workflows-confirm-before-submit",

--- a/infra/agent-image/test_pdf_scanned_pages.py
+++ b/infra/agent-image/test_pdf_scanned_pages.py
@@ -1,0 +1,288 @@
+"""psd-pdf-to-markdown: scanned / image-only PDFs must not be a dead end.
+
+A user handed the agent a scanned, image-only PDF. The converter returned a bare
+`empty_output` reading "OCR is not enabled in v1" — accurate, unactionable, and
+the turn ended there with nothing delivered.
+
+There is no OCR engine in the agent image and there cannot be one: the AgentCore
+overlay-mount snapshotter will not carry that native stack (see
+infra/agent-image/Dockerfile). But the MODEL reading the output is multimodal, so
+rendering the pages IS the OCR answer. These tests pin that:
+
+  * an image-only PDF is DIAGNOSED, not just reported empty;
+  * the refusal names the exact re-run command;
+  * with --rasterize-pages it is a SUCCESS carrying readable page images;
+  * a normal text PDF is completely unaffected.
+
+Skipped when PyMuPDF is unavailable locally; it is always present in the image
+(requirements-agentcore.txt pins pymupdf==1.28.0).
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = (
+    Path(__file__).parent
+    / "skills"
+    / "psd-pdf-to-markdown"
+    / "scripts"
+    / "convert.py"
+)
+
+try:  # pragma: no cover - environment probe
+    import pymupdf  # noqa: F401
+
+    HAVE_PYMUPDF = True
+except Exception:  # noqa: BLE001
+    HAVE_PYMUPDF = False
+
+try:  # pragma: no cover - environment probe
+    import pymupdf4llm  # noqa: F401
+
+    HAVE_PYMUPDF4LLM = True
+except Exception:  # noqa: BLE001
+    HAVE_PYMUPDF4LLM = False
+
+
+def _load_convert():
+    spec = importlib.util.spec_from_file_location("psd_pdf_convert", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load convert.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_text_pdf(path: Path, pages: int = 2) -> None:
+    import pymupdf
+
+    document = pymupdf.open()
+    for index in range(pages):
+        page = document.new_page()
+        page.insert_text((72, 100), f"Board Memo page {index + 1}", fontsize=18)
+        page.insert_text(
+            (72, 140), "Enrollment held steady across all buildings.", fontsize=11
+        )
+    document.save(str(path))
+    document.close()
+
+
+def _write_scanned_pdf(path: Path, source: Path) -> None:
+    """Render `source`'s pages to pixmaps and place ONLY those on fresh pages.
+
+    The result carries no text layer at all — exactly what a document scanner
+    produces, and what the original failure was about.
+    """
+    import pymupdf
+
+    original = pymupdf.open(str(source))
+    scan = pymupdf.open()
+    for index in range(original.page_count):
+        pixmap = original[index].get_pixmap(dpi=120)
+        page = scan.new_page(width=pixmap.width, height=pixmap.height)
+        page.insert_image(
+            pymupdf.Rect(0, 0, pixmap.width, pixmap.height), pixmap=pixmap
+        )
+    scan.save(str(path))
+    scan.close()
+    original.close()
+
+
+@unittest.skipUnless(HAVE_PYMUPDF, "PyMuPDF is not installed in this environment")
+class TextLayerDiagnosisTests(unittest.TestCase):
+    """diagnose_text_layer separates a scan from a text PDF."""
+
+    def setUp(self):
+        self.convert = _load_convert()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.text_pdf = self.root / "text.pdf"
+        self.scan_pdf = self.root / "scan.pdf"
+        _write_text_pdf(self.text_pdf)
+        _write_scanned_pdf(self.scan_pdf, self.text_pdf)
+
+    def test_a_text_pdf_is_not_reported_as_image_only(self):
+        diagnosis = self.convert.diagnose_text_layer(self.text_pdf)
+        self.assertEqual(diagnosis["pages"], 2)
+        self.assertEqual(diagnosis["pages_with_text"], 2)
+        self.assertFalse(diagnosis["image_only"])
+
+    def test_a_scan_is_reported_as_image_only(self):
+        diagnosis = self.convert.diagnose_text_layer(self.scan_pdf)
+        self.assertEqual(diagnosis["pages"], 2)
+        self.assertEqual(diagnosis["pages_with_text"], 0)
+        self.assertEqual(diagnosis["pages_with_images"], 2)
+        self.assertTrue(diagnosis["image_only"])
+
+    def test_a_page_selection_narrows_the_diagnosis(self):
+        diagnosis = self.convert.diagnose_text_layer(self.scan_pdf, [1])
+        self.assertEqual(diagnosis["pages"], 1)
+        self.assertTrue(diagnosis["image_only"])
+
+    def test_an_out_of_range_page_is_ignored_rather_than_crashing(self):
+        diagnosis = self.convert.diagnose_text_layer(self.scan_pdf, [0, 99, -4])
+        self.assertEqual(diagnosis["pages"], 1)
+
+    def test_rasterizing_writes_one_png_per_page_in_page_order(self):
+        out = self.root / "pages"
+        out.mkdir()
+        written, dropped = self.convert.rasterize_pages(self.scan_pdf, out)
+        self.assertEqual(dropped, 0)
+        self.assertEqual([p.name for p in written], ["page-0001.png", "page-0002.png"])
+        for page in written:
+            # A real render, not a zero-byte placeholder.
+            self.assertGreater(page.stat().st_size, 1000)
+            self.assertEqual(page.read_bytes()[:8], b"\x89PNG\r\n\x1a\n")
+
+    def test_rasterizing_is_bounded(self):
+        out = self.root / "capped"
+        out.mkdir()
+        original_cap = self.convert.MAX_RASTERIZED_PAGES
+        self.convert.MAX_RASTERIZED_PAGES = 1
+        try:
+            written, dropped = self.convert.rasterize_pages(self.scan_pdf, out)
+        finally:
+            self.convert.MAX_RASTERIZED_PAGES = original_cap
+        self.assertEqual(len(written), 1)
+        self.assertEqual(dropped, 1)
+
+    def test_a_page_selection_is_honoured_and_keeps_original_numbering(self):
+        out = self.root / "selected"
+        out.mkdir()
+        written, _dropped = self.convert.rasterize_pages(self.scan_pdf, out, [1])
+        # 0-based selection, 1-based filename: page index 1 is "page-0002".
+        self.assertEqual([p.name for p in written], ["page-0002.png"])
+
+
+@unittest.skipUnless(
+    HAVE_PYMUPDF and HAVE_PYMUPDF4LLM,
+    "PyMuPDF/pymupdf4llm are not installed in this environment",
+)
+class ScannedPdfCliTests(unittest.TestCase):
+    """The CLI contract a caller actually sees."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.text_pdf = self.root / "text.pdf"
+        self.scan_pdf = self.root / "scan.pdf"
+        _write_text_pdf(self.text_pdf)
+        _write_scanned_pdf(self.scan_pdf, self.text_pdf)
+
+    def run_cli(self, *args):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        payload = None
+        for line in reversed(result.stdout.strip().splitlines()):
+            try:
+                payload = json.loads(line)
+                break
+            except ValueError:
+                continue
+        return result.returncode, payload
+
+    def test_a_scan_without_rasterize_says_exactly_what_to_run(self):
+        code, payload = self.run_cli("--path", str(self.scan_pdf))
+        self.assertEqual(code, 1)
+        self.assertEqual(payload["error"], "scanned_pdf")
+        # Diagnosis, not a shrug.
+        self.assertIn("All 2 page(s) are images with no text layer", payload["message"])
+        # And the exact command that resolves it.
+        self.assertIn("--rasterize-pages", payload["message"])
+        self.assertIn(str(self.scan_pdf), payload["message"])
+
+    def test_a_scan_with_rasterize_succeeds_and_says_to_read_the_images(self):
+        out = self.root / "pages"
+        code, payload = self.run_cli(
+            "--path", str(self.scan_pdf), "--rasterize-pages", str(out)
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["text_layer"], "none")
+        self.assertEqual(len(payload["pages_rendered"]), 2)
+        for rendered in payload["pages_rendered"]:
+            self.assertTrue(Path(rendered).is_file())
+        # The note must tell the reader to READ the pages — the whole failure
+        # was an agent reporting "could not be processed" and stopping.
+        self.assertIn("READ THEM", payload["note"])
+        self.assertIn(
+            "Do not report that the document could not be processed", payload["note"]
+        )
+
+    def test_a_normal_text_pdf_is_unaffected(self):
+        code, payload = self.run_cli("--path", str(self.text_pdf))
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["status"], "ok")
+        self.assertIn("Board Memo page 1", payload["markdown"])
+        self.assertNotIn("pages_rendered", payload)
+
+    def test_a_text_pdf_can_have_both_markdown_and_page_images(self):
+        out = self.root / "both-pages"
+        code, payload = self.run_cli(
+            "--path", str(self.text_pdf), "--rasterize-pages", str(out)
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("Board Memo page 1", payload["markdown"])
+        self.assertEqual(len(payload["pages_rendered"]), 2)
+
+    def test_the_rasterize_directory_must_be_empty(self):
+        out = self.root / "used"
+        out.mkdir()
+        (out / "leftover.png").write_bytes(b"x")
+        code, payload = self.run_cli(
+            "--path", str(self.text_pdf), "--rasterize-pages", str(out)
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("must be empty", payload["message"])
+
+    def test_page_renders_and_embedded_images_cannot_share_a_directory(self):
+        shared = self.root / "shared"
+        code, payload = self.run_cli(
+            "--path",
+            str(self.text_pdf),
+            "--rasterize-pages",
+            str(shared),
+            "--extract-images",
+            str(shared),
+        )
+        self.assertEqual(code, 1)
+        self.assertEqual(payload["error"], "bad_args")
+        self.assertIn("different", payload["message"])
+
+    def test_the_shared_directory_check_resolves_both_paths_first(self):
+        """Two spellings of ONE directory must still collide.
+
+        Comparing the raw arguments passes whenever the spellings differ but the
+        directory is the same — on macOS `/var/x` and `/private/var/x` are one
+        directory — and the result then lists every page render twice: once as a
+        page, once as an "embedded image" it never was.
+        """
+        shared = self.root / "shared-alias"
+        alias = Path(str(shared).replace("/var/", "/private/var/", 1))
+        if alias == shared:
+            self.skipTest("no symlinked temp root on this platform")
+        code, payload = self.run_cli(
+            "--path",
+            str(self.text_pdf),
+            "--rasterize-pages",
+            str(shared),
+            "--extract-images",
+            str(alias),
+        )
+        self.assertEqual(code, 1)
+        self.assertEqual(payload["error"], "bad_args")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -3291,5 +3291,300 @@ class SQLitePersistenceTests(unittest.TestCase):
         )
 
 
+class BrokerUploadCapTests(unittest.TestCase):
+    """A file the broker will never accept is caught here, by name and size."""
+
+    def setUp(self):
+        td = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, td, ignore_errors=True)
+        self.root = Path(td).resolve()
+        workspace_sync._uploaded_state.clear()
+        self.addCleanup(workspace_sync._uploaded_state.clear)
+
+    def test_a_file_over_the_broker_cap_names_itself_and_its_size(self):
+        oversized = self.root / "memory" / "huge.bin"
+        oversized.parent.mkdir(parents=True)
+        oversized.write_bytes(b"x")
+        fake_size = workspace_sync.BROKER_PRIVATE_UPLOAD_MAX_BYTES + 1
+        real_stat = os.stat
+
+        def stat_with_inflated_size(fileno):
+            result = real_stat(fileno)
+
+            class _Inflated:
+                st_size = fake_size
+                st_mode = result.st_mode
+                st_mtime_ns = result.st_mtime_ns
+                st_ctime_ns = result.st_ctime_ns
+                st_uid = result.st_uid
+                st_gid = result.st_gid
+                st_ino = result.st_ino
+                st_dev = result.st_dev
+                st_nlink = result.st_nlink
+
+            return _Inflated()
+
+        prepared = []
+
+        def open_no_follow(relative):
+            source, metadata = original_open(relative)
+            if relative == "memory/huge.bin":
+                return source, stat_with_inflated_size(source.fileno())
+            return source, metadata
+
+        original_open = workspace_sync._open_regular_no_follow
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_open_regular_no_follow",
+            side_effect=open_no_follow,
+        ), mock.patch.object(
+            workspace_sync, "_upload_spec", side_effect=lambda *a: prepared.append(a)
+        ):
+            with self.assertRaises(
+                workspace_sync.WorkspacePushIncomplete
+            ) as caught:
+                workspace_sync.push_workspace("owner")
+
+        message = str(caught.exception)
+        self.assertIn("memory/huge.bin", message)
+        self.assertIn(str(fake_size), message)
+        self.assertIn("workspace upload limit", message)
+        # Detected BEFORE the batch is built, so nothing was reserved.
+        self.assertEqual(prepared, [])
+
+    def test_the_client_cap_matches_the_broker_constant(self):
+        broker = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "lib"
+            / "agent-workspace"
+            / "storage-broker.ts"
+        )
+        self.assertIn(
+            "export const MAX_PRIVATE_UPLOAD_BYTES = 512 * 1024 * 1024",
+            broker.read_text(encoding="utf-8"),
+            "BROKER_PRIVATE_UPLOAD_MAX_BYTES drifted from the broker's cap",
+        )
+        self.assertEqual(
+            workspace_sync.BROKER_PRIVATE_UPLOAD_MAX_BYTES,
+            512 * 1024 * 1024,
+        )
+
+
+class StagedReservationReleaseTests(unittest.TestCase):
+    """An aborted batch gives its siblings' reservations back immediately."""
+
+    def test_a_staging_failure_releases_the_reservations_that_succeeded(self):
+        staged = [
+            (("/p/a", "a", 1, 0, 0, "c"), workspace_sync._PreparedWorkspaceUpload(
+                upload_url="https://example.invalid/a",
+                reservation_id="11111111-1111-4111-8111-111111111111",
+                required_headers={},
+            )),
+            (("/p/b", "b", 1, 0, 0, "c"), workspace_sync._PreparedWorkspaceUpload(
+                upload_url=None,
+                reservation_id=None,
+                required_headers={},
+                unchanged_e_tag='"unchanged"',
+            )),
+        ]
+        calls = []
+        with mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            side_effect=lambda payload, *a, **k: calls.append(payload) or {},
+        ):
+            workspace_sync._release_staged_reservations(staged)
+
+        self.assertEqual(
+            calls,
+            [
+                {
+                    "operation": "release-upload",
+                    # The unchanged entry holds no reservation, so it is not sent.
+                    "reservationIds": [
+                        "11111111-1111-4111-8111-111111111111"
+                    ],
+                }
+            ],
+        )
+
+    def test_a_release_failure_never_masks_the_real_push_error(self):
+        staged = [
+            (("/p/a", "a", 1, 0, 0, "c"), workspace_sync._PreparedWorkspaceUpload(
+                upload_url="https://example.invalid/a",
+                reservation_id="11111111-1111-4111-8111-111111111111",
+                required_headers={},
+            )),
+        ]
+        with mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            side_effect=RuntimeError("broker down"),
+        ):
+            workspace_sync._release_staged_reservations(staged)
+
+
+class TrajectoryPruneTests(unittest.TestCase):
+    """Prune only closed sessions' runtime events, and only from that table."""
+
+    def setUp(self):
+        td = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, td, ignore_errors=True)
+        self.root = Path(td).resolve()
+        self.database = self.root / "agents" / "main" / "agent" / (
+            workspace_sync.TRANSCRIPT_DB_FILENAME
+        )
+        self.database.parent.mkdir(parents=True)
+
+    def _build(self, newest_ms):
+        day_ms = 86_400_000
+        connection = sqlite3.connect(self.database)
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute(
+            "CREATE TABLE trajectory_runtime_events ("
+            "  session_id TEXT NOT NULL,"
+            "  seq INTEGER NOT NULL,"
+            "  event_json TEXT NOT NULL,"
+            "  created_at INTEGER NOT NULL)"
+        )
+        connection.execute(
+            "CREATE TABLE transcript_events ("
+            "  session_id TEXT NOT NULL,"
+            "  event_json TEXT NOT NULL,"
+            "  created_at INTEGER NOT NULL)"
+        )
+        rows = []
+        # `stale` last touched 10 days ago; `live` touched at `newest_ms`.
+        for seq in range(50):
+            rows.append(("stale", seq, "x" * 2048, newest_ms - 10 * day_ms))
+        for seq in range(5):
+            rows.append(("live", seq, "y" * 2048, newest_ms))
+        connection.executemany(
+            "INSERT INTO trajectory_runtime_events VALUES (?, ?, ?, ?)", rows
+        )
+        connection.executemany(
+            "INSERT INTO transcript_events VALUES (?, ?, ?)",
+            [("stale", "durable", newest_ms - 10 * day_ms)],
+        )
+        connection.commit()
+        connection.close()
+
+    def test_closed_sessions_are_pruned_and_recent_ones_are_kept(self):
+        newest = 1_757_000_000_000
+        self._build(newest)
+        deleted = workspace_sync._prune_trajectory_runtime_events(self.database)
+        self.assertEqual(deleted, 50)
+        connection = sqlite3.connect(self.database)
+        self.addCleanup(connection.close)
+        self.assertEqual(
+            connection.execute(
+                "SELECT DISTINCT session_id FROM trajectory_runtime_events"
+            ).fetchall(),
+            [("live",)],
+        )
+        # The durable table is untouched, including for the pruned session.
+        self.assertEqual(
+            connection.execute(
+                "SELECT COUNT(*) FROM transcript_events"
+            ).fetchone()[0],
+            1,
+        )
+        self.assertEqual(
+            str(
+                connection.execute("PRAGMA journal_mode").fetchone()[0]
+            ).lower(),
+            "wal",
+        )
+        self.assertEqual(
+            connection.execute("PRAGMA integrity_check").fetchall(),
+            [("ok",)],
+        )
+        self.assertEqual(
+            connection.execute("PRAGMA foreign_key_check").fetchall(), []
+        )
+
+    def test_a_missing_table_or_unknown_schema_prunes_nothing(self):
+        connection = sqlite3.connect(self.database)
+        connection.execute("CREATE TABLE unrelated (value TEXT)")
+        connection.commit()
+        connection.close()
+        self.assertEqual(
+            workspace_sync._prune_trajectory_runtime_events(self.database), 0
+        )
+
+        other = self.root / "agents" / "two" / "agent" / (
+            workspace_sync.TRANSCRIPT_DB_FILENAME
+        )
+        other.parent.mkdir(parents=True)
+        connection = sqlite3.connect(other)
+        connection.execute(
+            "CREATE TABLE trajectory_runtime_events (blob TEXT)"
+        )
+        connection.commit()
+        connection.close()
+        self.assertEqual(
+            workspace_sync._prune_trajectory_runtime_events(other), 0
+        )
+
+    def test_a_small_database_is_left_alone_entirely(self):
+        self._build(1_757_000_000_000)
+        calls = []
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_prune_trajectory_runtime_events",
+            side_effect=lambda *a, **k: calls.append(a) or 0,
+        ):
+            workspace_sync._prune_oversized_transcript_databases()
+        self.assertEqual(calls, [])
+
+    def test_an_oversized_database_is_pruned_by_the_finalization_sweep(self):
+        self._build(1_757_000_000_000)
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync, "TRAJECTORY_PRUNE_MIN_DB_BYTES", 1
+        ):
+            workspace_sync._prune_oversized_transcript_databases()
+        connection = sqlite3.connect(self.database)
+        self.addCleanup(connection.close)
+        self.assertEqual(
+            connection.execute(
+                "SELECT DISTINCT session_id FROM trajectory_runtime_events"
+            ).fetchall(),
+            [("live",)],
+        )
+
+    def test_a_prune_failure_never_breaks_the_snapshot(self):
+        self._build(1_757_000_000_000)
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync, "TRAJECTORY_PRUNE_MIN_DB_BYTES", 1
+        ), mock.patch.object(
+            workspace_sync,
+            "_prune_trajectory_runtime_events",
+            side_effect=RuntimeError("locked"),
+        ):
+            workspace_sync._prune_oversized_transcript_databases()
+
+    def test_a_seconds_epoch_column_is_handled_as_seconds(self):
+        self.assertEqual(
+            workspace_sync._trajectory_cutoff_value(1_757_000_000, 2),
+            1_757_000_000 - 2 * 86_400,
+        )
+        self.assertEqual(
+            workspace_sync._trajectory_cutoff_value(1_757_000_000_000, 2),
+            1_757_000_000_000 - 2 * 86_400_000,
+        )
+        for unusable in (None, 0, -1, True, "2026-09-05", 12345):
+            self.assertIsNone(
+                workspace_sync._trajectory_cutoff_value(unusable, 2)
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -20,6 +20,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -3570,6 +3571,93 @@ class TrajectoryPruneTests(unittest.TestCase):
             side_effect=RuntimeError("locked"),
         ):
             workspace_sync._prune_oversized_transcript_databases()
+
+    def test_a_skipped_vacuum_does_not_strand_the_file_forever(self):
+        """The delete commits; a later run must still be able to reclaim.
+
+        The regression this guards: VACUUM used to be gated on `deleted > 0`.
+        The DELETE is already committed by the time VACUUM runs, so any run
+        where VACUUM does not happen — it failed, or the budget ran out, or
+        (here) the freelist was not yet worth rewriting the file for — left
+        every LATER run finding 0 eligible rows, returning early, and never
+        vacuuming again. The bloated file the function exists to shrink would
+        survive forever.
+        """
+        newest = 1_757_000_000_000
+        self._build(newest)
+
+        # First run: rows are deleted, but the freelist gate declines to VACUUM.
+        with mock.patch.object(
+            workspace_sync, "TRAJECTORY_VACUUM_MIN_FREE_BYTES", 1 << 40
+        ):
+            deleted = workspace_sync._prune_trajectory_runtime_events(
+                self.database
+            )
+        self.assertEqual(deleted, 50)
+        stranded = self.database.stat().st_size
+
+        # Second run deletes nothing — the rows are already gone — but the
+        # freelist is now worth reclaiming, so it must still VACUUM and shrink.
+        with mock.patch.object(
+            workspace_sync, "TRAJECTORY_VACUUM_MIN_FREE_BYTES", 1
+        ):
+            again = workspace_sync._prune_trajectory_runtime_events(
+                self.database
+            )
+        self.assertEqual(again, 0)
+        self.assertLess(self.database.stat().st_size, stranded)
+
+    def test_an_exhausted_deadline_stops_vacuum_without_losing_the_delete(self):
+        newest = 1_757_000_000_000
+        self._build(newest)
+        # A deadline already in the past. _remaining_timeout raises TimeoutError
+        # rather than letting an unbounded VACUUM spend budget the push still
+        # needs — the prune is an optimization, the upload is the job.
+        with mock.patch.object(
+            workspace_sync, "TRAJECTORY_VACUUM_MIN_FREE_BYTES", 1
+        ), self.assertRaises(TimeoutError):
+            workspace_sync._prune_trajectory_runtime_events(
+                self.database,
+                deadline_monotonic=time.monotonic() - 1,
+            )
+        # The delete is durable regardless — it committed before the VACUUM —
+        # and the caller swallows this exception, so the turn still pushes.
+        connection = sqlite3.connect(self.database)
+        self.addCleanup(connection.close)
+        self.assertEqual(
+            connection.execute(
+                "SELECT DISTINCT session_id FROM trajectory_runtime_events"
+            ).fetchall(),
+            [("live",)],
+        )
+
+    def test_only_the_managed_agent_database_path_is_pruned(self):
+        """A basename match would rewrite look-alike files elsewhere."""
+        newest = 1_757_000_000_000
+        self._build(newest)
+        stray = self.root / "attachments" / workspace_sync.TRANSCRIPT_DB_FILENAME
+        stray.parent.mkdir(parents=True)
+        shutil.copyfile(self.database, stray)
+        before = stray.stat().st_size
+
+        opened = []
+        real_prune = workspace_sync._prune_trajectory_runtime_events
+
+        def record(database, *args, **kwargs):
+            opened.append(Path(database).resolve())
+            return real_prune(database, *args, **kwargs)
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync, "TRAJECTORY_PRUNE_MIN_DB_BYTES", 1
+        ), mock.patch.object(
+            workspace_sync, "_prune_trajectory_runtime_events", record
+        ):
+            workspace_sync._prune_oversized_transcript_databases()
+
+        self.assertEqual(opened, [self.database.resolve()])
+        self.assertEqual(stray.stat().st_size, before)
 
     def test_a_seconds_epoch_column_is_handled_as_seconds(self):
         self.assertEqual(

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -194,6 +194,21 @@ _IMAGE_WORKSPACE_SEEDS = {
 # hitting one can no longer fail a restore. See pull_workspace().
 MAX_SYNC_FILE_BYTES = 2 * 1024 * 1024 * 1024
 MAX_SYNC_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
+# The ceiling the BROKER enforces (MAX_PRIVATE_UPLOAD_BYTES in
+# lib/agent-workspace/storage-broker.ts). Distinct from MAX_SYNC_FILE_BYTES
+# above, which is a runaway-traversal backstop four times larger.
+#
+# Keeping only the backstop meant the agent happily built batches the broker
+# could never accept, with no client-side detection at all: the refusal arrived
+# per-file from the web tier as a generic staging error, the finalization
+# aborted, and the user was told to "retry after the agent service is repaired"
+# — advice that can never work, because the same oversized file is rebuilt on
+# every subsequent turn. One owner was hard-down for a day that way
+# (prod 2026-09-05). Detect it here, before the batch is built, and say which
+# file and how big it is.
+#
+# Keep in sync with MAX_PRIVATE_UPLOAD_BYTES.
+BROKER_PRIVATE_UPLOAD_MAX_BYTES = 512 * 1024 * 1024
 # Raised from 1,000 (#1353) after that cap silently destroyed a user's agent
 # memory on 2026-07-27. Real workspaces already exceed it: two of the 38 live
 # prefixes hold ~5,000 objects each. The cap is a runaway-traversal backstop,
@@ -2506,13 +2521,236 @@ def _is_managed_openclaw_sqlite(relative: str) -> bool:
     )
 
 
+# ── OpenClaw transcript-database pruning ──────────────────────────────────────
+#
+# `agents/<id>/agent/openclaw-agent.sqlite` is OpenClaw's own database and it
+# grows monotonically: nothing in OpenClaw, and nothing here, ever removed a
+# row. On 2026-09-05 one owner's file reached 268,390,400 bytes — 45,056 bytes
+# under the broker's then-256 MiB upload cap — and the workspace could never be
+# saved again. Every turn and all three of that owner's 15-minute schedules
+# failed at finalization, and two more owners were within 30 % of the same wall.
+#
+# Profiling that real database: `trajectory_runtime_events` held 128.1 MB of the
+# 268 MB in only 3,468 rows (~37 KB of `event_json` each) — 48 % of the file.
+# `transcript_events`, the table the product actually reads back, was 20.3 MB.
+# VACUUM alone reclaimed nothing (23 free pages). Deleting the runtime-event
+# rows of CLOSED sessions and vacuuming took the same file to 153,149,440 bytes
+# with `integrity_check` ok, `foreign_key_check` clean and WAL mode intact.
+#
+# So: prune ONLY `trajectory_runtime_events`, ONLY for sessions with no activity
+# in the retention window, and only once the file is actually large.
+# `transcript_events`, `session_windows`, `memory_index_chunks` and
+# `memory_embedding_cache` are never touched — they are durable history and
+# recall, not per-turn runtime tracing.
+def _positive_int_env(name: str, default: int) -> int:
+    """Read a positive integer override, falling back on anything malformed."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+TRANSCRIPT_DB_FILENAME = "openclaw-agent.sqlite"
+TRAJECTORY_EVENTS_TABLE = "trajectory_runtime_events"
+# Prune only once the file is big enough to be worth the VACUUM. Comfortably
+# under the old 256 MiB cliff, so a workspace approaching trouble is trimmed
+# well before it can reach the current 512 MiB ceiling.
+TRAJECTORY_PRUNE_MIN_DB_BYTES = _positive_int_env(
+    "OPENCLAW_TRAJECTORY_PRUNE_MIN_DB_BYTES", 192 * 1024 * 1024
+)
+# Keep every session that did anything inside this window, including the one
+# this very turn belongs to. Two days was the value validated against the real
+# database above.
+TRAJECTORY_PRUNE_KEEP_DAYS = _positive_int_env(
+    "OPENCLAW_TRAJECTORY_PRUNE_KEEP_DAYS", 2
+)
+# Pruning is an optimization on the finalization path, which is already inside a
+# hard flush deadline. Bound it so a pathological VACUUM cannot eat the budget
+# that the actual upload needs.
+TRAJECTORY_PRUNE_TIMEOUT_SECONDS = 60
+# Candidate activity columns, most authoritative first. The column set is
+# DISCOVERED rather than assumed: an OpenClaw upgrade that renames or drops one
+# must make this skip, never make it delete the wrong rows.
+_TRAJECTORY_SESSION_COLUMNS = ("session_id", "sessionId")
+_TRAJECTORY_TIME_COLUMNS = ("created_at", "createdAt", "timestamp", "ts")
+
+
+def _first_present(candidates: tuple, available: set) -> str | None:
+    for name in candidates:
+        if name in available:
+            return name
+    return None
+
+
+def _trajectory_cutoff_value(newest: object, keep_days: int) -> int | None:
+    """Convert the table's own newest timestamp into a cutoff in its own units.
+
+    The column is an integer epoch, but OpenClaw has shipped both seconds and
+    milliseconds. Rather than guess from a constant, derive the unit from the
+    magnitude of the newest value the table actually holds, and refuse to prune
+    anything that is not a plain positive integer.
+    """
+    if isinstance(newest, bool) or not isinstance(newest, int) or newest <= 0:
+        return None
+    if newest >= 10**12:
+        window = keep_days * 86_400_000
+    elif newest >= 10**9:
+        window = keep_days * 86_400
+    else:
+        # Neither a seconds nor a milliseconds epoch. Unknown unit: do nothing.
+        return None
+    return newest - window
+
+
+def _prune_trajectory_runtime_events(
+    database: Path,
+    keep_days: int = TRAJECTORY_PRUNE_KEEP_DAYS,
+) -> int:
+    """Delete closed sessions' runtime-event rows, then VACUUM. Best-effort.
+
+    Returns the number of rows deleted (0 when nothing was eligible or the
+    schema did not match what this function knows how to prune safely).
+
+    The gateway MUST already be stopped — this runs from
+    prepare_sqlite_snapshot(), after adapter.shutdown().
+    """
+    with closing(
+        sqlite3.connect(
+            f"{database.as_uri()}?mode=rw",
+            uri=True,
+            timeout=TRAJECTORY_PRUNE_TIMEOUT_SECONDS,
+        )
+    ) as connection:
+        table = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (TRAJECTORY_EVENTS_TABLE,),
+        ).fetchone()
+        if table is None:
+            return 0
+        columns = {
+            str(row[1])
+            for row in connection.execute(
+                f'PRAGMA table_info("{TRAJECTORY_EVENTS_TABLE}")'
+            ).fetchall()
+        }
+        session_column = _first_present(_TRAJECTORY_SESSION_COLUMNS, columns)
+        time_column = _first_present(_TRAJECTORY_TIME_COLUMNS, columns)
+        if session_column is None or time_column is None:
+            logger.info(
+                "trajectory prune skipped — %s lacks a session/time column",
+                TRAJECTORY_EVENTS_TABLE,
+            )
+            return 0
+
+        # Identifiers are interpolated; every one of them came from
+        # sqlite_master/table_info and was matched against a fixed tuple of
+        # literals above, so no caller-controlled text reaches the SQL text.
+        newest = connection.execute(
+            f'SELECT MAX("{time_column}") FROM "{TRAJECTORY_EVENTS_TABLE}"'
+        ).fetchone()[0]
+        cutoff = _trajectory_cutoff_value(newest, keep_days)
+        if cutoff is None:
+            logger.info(
+                "trajectory prune skipped — %s.%s is not an epoch integer",
+                TRAJECTORY_EVENTS_TABLE,
+                time_column,
+            )
+            return 0
+
+        # Foreign keys ON so a row some other table depends on makes this raise
+        # and abandon the prune, rather than silently orphaning a reference.
+        connection.execute("PRAGMA foreign_keys=ON")
+        # Delete by SESSION, not by row age: a long-running session's early
+        # events stay with its recent ones, and any session that did anything
+        # inside the window is kept whole.
+        cursor = connection.execute(
+            f'DELETE FROM "{TRAJECTORY_EVENTS_TABLE}" '
+            f'WHERE "{session_column}" IN ('
+            f'  SELECT "{session_column}" FROM "{TRAJECTORY_EVENTS_TABLE}"'
+            f'  GROUP BY "{session_column}"'
+            f'  HAVING MAX("{time_column}") < ?'
+            f")",
+            (cutoff,),
+        )
+        deleted = cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
+        connection.commit()
+        if deleted == 0:
+            return 0
+        violations = connection.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise RuntimeError(
+                f"trajectory prune left {len(violations)} foreign-key violation(s)"
+            )
+        # Reclaim the pages. Without this the DELETE only moves bytes onto the
+        # freelist and the FILE — which is what the upload cap measures — does
+        # not shrink at all.
+        connection.isolation_level = None
+        connection.execute("VACUUM")
+        mode = connection.execute("PRAGMA journal_mode").fetchone()
+        if mode is None or str(mode[0]).lower() != "wal":
+            raise RuntimeError(
+                "trajectory prune did not preserve WAL journal mode"
+            )
+    return deleted
+
+
+def _prune_oversized_transcript_databases() -> None:
+    """Trim any agent transcript database that has grown large. Never raises."""
+    for relative in _iter_workspace_files():
+        if os.path.basename(relative) != TRANSCRIPT_DB_FILENAME:
+            continue
+        database = WORKSPACE_DIR / relative
+        try:
+            size_before = database.stat().st_size
+        except OSError:
+            continue
+        if size_before < TRAJECTORY_PRUNE_MIN_DB_BYTES:
+            continue
+        try:
+            deleted = _prune_trajectory_runtime_events(database)
+        except Exception as exc:  # noqa: BLE001
+            # A prune failure must never block the save it exists to protect.
+            # The checkpoint + integrity_check below still gate the push.
+            logger.warning(
+                "trajectory prune failed for %s: %s", relative, exc
+            )
+            continue
+        if deleted == 0:
+            logger.info(
+                "trajectory prune found nothing eligible in %s (%d bytes)",
+                relative,
+                size_before,
+            )
+            continue
+        try:
+            size_after = database.stat().st_size
+        except OSError:
+            size_after = size_before
+        logger.info(
+            "trajectory prune %s: rows=%d bytes %d -> %d",
+            relative,
+            deleted,
+            size_before,
+            size_after,
+        )
+
+
 def prepare_sqlite_snapshot() -> int:
     """Checkpoint and validate every persisted OpenClaw database.
 
     The gateway MUST be stopped before this runs. A failed checkpoint or
     integrity check aborts the subsequent push, preserving the last known-good
     remote database rather than replacing it with a torn generation.
+
+    Oversized transcript databases are pruned FIRST, so the checkpoint and
+    integrity check below validate the file that is actually about to be
+    uploaded rather than the pre-prune one.
     """
+    _prune_oversized_transcript_databases()
     candidates = sorted(
         WORKSPACE_DIR / relative
         for relative in _iter_workspace_files()
@@ -2900,6 +3138,58 @@ def _legacy_finalize_pending_atomic_workspace(
     return current_generation
 
 
+# One release call carries at most this many ids, matching the broker's
+# MAX_RELEASE_UPLOAD_ITEMS. A larger batch is chunked rather than rejected.
+RELEASE_RESERVATION_BATCH = 250
+
+
+def _release_staged_reservations(
+    staged: list,
+    deadline_monotonic: float | None = None,
+) -> None:
+    """Abandon the reservations of a finalization batch that will not commit.
+
+    A workspace push is atomic: every changed file is reserved and staged, then
+    the whole set is committed together. When one file is refused the batch is
+    dead — but its SIBLINGS' rows stay `reserved` for the full five-minute
+    lease, and the broker's partial unique index
+    `uq_workspace_upload_target_active (owner_key, target_key)` then rejects the
+    retry's reservation for those very same paths. The natural recovery — run
+    the turn again — therefore failed in ~30 ms with an opaque `Failed query`
+    until the TTL ran out (prod 2026-09-05).
+
+    Best-effort by contract. The reservations expire on their own regardless, so
+    a failure here must never replace the real, actionable push error with a
+    cleanup error.
+    """
+    reservation_ids = [
+        prepared.reservation_id
+        for _pair, prepared in staged
+        if getattr(prepared, "reservation_id", None)
+        and prepared.unchanged_e_tag is None
+    ]
+    if not reservation_ids:
+        return
+    for start in range(0, len(reservation_ids), RELEASE_RESERVATION_BATCH):
+        chunk = reservation_ids[start:start + RELEASE_RESERVATION_BATCH]
+        try:
+            _broker_request(
+                {"operation": "release-upload", "reservationIds": chunk},
+                deadline_monotonic,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "workspace push could not release %d staged reservation(s): %s",
+                len(chunk),
+                exc,
+            )
+            return
+    logger.info(
+        "workspace push released %d staged reservation(s) after abort",
+        len(reservation_ids),
+    )
+
+
 def push_workspace(
     prefix: str,
     deadline_monotonic: float | None = None,
@@ -2940,6 +3230,21 @@ def push_workspace(
         except OSError as exc:
             logger.warning("workspace push skip unsafe file %s: %s", relative, exc)
             preparation_errors.append(f"{relative}: {exc}")
+            continue
+        if metadata.st_size > BROKER_PRIVATE_UPLOAD_MAX_BYTES:
+            source.close()
+            # Named and sized deliberately: this error text is what reaches the
+            # user, and "retry later" is wrong advice for a file that will be
+            # exactly as large next turn.
+            logger.warning(
+                "workspace push skip file over broker cap %s (%d bytes)",
+                relative,
+                metadata.st_size,
+            )
+            preparation_errors.append(
+                f"{relative}: {metadata.st_size} bytes exceeds the "
+                f"{BROKER_PRIVATE_UPLOAD_MAX_BYTES}-byte workspace upload limit"
+            )
             continue
         if metadata.st_size > MAX_SYNC_FILE_BYTES:
             source.close()
@@ -2999,9 +3304,14 @@ def push_workspace(
             to_upload.append(upload)
 
     if preparation_errors:
+        # Carry the per-file detail, not just a count. The count alone is what
+        # produced the unactionable "retry after the agent service is repaired"
+        # message an owner saw for a day while one over-cap file blocked every
+        # save (prod 2026-09-05).
         raise WorkspacePushIncomplete(
             f"workspace push incomplete ({len(preparation_errors)} file "
-            f"error(s)) for prefix {prefix}"
+            f"error(s)) for prefix {prefix}: "
+            + "; ".join(preparation_errors[:5])
         )
 
     current_generation = expected_generation
@@ -3338,9 +3648,10 @@ def push_workspace(
                 logger.warning("workspace push stage skip %s", error)
                 stage_errors.append(error)
     if stage_errors:
+        _release_staged_reservations(staged, deadline_monotonic)
         raise WorkspacePushIncomplete(
             f"workspace push incomplete ({len(stage_errors)} file error(s)) "
-            f"for prefix {prefix}"
+            f"for prefix {prefix}: " + "; ".join(stage_errors[:5])
         )
     # Stage the migration marker last. Atomic-capable brokers promote this
     # reservation in the same checkpoint as every database/state object; the
@@ -3350,6 +3661,7 @@ def push_workspace(
             marker_upload
         )
         if marker_error is not None or marker_prepared is None:
+            _release_staged_reservations(staged, deadline_monotonic)
             raise WorkspacePushIncomplete(
                 "workspace push incomplete (migration marker stage failed) "
                 f"for prefix {prefix}: {marker_error or 'unknown error'}"

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -208,6 +208,14 @@ MAX_SYNC_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
 # file and how big it is.
 #
 # Keep in sync with MAX_PRIVATE_UPLOAD_BYTES.
+#
+# DEPLOY ORDER IS LOAD-BEARING: the web tier must ship a raise BEFORE this image
+# does. These are two independently deployed units, and this value is only ever
+# safe when it is <= the broker's. Ship the agent first and the pre-check below
+# passes a file the broker still refuses at the old ceiling — reproducing the
+# exact opaque outage this constant exists to prevent, for the whole rollout
+# window. Lowering works in the other order: a stale, smaller value here is
+# merely conservative and rejects early with a clear message.
 BROKER_PRIVATE_UPLOAD_MAX_BYTES = 512 * 1024 * 1024
 # Raised from 1,000 (#1353) after that cap silently destroyed a user's agent
 # memory on 2026-07-27. Real workspaces already exceed it: two of the 38 live
@@ -2570,8 +2578,14 @@ TRAJECTORY_PRUNE_KEEP_DAYS = _positive_int_env(
 )
 # Pruning is an optimization on the finalization path, which is already inside a
 # hard flush deadline. Bound it so a pathological VACUUM cannot eat the budget
-# that the actual upload needs.
+# that the actual upload needs. This is enforced with a progress handler, NOT
+# with sqlite3.connect(timeout=...) — that argument only bounds how long a
+# statement waits to acquire a lock, never how long one runs.
 TRAJECTORY_PRUNE_TIMEOUT_SECONDS = 60
+# Only rewrite the whole file when there is real space to win. VACUUM copies the
+# database, so running it to reclaim a few pages costs far more (time, and
+# transient disk equal to the file's own size) than it returns.
+TRAJECTORY_VACUUM_MIN_FREE_BYTES = 16 * 1024 * 1024
 # Candidate activity columns, most authoritative first. The column set is
 # DISCOVERED rather than assumed: an OpenClaw upgrade that renames or drops one
 # must make this skip, never make it delete the wrong rows.
@@ -2609,6 +2623,7 @@ def _trajectory_cutoff_value(newest: object, keep_days: int) -> int | None:
 def _prune_trajectory_runtime_events(
     database: Path,
     keep_days: int = TRAJECTORY_PRUNE_KEEP_DAYS,
+    deadline_monotonic: float | None = None,
 ) -> int:
     """Delete closed sessions' runtime-event rows, then VACUUM. Best-effort.
 
@@ -2661,8 +2676,8 @@ def _prune_trajectory_runtime_events(
             )
             return 0
 
-        # Foreign keys ON so a row some other table depends on makes this raise
-        # and abandon the prune, rather than silently orphaning a reference.
+        # Foreign keys ON so a row some other table depends on aborts the prune
+        # rather than silently orphaning a reference.
         connection.execute("PRAGMA foreign_keys=ON")
         # Delete by SESSION, not by row age: a long-running session's early
         # events stay with its recent ones, and any session that did anything
@@ -2677,19 +2692,62 @@ def _prune_trajectory_runtime_events(
             (cutoff,),
         )
         deleted = cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
-        connection.commit()
-        if deleted == 0:
-            return 0
+        # Check BEFORE committing. Run after commit this proves nothing: the
+        # rows are already durably gone, so raising can only stop the VACUUM,
+        # not undo the damage it is supposed to be protecting against.
         violations = connection.execute("PRAGMA foreign_key_check").fetchall()
         if violations:
+            connection.rollback()
             raise RuntimeError(
-                f"trajectory prune left {len(violations)} foreign-key violation(s)"
+                f"trajectory prune would leave {len(violations)} "
+                "foreign-key violation(s); rolled back"
             )
-        # Reclaim the pages. Without this the DELETE only moves bytes onto the
-        # freelist and the FILE — which is what the upload cap measures — does
-        # not shrink at all.
+        connection.commit()
+
+        # VACUUM on its own schedule, NOT gated on `deleted`. The delete is
+        # already committed by this point, so a VACUUM that fails once (disk
+        # pressure, a lock, an exhausted deadline) must not strand the file
+        # forever: on the next turn the same rows are already gone, `deleted`
+        # comes back 0, and an early return here would skip the VACUUM for
+        # good — leaving the bloated file that this whole function exists to
+        # shrink. Freelist pages are the real signal that bytes are reclaimable.
+        page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
+        free_pages = int(connection.execute("PRAGMA freelist_count").fetchone()[0])
+        if free_pages * page_size < TRAJECTORY_VACUUM_MIN_FREE_BYTES:
+            return deleted
+
+        # Bound the VACUUM for real. `sqlite3.connect(timeout=...)` is the
+        # BUSY-handler timeout — how long a statement waits to ACQUIRE a lock —
+        # and places no cap whatever on how long VACUUM runs once it starts.
+        # The progress handler is the only in-process way to abort a running
+        # statement, so the deadline is enforced there.
+        vacuum_deadline = time.monotonic() + _remaining_timeout(
+            deadline_monotonic, TRAJECTORY_PRUNE_TIMEOUT_SECONDS
+        )
+
+        def _abort_when_out_of_time() -> int:
+            # Non-zero aborts the running statement with sqlite3.OperationalError.
+            return 1 if time.monotonic() > vacuum_deadline else 0
+
         connection.isolation_level = None
-        connection.execute("VACUUM")
+        connection.set_progress_handler(_abort_when_out_of_time, 10_000)
+        try:
+            connection.execute("VACUUM")
+        except sqlite3.OperationalError as exc:
+            # Out of budget, or the file could not be rewritten. The delete
+            # stands and is durable; the file simply keeps its freelist until
+            # a later turn reaches this point with more time. Deliberately not
+            # fatal — the caller still has an upload to get through.
+            connection.set_progress_handler(None, 0)
+            logger.warning(
+                "trajectory prune deleted %d row(s) but could not VACUUM %s: %s",
+                deleted,
+                database.name,
+                exc,
+            )
+            return deleted
+        finally:
+            connection.set_progress_handler(None, 0)
         mode = connection.execute("PRAGMA journal_mode").fetchone()
         if mode is None or str(mode[0]).lower() != "wal":
             raise RuntimeError(
@@ -2698,20 +2756,33 @@ def _prune_trajectory_runtime_events(
     return deleted
 
 
-def _prune_oversized_transcript_databases() -> None:
+def _prune_oversized_transcript_databases(
+    deadline_monotonic: float | None = None,
+) -> None:
     """Trim any agent transcript database that has grown large. Never raises."""
+    workspace_root = WORKSPACE_DIR.resolve()
     for relative in _iter_workspace_files():
-        if os.path.basename(relative) != TRANSCRIPT_DB_FILENAME:
+        # Match the SAME predicate prepare_sqlite_snapshot() uses, not just the
+        # basename. A basename match would open and rewrite any file called
+        # openclaw-agent.sqlite anywhere in the tree — including under
+        # attachments/, which _iter_workspace_files does traverse — rather than
+        # only the managed agents/<id>/agent/ database this knows how to prune.
+        if not _is_managed_openclaw_sqlite(relative):
             continue
         database = WORKSPACE_DIR / relative
         try:
+            # Re-resolve and re-anchor before opening rw, the same way
+            # prepare_sqlite_snapshot does for this file class.
+            database.resolve().relative_to(workspace_root)
             size_before = database.stat().st_size
-        except OSError:
+        except (OSError, ValueError):
             continue
         if size_before < TRAJECTORY_PRUNE_MIN_DB_BYTES:
             continue
         try:
-            deleted = _prune_trajectory_runtime_events(database)
+            deleted = _prune_trajectory_runtime_events(
+                database, deadline_monotonic=deadline_monotonic
+            )
         except Exception as exc:  # noqa: BLE001
             # A prune failure must never block the save it exists to protect.
             # The checkpoint + integrity_check below still gate the push.
@@ -2719,17 +2790,14 @@ def _prune_oversized_transcript_databases() -> None:
                 "trajectory prune failed for %s: %s", relative, exc
             )
             continue
-        if deleted == 0:
-            logger.info(
-                "trajectory prune found nothing eligible in %s (%d bytes)",
-                relative,
-                size_before,
-            )
-            continue
         try:
             size_after = database.stat().st_size
         except OSError:
             size_after = size_before
+        # Reported even when deleted == 0: a run that deletes nothing can still
+        # have reclaimed a previous run's freelist, and "0 rows but 40 MB
+        # smaller" is exactly the recovery-after-a-failed-VACUUM case that is
+        # worth being able to see in the logs.
         logger.info(
             "trajectory prune %s: rows=%d bytes %d -> %d",
             relative,
@@ -2739,7 +2807,7 @@ def _prune_oversized_transcript_databases() -> None:
         )
 
 
-def prepare_sqlite_snapshot() -> int:
+def prepare_sqlite_snapshot(deadline_monotonic: float | None = None) -> int:
     """Checkpoint and validate every persisted OpenClaw database.
 
     The gateway MUST be stopped before this runs. A failed checkpoint or
@@ -2749,8 +2817,13 @@ def prepare_sqlite_snapshot() -> int:
     Oversized transcript databases are pruned FIRST, so the checkpoint and
     integrity check below validate the file that is actually about to be
     uploaded rather than the pre-prune one.
+
+    `deadline_monotonic` MUST be the same deadline the following push is held
+    to. The prune runs before the upload but inside the one flush budget, so
+    passing None here lets a slow VACUUM spend time the push then no longer
+    has — the caller computes the deadline first and threads it through.
     """
-    _prune_oversized_transcript_databases()
+    _prune_oversized_transcript_databases(deadline_monotonic)
     candidates = sorted(
         WORKSPACE_DIR / relative
         for relative in _iter_workspace_files()
@@ -3178,8 +3251,18 @@ def _release_staged_reservations(
                 deadline_monotonic,
             )
         except Exception as exc:  # noqa: BLE001
+            # Stop after the first failing chunk rather than hammering a broker
+            # that is already refusing, and rather than spending a finalization
+            # deadline that the real error still has to be reported within.
+            # A 400 here specifically means the web tier predates `release-upload`
+            # (same two-unit deploy-order note as BROKER_PRIVATE_UPLOAD_MAX_BYTES):
+            # harmless, but until it catches up the siblings hold their rows for
+            # the full lease, which is the behaviour this call exists to shorten.
+            # Anything unreleased simply expires on its own five-minute lease,
+            # which is the pre-existing behaviour this is an improvement on.
             logger.warning(
-                "workspace push could not release %d staged reservation(s): %s",
+                "workspace push could not release %d staged reservation(s); "
+                "abandoning the rest to their lease: %s",
                 len(chunk),
                 exc,
             )

--- a/infra/lambdas/agent-cron/run-telemetry.test.ts
+++ b/infra/lambdas/agent-cron/run-telemetry.test.ts
@@ -138,6 +138,55 @@ describe('recordRun contention settling', () => {
     ]);
   });
 
+  it('does not settle a skipped or promoted fire', async () => {
+    // Neither status is proof this occurrence did the work: `skipped` is a
+    // coalesced fire and `promoted` was handed to the job runner. Settling on
+    // either would acknowledge a live contention row for a fire that never ran.
+    for (const status of ['skipped', 'promoted'] as const) {
+      const client = recordingClient();
+
+      await createRunTelemetry(CONFIG, client).recordRun(
+        run({ status }),
+        logger(),
+      );
+
+      expect(settleStatements(client)).toHaveLength(0);
+    }
+  });
+
+  it('re-opens a settled row when the same fire later fails for real', async () => {
+    // One fire_key can be delivered twice: Scheduler retries while a slow
+    // invocation still holds the owner workspace lock. The retry can succeed
+    // and settle the row BEFORE the original invocation fails for real. If the
+    // upsert then overwrote the row's error text without clearing the
+    // acknowledgement, the new failure would be written into a row that stays
+    // acknowledged = TRUE and never appears in an unacknowledged-failures view
+    // again -- the exact burial the settle path exists to prevent.
+    const client = recordingClient();
+    const telemetry = createRunTelemetry(CONFIG, client);
+
+    await telemetry.recordRun(run(), logger());
+    expect(settleStatements(client)).toHaveLength(1);
+
+    await telemetry.recordRun(
+      run({
+        status: 'error',
+        errorMessage: 'workspace finalization failed',
+        failure: { severity: 'error', context: { phase: 'scheduled-run' } },
+      }),
+      logger(),
+    );
+
+    const upserts = client.statements.filter((statement) =>
+      statement.sql.includes('ON CONFLICT (source, fire_key)'),
+    );
+    expect(upserts).not.toHaveLength(0);
+    const reopening = upserts.at(-1)!.sql;
+    expect(reopening).toContain('acknowledged = FALSE');
+    expect(reopening).toContain('acknowledged_by = NULL');
+    expect(reopening).toContain('acknowledged_at = NULL');
+  });
+
   it('settles from the strict recorder too', async () => {
     const client = recordingClient();
 

--- a/infra/lambdas/agent-cron/run-telemetry.test.ts
+++ b/infra/lambdas/agent-cron/run-telemetry.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  createRunTelemetry,
+  settleCronFireFailure,
+  type RunTelemetryConfig,
+  type ScheduledRunRecord,
+} from './run-telemetry';
+
+const CONFIG: RunTelemetryConfig = {
+  databaseResourceArn: 'arn:aws:rds:us-east-1:1:cluster:agent',
+  databaseSecretArn: 'arn:aws:secretsmanager:us-east-1:1:secret:agent',
+  databaseName: 'aistudio',
+};
+
+const FIRE_KEY = 'schedule-1#2026-09-05T05:45:00Z';
+
+function recordingClient(failOn?: (sql: string) => boolean) {
+  const statements: Array<{ sql: string; parameters: unknown }> = [];
+  return {
+    statements,
+    async execute(input: { sql?: string; parameters?: unknown }) {
+      const sql = String(input.sql ?? '');
+      statements.push({ sql, parameters: input.parameters });
+      if (failOn?.(sql)) throw new Error('rds unavailable');
+      return {};
+    },
+  };
+}
+
+function logger() {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  return {
+    warnings,
+    errors,
+    warn: (message: string) => void warnings.push(message),
+    error: (message: string) => void errors.push(message),
+  };
+}
+
+function run(overrides: Partial<ScheduledRunRecord> = {}): ScheduledRunRecord {
+  return {
+    userEmail: 'owner@psd401.net',
+    scheduleId: 'schedule-1',
+    scheduleName: 'ParentSquare Daily Summary',
+    sessionId: 'session-1',
+    inputTokens: 10,
+    outputTokens: 20,
+    latencyMs: 100,
+    status: 'success',
+    fireKey: FIRE_KEY,
+    ...overrides,
+  };
+}
+
+function settleStatements(client: ReturnType<typeof recordingClient>) {
+  return client.statements.filter((statement) =>
+    statement.sql.includes("acknowledged_by = 'system:fire-succeeded'"),
+  );
+}
+
+describe('settleCronFireFailure', () => {
+  it('acknowledges only this fire, and only while it is unacknowledged', async () => {
+    const client = recordingClient();
+
+    await settleCronFireFailure(CONFIG, client, { fireKey: FIRE_KEY });
+
+    expect(client.statements).toHaveLength(1);
+    const [statement] = client.statements;
+    expect(statement.sql).toContain("source = 'cron'");
+    expect(statement.sql).toContain('fire_key = :fire_key');
+    expect(statement.sql).toContain('acknowledged = FALSE');
+    expect(statement.parameters).toEqual([
+      { name: 'fire_key', value: { stringValue: FIRE_KEY } },
+    ]);
+  });
+
+  it('refuses to run without a configured database', async () => {
+    await expect(
+      settleCronFireFailure(
+        { ...CONFIG, databaseResourceArn: '' },
+        recordingClient(),
+        { fireKey: FIRE_KEY },
+      ),
+    ).rejects.toThrow('not configured');
+  });
+});
+
+describe('recordRun contention settling', () => {
+  it('settles the fire’s contention row once the fire succeeds', async () => {
+    const client = recordingClient();
+    const log = logger();
+
+    await createRunTelemetry(CONFIG, client).recordRun(run(), log);
+
+    expect(settleStatements(client)).toHaveLength(1);
+    expect(log.warnings).toEqual([]);
+  });
+
+  it('leaves unresolved contention visible when the fire itself failed', async () => {
+    const client = recordingClient();
+    const log = logger();
+
+    await createRunTelemetry(CONFIG, client).recordRun(
+      run({
+        status: 'error',
+        errorMessage:
+          'Owner workspace is active for another schedule; retrying this fire',
+        failure: { severity: 'warn', context: { phase: 'schedule-fire' } },
+      }),
+      log,
+    );
+
+    expect(settleStatements(client)).toHaveLength(0);
+  });
+
+  it('does nothing for a fire with no Scheduler occurrence identity', async () => {
+    const client = recordingClient();
+
+    await createRunTelemetry(CONFIG, client).recordRun(
+      run({ fireKey: undefined }),
+      logger(),
+    );
+
+    expect(settleStatements(client)).toHaveLength(0);
+  });
+
+  it('never turns a settle failure into a failed run', async () => {
+    const client = recordingClient((sql) =>
+      sql.includes("acknowledged_by = 'system:fire-succeeded'"),
+    );
+    const log = logger();
+
+    await createRunTelemetry(CONFIG, client).recordRun(run(), log);
+
+    expect(log.warnings).toEqual([
+      'Failed to settle the contention row for a succeeded fire',
+    ]);
+  });
+
+  it('settles from the strict recorder too', async () => {
+    const client = recordingClient();
+
+    await createRunTelemetry(CONFIG, client).recordRunStrict(run(), logger());
+
+    expect(settleStatements(client)).toHaveLength(1);
+  });
+});

--- a/infra/lambdas/agent-cron/run-telemetry.ts
+++ b/infra/lambdas/agent-cron/run-telemetry.ts
@@ -551,6 +551,51 @@ export async function settlePromotedTurnFailure(
   });
 }
 
+/**
+ * Settle the contention row a fire left behind once that same fire succeeds.
+ *
+ * Every schedule an owner has shares ONE workspace lock, so schedules on the
+ * same cadence contend by design: `schedule-fire.ts` records
+ * "Owner workspace is active for another schedule; retrying this fire" and the
+ * retry then works. One owner with three schedules all firing every 15 minutes
+ * produced ~192 of those warn rows a day, which buried the real failures they
+ * sit next to in the operator feed.
+ *
+ * The failure insert already upserts on `(source, fire_key)`, so there is at
+ * most one row per Scheduler occurrence: when that occurrence finally
+ * succeeds, this acknowledges exactly that row. Contention that never resolves
+ * writes a row that nothing settles, so it stays visible — which is the whole
+ * point of recording it.
+ *
+ * Deliberately NOT bounded by a time window, unlike settlePromotedTurnFailure:
+ * `fire_key` is a unique Scheduler occurrence identity, not a reused session
+ * id, so it cannot match an unrelated failure however long the retries took.
+ */
+export async function settleCronFireFailure(
+  config: RunTelemetryConfig,
+  rdsDataClient: RunTelemetryRdsClient,
+  params: { fireKey: string },
+): Promise<void> {
+  if (!config.databaseResourceArn || !config.databaseSecretArn) {
+    throw new Error('Cron failure telemetry database is not configured');
+  }
+  await rdsDataClient.execute({
+    resourceArn: config.databaseResourceArn,
+    secretArn: config.databaseSecretArn,
+    database: config.databaseName,
+    sql: `UPDATE agent_failures
+             SET acknowledged = TRUE,
+                 acknowledged_by = 'system:fire-succeeded',
+                 acknowledged_at = NOW(),
+                 context = COALESCE(context, '{}'::jsonb)
+                           || '{"settledByLaterSuccess":true}'::jsonb
+           WHERE source = 'cron'
+             AND fire_key = :fire_key
+             AND acknowledged = FALSE`,
+    parameters: [{ name: 'fire_key', value: { stringValue: params.fireKey } }],
+  });
+}
+
 type CronFailureRecorder = (
   params: CronFailureRecord,
   log: CronTelemetryLogger,
@@ -674,6 +719,34 @@ export function createRunTelemetry(
     recordCronFailure,
   );
 
+  /**
+   * Acknowledge this fire's own failure row now that the fire has succeeded.
+   *
+   * Best-effort: a settle that cannot run leaves a stale warn row, which is a
+   * noisy feed, not a broken run. It must never turn a successful scheduled
+   * turn into a reported failure.
+   */
+  async function settleSucceededFire(
+    params: ScheduledRunRecord,
+    log: CronTelemetryLogger,
+  ): Promise<void> {
+    if (!databaseConfigured) return;
+    if (params.status === 'error' || params.failure) return;
+    if (!params.fireKey) return;
+    try {
+      await settleCronFireFailure(config, rdsDataClient, {
+        fireKey: params.fireKey,
+      });
+    } catch (error) {
+      log.warn('Failed to settle the contention row for a succeeded fire', {
+        scheduleId: params.scheduleId,
+        error: sanitizeDiagnostic(
+          error instanceof Error ? error.message : String(error),
+        ),
+      });
+    }
+  }
+
   async function recordRun(
     params: ScheduledRunRecord,
     log: CronTelemetryLogger,
@@ -714,6 +787,7 @@ export function createRunTelemetry(
       }
     }
 
+    await settleSucceededFire(params, log);
   }
 
   async function recordRunStrict(
@@ -736,6 +810,9 @@ export function createRunTelemetry(
       );
     }
     await writeScheduledRun(config, rdsDataClient, params);
+    // Strict callers still get a best-effort settle: the run itself succeeded,
+    // and a stale contention row must not fail it.
+    await settleSucceededFire(params, log);
   }
 
   return {

--- a/infra/lambdas/agent-cron/run-telemetry.ts
+++ b/infra/lambdas/agent-cron/run-telemetry.ts
@@ -485,7 +485,19 @@ export async function writeCronFailure(
               session_id = EXCLUDED.session_id,
               schedule_name = EXCLUDED.schedule_name,
               error_message = EXCLUDED.error_message,
-              context = EXCLUDED.context`,
+              context = EXCLUDED.context,
+              -- Re-open a row that settleCronFireFailure already acknowledged.
+              -- One fire_key can be delivered twice (Scheduler retries while a
+              -- slow invocation is still holding the owner workspace lock), so
+              -- the order success-then-real-failure is reachable: the retry
+              -- succeeds and settles the row, then the original invocation
+              -- fails for real and lands here. Without this reset the new error
+              -- text is written into a row that stays acknowledged = TRUE, and
+              -- every "unacknowledged failures" view silently loses it — the
+              -- exact burial this settle path was added to prevent.
+              acknowledged = FALSE,
+              acknowledged_by = NULL,
+              acknowledged_at = NULL`,
       parameters: [
         { name: 'severity', value: { stringValue: severity } },
         { name: 'user_id', value: { stringValue: params.userEmail } },
@@ -731,7 +743,13 @@ export function createRunTelemetry(
     log: CronTelemetryLogger,
   ): Promise<void> {
     if (!databaseConfigured) return;
-    if (params.status === 'error' || params.failure) return;
+    // Positive test, not "anything that isn't an error". `skipped` (coalesced
+    // fire) and `promoted` (handed off to the job runner) are BOTH reachable
+    // without a `failure` object, and neither is proof this occurrence did the
+    // work — settling on them would acknowledge a live contention row for a
+    // fire that never actually ran.
+    if (params.status !== 'success') return;
+    if (params.failure) return;
     if (!params.fireKey) return;
     try {
       await settleCronFireFailure(config, rdsDataClient, {

--- a/lib/agent-credentials/owner-operation-broker.ts
+++ b/lib/agent-credentials/owner-operation-broker.ts
@@ -1222,6 +1222,34 @@ const FRESHSERVICE_ROUTES: ReadonlyArray<{
     build: (id) => `/workspaces/${id}`,
   },
   { method: "GET", pattern: /^\/approvals$/, build: () => "/approvals" },
+  // Service Catalog. A caller asked the agent to create a catalog item
+  // ("Student Travel — Hotel Reservations", with custom required fields) on
+  // 2026-08-31; the skill covered only tickets, notes and approvals, so the
+  // agent searched, found nothing, and offered a plain ticket instead.
+  //
+  // Note the path asymmetry, which is Freshservice's and not a typo here:
+  // reads live under `/service_catalog/...` while the create verb is the
+  // top-level `/service_catalog_items`. Each is written out literally below.
+  {
+    method: "GET",
+    pattern: /^\/service_catalog\/items$/,
+    build: () => "/service_catalog/items",
+  },
+  {
+    method: "GET",
+    pattern: /^\/service_catalog\/items\/(\d+)$/,
+    build: (id) => `/service_catalog/items/${id}`,
+  },
+  {
+    method: "GET",
+    pattern: /^\/service_catalog\/categories$/,
+    build: () => "/service_catalog/categories",
+  },
+  {
+    method: "POST",
+    pattern: /^\/service_catalog_items$/,
+    build: () => "/service_catalog_items",
+  },
 ]
 
 /** Query keys the skill actually sends, with the value charset each may use. */
@@ -1238,6 +1266,9 @@ const FRESHSERVICE_QUERY_KEYS = new Set([
   "workspace_id",
   "filter",
   "query",
+  // Service-catalog browsing: narrow items to one category, or search by name.
+  "category_id",
+  "search_term",
 ])
 const FRESHSERVICE_VALUE_CHARS = /^[A-Za-z0-9_.,:+@ -]*$/
 const FRESHSERVICE_FILTER_QUERY_CHARS = /^[A-Za-z0-9_.,:+@()'<>"= -]*$/

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -984,7 +984,7 @@ const DOWNLOAD_CONTENT_TYPES: Record<string, string> = {
 /**
  * Cap on a rescued download.
  *
- * Deliberately tighter than storage-broker's MAX_PRIVATE_UPLOAD_BYTES (256 MB),
+ * Deliberately tighter than storage-broker's MAX_PRIVATE_UPLOAD_BYTES (512 MB),
  * which bounds what an agent may deliberately upload. This bounds a file the
  * agent did NOT choose the size of — whatever a caller happened to attach in
  * Drive — and the whole thing is buffered in the web tier's memory on its way

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -51,7 +51,17 @@ export interface WorkspaceMediaHandoff {
   contentType?: string
 }
 
-export type WorkspaceCommandRejectionReason = "operation_not_allowed"
+/**
+ * Machine-readable rejection reasons the skill layer branches on.
+ *
+ * `drive_upload_use_publish` is distinct from `operation_not_allowed` on
+ * purpose: it is not "you may not do this", it is "this can never work; here
+ * is the thing that does". Collapsing it into the generic reason would put it
+ * back in the bucket the agent already knows to give up on.
+ */
+export type WorkspaceCommandRejectionReason =
+  | "operation_not_allowed"
+  | "drive_upload_use_publish"
 
 export class WorkspaceCommandValidationError extends Error {
   constructor(
@@ -168,11 +178,12 @@ const ALLOWED_WRITES = new Set([
   // operation_not_allowed while its canonical twin was allowed, so the
   // capability existed and only the documented spelling of it did not
   // (agent_failures 5979, 7728). `sheets +append` is
-  // `sheets spreadsheets values append`; `drive +upload` is a
-  // `drive files create` carrying media, and is held to the same agent-only
-  // boundary below so it cannot author a file owned by the user.
+  // `sheets spreadsheets values append`.
+  //
+  // `drive +upload` was allowlisted here alongside it and is NOT reachable —
+  // see refuseDriveUploadWithPublishGuidance below for why, and for the
+  // refusal that now points at the path that does work.
   "sheets +append",
-  "drive +upload",
   // `tasks tasks insert` was allowed but creating the LIST to put tasks in was
   // not, so a request for one list per person failed on all five calls
   // (agent_failures 7134). Same resource family, same slot rules.
@@ -245,11 +256,8 @@ const AGENT_ONLY_WRITES = new Set([
   "drive comments create",
   "drive files copy",
   "drive files create",
-  // The helper form of `drive files create` with media attached. It authors
-  // file CONTENT, so it sits on the same side of the impersonation boundary as
-  // the canonical create: on the user slot the file would be owned by the
-  // user, which is the thing that boundary exists to prevent.
-  "drive +upload",
+  // `drive +upload` was here too, and is removed with its ALLOWED_WRITES twin:
+  // it could never execute either way. See refuseDriveUploadWithPublishGuidance.
   "drive permissions create",
   "drive accessproposals resolve",
   // A Form is authored content in exactly the sense a Doc, Sheet or Slides deck
@@ -680,6 +688,45 @@ function carriesDriveContent(argv: readonly string[]): boolean {
   return false
 }
 
+/**
+ * Refuse `drive +upload` with the instruction that actually works.
+ *
+ * The operation was allowlisted (in both ALLOWED_WRITES and AGENT_ONLY_WRITES)
+ * and could never run, for two independent reasons:
+ *
+ *  1. `operationTokens()` folds LEADING POSITIONAL tokens into the operation
+ *     string, so `drive +upload /home/node/report.pdf` produces the operation
+ *     `drive +upload /home/node/report.pdf`, which never equals the allowlist
+ *     entry `drive +upload`. Only the flag spelling (`drive +upload --upload
+ *     <path>`) stopped at a `-` and matched — which is exactly why the existing
+ *     allowlist-gap test never caught this: it asserts on the flag form.
+ *  2. Past validation it still could not work. `gws` runs in a fresh empty
+ *     `mkdtemp` on the WEB tier, so a container path simply does not exist
+ *     there. There is a download hand-off (`handOffDownloadedMedia`) but no
+ *     upload counterpart, and `--json-file`/`--body-file`/`--text-file` inline
+ *     their target with `readFileSync(path, 'utf8')` — text only, never binary.
+ *
+ * A user who asked for "a link to this PDF" therefore dead-ended on a bare
+ * `operation_not_allowed` that named an operation the allowlist appeared to
+ * contain. Removing the entries alone would keep that dead end; this replaces
+ * it with the route that does exist.
+ */
+function refuseDriveUploadWithPublishGuidance(argv: readonly string[]): void {
+  const tokens = operationTokens(argv)
+  if (tokens[0] !== "drive" || tokens[1] !== "+upload") return
+  throw new WorkspaceCommandValidationError(
+    "`drive +upload` cannot move a container file into Drive: the Workspace " +
+      "CLI runs in an empty temporary directory on the web tier, so a local " +
+      "path does not exist there. To hand someone a link to a file you " +
+      "generated, publish it instead: " +
+      "`node /opt/psd-skills/psd-publish-file/publish.js --file <path>`, " +
+      "which returns a shareable HTTPS URL. For an HTML page, use " +
+      "psd-html-artifact, which publishes to Atrium.",
+    "drive_upload_use_publish",
+    "drive +upload"
+  )
+}
+
 function validateUserDriveFolderCreate(argv: readonly string[]): void {
   const resource = jsonResource(argv)
   const mimeType =
@@ -1088,6 +1135,7 @@ function validateWorkspaceMutation(
     }
     return
   }
+  refuseDriveUploadWithPublishGuidance(argv)
   if (scope === "user" && operation === "drive files create") {
     validateUserDriveFolderCreate(argv)
     return

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -163,9 +163,20 @@ export function workspaceReservationCountsAsRetained(
   )
 }
 const SAFE_PUBLIC_ARTIFACT_NAME = /^[A-Za-z0-9._@+= -]+$/
+// `.html` is deliberately ABSENT.
+//
+// HTML artifacts go to Atrium, never S3. `public-images/` is unsigned and
+// public-by-link, so an HTML page delivered there is a district document
+// readable by anyone who ever receives the URL, with no owner, no visibility
+// level and no publication record. psd-html-artifact was the last skill still
+// doing that; it now publishes through psd-atrium (create-artifact --body-format
+// html, then publish --destination intranet). Removing the extension and its
+// content type here is what makes that a rule the broker enforces rather than a
+// convention a skill can drift away from.
+//
+// Every other file type still goes to S3 — see the psd-publish-file skill.
 const PUBLIC_EXTENSIONS = new Set([
   ".csv",
-  ".html",
   ".jpeg",
   ".jpg",
   ".json",
@@ -180,7 +191,7 @@ const PUBLIC_EXTENSIONS = new Set([
 ])
 const PUBLIC_CONTENT_TYPES = new Map<string, ReadonlySet<string>>([
   [".csv", new Set(["text/csv"])],
-  [".html", new Set(["text/html"])],
+  // No ".html" — see PUBLIC_EXTENSIONS above.
   [".jpeg", new Set(["image/jpeg"])],
   [".jpg", new Set(["image/jpeg"])],
   [".json", new Set(["application/json"])],

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -60,7 +60,27 @@ export { validateWorkspaceRelativePath } from "@/lib/agent-workspace/path-policy
 const log = createLogger({ module: "workspace-storage-broker" })
 
 const MAX_LIST_KEYS = 1_000
-export const MAX_PRIVATE_UPLOAD_BYTES = 256 * 1024 * 1024
+// 512 MiB, raised from 256 MiB on 2026-09-05.
+//
+// This is an APPLICATION constant, not an S3 one — a single PUT accepts 5 GB.
+// The 256 MiB value became a hard outage: OpenClaw's own transcript database
+// (`agents/<id>/agent/openclaw-agent.sqlite`) grows monotonically every turn
+// and nothing pruned it, so the first owner to cross the line could never save
+// a workspace again — every subsequent turn and every scheduled fire failed at
+// finalization (prod, one owner hard-down from 2026-09-05 05:49 UTC at
+// 268,390,400 of 268,435,456 bytes, with two more owners within 30 % of it).
+//
+// Raising the ceiling is the unblock. It is not the fix: the agent image now
+// prunes closed-session `trajectory_runtime_events` rows at finalization
+// (infra/agent-image/workspace_sync.py), which is what keeps the file from
+// walking into the new ceiling as well. Both are required — the prune cannot
+// run until the workspace can be written again.
+//
+// Keep in sync with BROKER_PRIVATE_UPLOAD_MAX_BYTES in
+// infra/agent-image/workspace_sync.py, which detects an over-cap file
+// client-side so the agent reports the offending path instead of building a
+// batch the broker can never accept.
+export const MAX_PRIVATE_UPLOAD_BYTES = 512 * 1024 * 1024
 export const MAX_PUBLIC_ARTIFACT_BYTES = 100 * 1024 * 1024
 const MAX_PRIVATE_RETAINED_BYTES = 4 * 1024 * 1024 * 1024
 const MAX_PUBLIC_RETAINED_BYTES = 1024 * 1024 * 1024
@@ -4726,6 +4746,72 @@ export async function completeWorkspaceUpload(
     }
     throw error
   }
+}
+
+/** Most reservations one abort may release — the agent's push batch cap. */
+const MAX_RELEASED_UPLOAD_RESERVATIONS = 250
+
+/**
+ * Abandon `reserved` uploads whose batch will never be finalized.
+ *
+ * A workspace finalization is a batch: the agent reserves and stages every
+ * changed file, then commits them together. When ONE file in that batch is
+ * refused — an oversized object, a checksum mismatch, a signing failure — the
+ * agent aborts, but its siblings' rows stay `reserved` for the full five-minute
+ * lease. Inside that window the partial unique index
+ * `uq_workspace_upload_target_active (owner_key, target_key)
+ *  WHERE status IN ('reserved','verifying')` rejects the retry's reservation
+ * for the very same path, so the natural "just run the turn again" recovery
+ * fails in ~30 ms with a bare `Failed query` and the owner has to wait out the
+ * TTL. Releasing the batch on abort removes that dead window.
+ *
+ * Scoped by `ownerKey` and to `reserved` only, so this can never touch another
+ * owner's rows, a committed upload, or one already being verified. Unknown or
+ * already-settled ids are silently skipped: an abort path must be idempotent
+ * and must not itself fail.
+ */
+export async function releaseWorkspaceUploads(
+  ownerEmail: string,
+  reservationIds: readonly string[],
+): Promise<{ released: number }> {
+  if (reservationIds.length === 0) return { released: 0 }
+  if (reservationIds.length > MAX_RELEASED_UPLOAD_RESERVATIONS) {
+    throw new Error("Invalid upload reservation release batch")
+  }
+  for (const reservationId of reservationIds) {
+    if (!WORKSPACE_RESERVATION_ID_RE.test(reservationId)) {
+      throw new Error("Invalid upload reservation")
+    }
+  }
+  const ownerKey = ownerEmail.trim().toLowerCase()
+  const released = await executeQuery(
+    (db) =>
+      db
+        .update(workspaceUploadReservations)
+        .set({ status: "expired", updatedAt: new Date() })
+        .where(
+          and(
+            eq(workspaceUploadReservations.ownerKey, ownerKey),
+            eq(workspaceUploadReservations.status, "reserved"),
+            inArray(workspaceUploadReservations.id, [...reservationIds]),
+          ),
+        )
+        .returning({
+          byteLeaseId: workspaceUploadReservations.byteLeaseId,
+          objectLeaseId: workspaceUploadReservations.objectLeaseId,
+        }),
+    "releaseWorkspaceUploadReservations",
+  )
+  // The reservation rows are already out of the active index above; giving the
+  // admission leases back is best-effort capacity hygiene on top of that, so a
+  // lease-store hiccup must not turn an abort into a second failure.
+  await Promise.allSettled(
+    released.flatMap((row) => [
+      dropLease(row.byteLeaseId),
+      dropLease(row.objectLeaseId),
+    ]),
+  )
+  return { released: released.length }
 }
 
 export async function createPublicArtifactDownloadUrl(

--- a/lib/db/query-error.ts
+++ b/lib/db/query-error.ts
@@ -25,7 +25,11 @@ interface DriverErrorShape {
   constraint?: unknown
   table_name?: unknown
   table?: unknown
-  detail?: unknown
+  // `detail` is deliberately NOT read. Postgres DETAIL lines embed the literal
+  // row values that violated the constraint — `Key (owner_key, target_key)=
+  // (someone@psd401.net, …) already exists.` — and this object is logged.
+  // `code` + `constraint_name` already answer WHICH constraint fired, which is
+  // the whole diagnostic need, without putting user data in CloudWatch.
 }
 
 const MAX_CAUSE_DEPTH = 4
@@ -41,7 +45,6 @@ export interface QueryErrorCause {
   causeCode?: string
   causeConstraint?: string
   causeTable?: string
-  causeDetail?: string
 }
 
 /**
@@ -65,12 +68,10 @@ export function describeQueryErrorCause(
     const constraint =
       boundedString(shape.constraint_name) ?? boundedString(shape.constraint)
     const table = boundedString(shape.table_name) ?? boundedString(shape.table)
-    const detail = boundedString(shape.detail)
     if (message) candidate.causeMessage = message
     if (code) candidate.causeCode = code
     if (constraint) candidate.causeConstraint = constraint
     if (table) candidate.causeTable = table
-    if (detail) candidate.causeDetail = detail
     if (Object.keys(candidate).length > 0) described = candidate
     current = (current as { cause?: unknown }).cause
   }

--- a/lib/db/query-error.ts
+++ b/lib/db/query-error.ts
@@ -1,0 +1,78 @@
+/**
+ * Surface the real database error behind a Drizzle `DrizzleQueryError`.
+ *
+ * Drizzle wraps every driver failure in an error whose `message` is only
+ * `Failed query: insert into "…"` plus the SQL text. The postgres.js error that
+ * actually says WHY — the SQLSTATE code, the violated constraint, the detail
+ * line — hangs off `.cause` and is dropped by any handler that logs
+ * `error.message` alone.
+ *
+ * That cost real time during a 2026-09-05 production workspace outage: the
+ * broker's logs showed only `Failed query: insert into
+ * "workspace_upload_reservations"`, so the actual cause (a unique violation on
+ * the partial index `uq_workspace_upload_target_active`) had to be inferred by
+ * reading the schema rather than read off a log line.
+ *
+ * Returns `undefined` when there is no cause worth logging, so callers can
+ * spread it into a log payload unconditionally.
+ */
+
+/** Fields postgres.js sets on its error objects (a superset of `pg`'s). */
+interface DriverErrorShape {
+  message?: unknown
+  code?: unknown
+  constraint_name?: unknown
+  constraint?: unknown
+  table_name?: unknown
+  table?: unknown
+  detail?: unknown
+}
+
+const MAX_CAUSE_DEPTH = 4
+const MAX_FIELD_LENGTH = 500
+
+function boundedString(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined
+  return value.slice(0, MAX_FIELD_LENGTH)
+}
+
+export interface QueryErrorCause {
+  causeMessage?: string
+  causeCode?: string
+  causeConstraint?: string
+  causeTable?: string
+  causeDetail?: string
+}
+
+/**
+ * Walk the `cause` chain and describe the deepest link that carries driver
+ * detail. Bounded in depth so a self-referential chain cannot spin, and in
+ * field length so a driver detail line cannot flood the log.
+ */
+export function describeQueryErrorCause(
+  error: unknown,
+): QueryErrorCause | undefined {
+  let current: unknown = (error as { cause?: unknown } | null)?.cause
+  let described: QueryErrorCause | undefined
+  const seen = new Set<unknown>()
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (!current || typeof current !== "object" || seen.has(current)) break
+    seen.add(current)
+    const shape = current as DriverErrorShape
+    const candidate: QueryErrorCause = {}
+    const message = boundedString(shape.message)
+    const code = boundedString(shape.code)
+    const constraint =
+      boundedString(shape.constraint_name) ?? boundedString(shape.constraint)
+    const table = boundedString(shape.table_name) ?? boundedString(shape.table)
+    const detail = boundedString(shape.detail)
+    if (message) candidate.causeMessage = message
+    if (code) candidate.causeCode = code
+    if (constraint) candidate.causeConstraint = constraint
+    if (table) candidate.causeTable = table
+    if (detail) candidate.causeDetail = detail
+    if (Object.keys(candidate).length > 0) described = candidate
+    current = (current as { cause?: unknown }).cause
+  }
+  return described
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "agent:probe-context": "bun run scripts/agent-workspace/mint-agent-probe-context.ts",
     "test:skill:workspace": "cd infra/agent-image/skills/psd-workspace && bun test common.test.js",
     "test:lambda:router": "cd infra/lambdas/agent-router && bun test",
+    "test:lambda:cron": "cd infra/lambdas/agent-cron && bun test",
+    "test:skill:publish-file": "cd infra/agent-image/skills/psd-publish-file && bun test",
     "test:skill:directory": "cd infra/agent-image/skills/psd-directory && bun test run.test.js",
     "test:skill:workflows": "cd infra/agent-image/skills/psd-workflows && node --test",
     "test:skill:schedules": "cd infra/agent-image/skills/psd-schedules && bun test",

--- a/tests/unit/agent-schedules-route.test.ts
+++ b/tests/unit/agent-schedules-route.test.ts
@@ -1,5 +1,9 @@
 let context:
-  | { actorEmail: string; ownerEmail: string; mode: "owner" | "scheduled" }
+  | {
+      actorEmail: string
+      ownerEmail: string
+      mode: "owner" | "scheduled" | "consultation" | "email-task"
+    }
   | null = {
   actorEmail: "owner@psd401.net",
   ownerEmail: "owner@psd401.net",
@@ -10,11 +14,13 @@ const listMock = jest.fn()
 const createMock = jest.fn()
 const updateMock = jest.fn()
 const deleteMock = jest.fn()
+const runsMock = jest.fn()
 const serviceFactoryMock = jest.fn(() => ({
   list: listMock,
   create: createMock,
   update: updateMock,
   delete: deleteMock,
+  runs: runsMock,
 }))
 
 jest.mock("@/lib/agent-workspace/invocation-context", () => ({
@@ -88,6 +94,7 @@ beforeEach(() => {
   createMock.mockReset().mockResolvedValue({ scheduleId: "schedule-1" })
   updateMock.mockReset().mockResolvedValue({ scheduleId: "schedule-1" })
   deleteMock.mockReset().mockResolvedValue("schedule-1")
+  runsMock.mockReset().mockResolvedValue([])
 })
 
 describe("POST /api/agent/schedules", () => {
@@ -100,8 +107,8 @@ describe("POST /api/agent/schedules", () => {
     expect(serviceFactoryMock).not.toHaveBeenCalled()
   })
 
-  it.each(["create", "list", "update", "delete"])(
-    "names the schedule management gate for verified non-owner %s requests",
+  it.each(["create", "update", "delete"])(
+    "refuses %s from a scheduled run without weakening the crypto ordering",
     async (operation) => {
       context = {
         actorEmail: "owner@psd401.net",
@@ -112,13 +119,66 @@ describe("POST /api/agent/schedules", () => {
 
       expect(response.status).toBe(403)
       await expect(response.json()).resolves.toEqual({
-        error: "Schedule management requires a live owner-mode turn",
-        reason: "mode_not_allowed",
+        error:
+          "Creating, updating, or deleting a schedule requires a live " +
+          "owner-mode turn. A scheduled run may only list schedules and read " +
+          "their runs.",
         mode: "scheduled",
       })
       expect(serviceFactoryMock).not.toHaveBeenCalled()
     }
   )
+
+  it.each(["list", "runs"])(
+    "lets a scheduled run audit its own schedules via %s",
+    async (operation) => {
+      context = {
+        actorEmail: "owner@psd401.net",
+        ownerEmail: "owner@psd401.net",
+        mode: "scheduled",
+      }
+      const response = await POST(request({ operation }))
+
+      expect(response.status).toBe(200)
+      expect(serviceFactoryMock).toHaveBeenCalled()
+    }
+  )
+
+  it.each(["consultation", "email-task"])(
+    "still reports a plain mode mismatch for %s",
+    async (mode) => {
+      context = {
+        actorEmail: "owner@psd401.net",
+        ownerEmail: "owner@psd401.net",
+        mode: mode as "consultation" | "email-task",
+      }
+      const response = await POST(request({ operation: "list" }))
+
+      expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toEqual({
+        error: "Schedule management requires a live owner-mode turn",
+        reason: "mode_not_allowed",
+        mode,
+      })
+      expect(serviceFactoryMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it("rejects a scheduled mutation before any authority selector is read", async () => {
+    context = {
+      actorEmail: "owner@psd401.net",
+      ownerEmail: "owner@psd401.net",
+      mode: "scheduled",
+    }
+    // The authority-selector guard runs first and is unchanged: a scheduled
+    // turn cannot use a rejected mutation to probe for it either way.
+    const response = await POST(
+      request({ operation: "delete", ownerEmail: "victim@psd401.net" })
+    )
+
+    expect(response.status).toBe(400)
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
 
   it.each([
     "ownerEmail",

--- a/tests/unit/agent-workspace-storage-route.test.ts
+++ b/tests/unit/agent-workspace-storage-route.test.ts
@@ -13,6 +13,7 @@ const ensureWorkspaceCheckpointMock = jest.fn()
 const commitWorkspaceCheckpointMock = jest.fn()
 const finalizeWorkspaceCheckpointMock = jest.fn()
 const deleteWorkspacePathMock = jest.fn()
+const releaseWorkspaceUploadsMock = jest.fn()
 
 jest.mock("@/lib/agent-workspace/invocation-context", () => ({
   verifyAgentInvocationContext: (...args: unknown[]) =>
@@ -41,6 +42,8 @@ jest.mock("@/lib/agent-workspace/storage-broker", () => ({
     finalizeWorkspaceCheckpointMock(...args),
   deleteWorkspacePath: (...args: unknown[]) =>
     deleteWorkspacePathMock(...args),
+  releaseWorkspaceUploads: (...args: unknown[]) =>
+    releaseWorkspaceUploadsMock(...args),
 }))
 jest.mock("@/lib/logger", () => ({
   createLogger: () => ({
@@ -94,6 +97,7 @@ beforeEach(() => {
     checkpointCommitted: true,
     workspaceGeneration: "2".repeat(64),
   })
+  releaseWorkspaceUploadsMock.mockResolvedValue({ released: 2 })
   deleteWorkspacePathMock.mockResolvedValue({
     deleted: true,
     workspaceGeneration: "3".repeat(64),
@@ -528,6 +532,58 @@ describe("POST /api/agent/workspace-storage", () => {
 
     expect(response.status).toBe(400)
     expect(finalizeWorkspaceCheckpointMock).not.toHaveBeenCalled()
+  })
+
+  it("releases an aborted batch's sibling reservations for the signed owner", async () => {
+    const response = await POST(
+      request({
+        operation: "release-upload",
+        reservationIds: [
+          "11111111-2222-4333-8444-555555555555",
+          "66666666-7777-4888-8999-aaaaaaaaaaaa",
+        ],
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(releaseWorkspaceUploadsMock).toHaveBeenCalledWith(
+      "owner@example.com",
+      [
+        "11111111-2222-4333-8444-555555555555",
+        "66666666-7777-4888-8999-aaaaaaaaaaaa",
+      ],
+    )
+  })
+
+  it("rejects a release that carries anything but reservation ids", async () => {
+    const response = await POST(
+      request({
+        operation: "release-upload",
+        reservationIds: ["11111111-2222-4333-8444-555555555555"],
+        path: "memory/notes.md",
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(releaseWorkspaceUploadsMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects an empty, malformed, or duplicated release batch", async () => {
+    for (const reservationIds of [
+      [],
+      ["not-a-uuid"],
+      [
+        "11111111-2222-4333-8444-555555555555",
+        "11111111-2222-4333-8444-555555555555",
+      ],
+      Array.from({ length: 251 }, () => "11111111-2222-4333-8444-555555555555"),
+    ]) {
+      const response = await POST(
+        request({ operation: "release-upload", reservationIds }),
+      )
+      expect(response.status).toBe(400)
+    }
+    expect(releaseWorkspaceUploadsMock).not.toHaveBeenCalled()
   })
 
   it("generation-fences deletes inside the signed prefix", async () => {

--- a/tests/unit/lib/agent-credentials/freshservice-broker.test.ts
+++ b/tests/unit/lib/agent-credentials/freshservice-broker.test.ts
@@ -100,6 +100,15 @@ describe("Freshservice broker allowlist", () => {
     ["GET", "/workspaces"],
     ["GET", "/workspaces/2"],
     ["GET", "/approvals?approver_id=5&status=pending&parent=true"],
+    // Service Catalog. Note the path asymmetry — reads under
+    // `/service_catalog/...`, the create verb at top-level
+    // `/service_catalog_items` — which is Freshservice's own shape.
+    ["GET", "/service_catalog/categories"],
+    ["GET", "/service_catalog/items"],
+    ["GET", "/service_catalog/items?category_id=12&per_page=50"],
+    ["GET", "/service_catalog/items?search_term=hotel"],
+    ["GET", "/service_catalog/items/4242"],
+    ["POST", "/service_catalog_items"],
   ])("allows %s %s (used by the skill)", async (method, path) => {
     await expect(call(path, method)).resolves.toBeDefined()
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -124,6 +133,15 @@ describe("Freshservice broker allowlist", () => {
     ["GET", "/tickets/abc"],
     // Absolute URLs must not escape the fixed host.
     ["GET", "//evil.example/tickets"],
+    // Catalog: only create and read are wired. Editing or deleting a live
+    // catalog item is a UI action, not something an agent turn may reach.
+    ["PUT", "/service_catalog_items/4242"],
+    ["DELETE", "/service_catalog_items/4242"],
+    // The two spellings do not interchange — each route is its own literal.
+    ["POST", "/service_catalog/items"],
+    ["GET", "/service_catalog_items"],
+    ["GET", "/service_catalog/items/abc"],
+    ["GET", "/service_catalog/categories/12"],
   ])("rejects %s %s", async (method, path) => {
     await expect(call(path, method)).rejects.toThrow(/not allowed|Invalid/)
     expect(fetchMock).not.toHaveBeenCalled()

--- a/tests/unit/lib/agent-workspace/allowlist-closure.test.ts
+++ b/tests/unit/lib/agent-workspace/allowlist-closure.test.ts
@@ -87,10 +87,16 @@ describe("helper verbs and their canonical operations travel together", () => {
   // is what the skill documents. The canonical form is what gws implements.
   // Allowing one without the other means the capability exists but the
   // documented way to use it is refused — the `+draft` failure exactly.
+  //
+  // `drive +upload` is deliberately NOT in this pairing any more. It is the one
+  // helper whose canonical form the agent can reach and whose helper form it
+  // cannot: gws runs in an empty mkdtemp on the web tier, so no local path
+  // exists for it to upload. Pairing them would demand we re-allow a spelling
+  // that cannot execute. It is refused explicitly instead, pointing at
+  // psd-publish-file — see workspace-allowlist-gaps.test.ts.
   const HELPERS: Array<[string, string]> = [
     ["gmail +draft", "gmail users drafts create"],
     ["sheets +append", "sheets spreadsheets values append"],
-    ["drive +upload", "drive files create"],
   ]
 
   it.each(HELPERS)("allows %s and %s together", (helper, canonical) => {

--- a/tests/unit/lib/agent-workspace/storage-broker-release.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-release.test.ts
@@ -1,0 +1,123 @@
+/** @jest-environment node */
+
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals"
+
+type AsyncUnknownMock = (...args: unknown[]) => Promise<unknown>
+
+const executeQueryMock = jest.fn<AsyncUnknownMock>()
+const releaseMock = jest.fn<AsyncUnknownMock>()
+
+jest.mock("@aws-sdk/client-s3", () => {
+  class Command {
+    constructor(public readonly input: Record<string, unknown>) {}
+  }
+  return {
+    S3Client: class S3Client {
+      send = jest.fn()
+    },
+    CopyObjectCommand: class CopyObjectCommand extends Command {},
+    DeleteObjectCommand: class DeleteObjectCommand extends Command {},
+    GetObjectCommand: class GetObjectCommand extends Command {},
+    HeadObjectCommand: class HeadObjectCommand extends Command {},
+    ListObjectsV2Command: class ListObjectsV2Command extends Command {},
+    PutObjectCommand: class PutObjectCommand extends Command {},
+  }
+})
+jest.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: jest.fn(),
+}))
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...args: unknown[]) => executeQueryMock(...args),
+  executeTransaction: jest.fn(),
+  toPgRows: (value: unknown) => value,
+  withUnretriedDatabaseSession: jest.fn(),
+}))
+jest.mock("@/lib/resource-admission", () => ({
+  acquireResourceAdmission: jest.fn(),
+  finishResourceAdmission: jest.fn(),
+  releaseResourceAdmission: (...args: unknown[]) => releaseMock(...args),
+  isCapacityDenial: () => false,
+}))
+
+let releaseWorkspaceUploads:
+  typeof import("@/lib/agent-workspace/storage-broker").releaseWorkspaceUploads
+
+const OWNER = "Owner@Example.com"
+const RESERVATION_A = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+const RESERVATION_B = "8f2c1c2a-9b21-4c0b-9a5d-1d1f4b6a7c31"
+
+beforeAll(async () => {
+  const broker = await import("@/lib/agent-workspace/storage-broker")
+  releaseWorkspaceUploads = broker.releaseWorkspaceUploads
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  executeQueryMock.mockReset().mockResolvedValue([])
+  releaseMock.mockReset().mockResolvedValue(undefined)
+})
+
+describe("releaseWorkspaceUploads", () => {
+  it("does nothing at all for an empty batch", async () => {
+    await expect(releaseWorkspaceUploads(OWNER, [])).resolves.toEqual({
+      released: 0,
+    })
+    expect(executeQueryMock).not.toHaveBeenCalled()
+  })
+
+  it("expires the batch's reserved rows and gives their leases back", async () => {
+    executeQueryMock.mockResolvedValueOnce([
+      { byteLeaseId: "byte-a", objectLeaseId: "object-a" },
+      // Since migration 154 an upload may be admitted with no lease at all.
+      { byteLeaseId: null, objectLeaseId: null },
+    ])
+
+    await expect(
+      releaseWorkspaceUploads(OWNER, [RESERVATION_A, RESERVATION_B]),
+    ).resolves.toEqual({ released: 2 })
+
+    expect(executeQueryMock).toHaveBeenCalledTimes(1)
+    expect(executeQueryMock.mock.calls[0][1]).toBe(
+      "releaseWorkspaceUploadReservations",
+    )
+    expect(releaseMock.mock.calls.map((call) => call[0])).toEqual([
+      "byte-a",
+      "object-a",
+    ])
+  })
+
+  it("rejects a malformed reservation id before touching the database", async () => {
+    await expect(
+      releaseWorkspaceUploads(OWNER, [RESERVATION_A, "not-a-uuid"]),
+    ).rejects.toThrow("Invalid upload reservation")
+    expect(executeQueryMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects a batch larger than one finalization can produce", async () => {
+    await expect(
+      releaseWorkspaceUploads(
+        OWNER,
+        Array.from({ length: 251 }, () => RESERVATION_A),
+      ),
+    ).rejects.toThrow("Invalid upload reservation release batch")
+    expect(executeQueryMock).not.toHaveBeenCalled()
+  })
+
+  it("survives a lease store that is refusing releases", async () => {
+    executeQueryMock.mockResolvedValueOnce([
+      { byteLeaseId: "byte-a", objectLeaseId: "object-a" },
+    ])
+    releaseMock.mockRejectedValue(new Error("lease store down"))
+
+    await expect(
+      releaseWorkspaceUploads(OWNER, [RESERVATION_A]),
+    ).resolves.toEqual({ released: 1 })
+  })
+})

--- a/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts
@@ -289,23 +289,41 @@ function defineVerifiedWorkspaceUploadReservationsSuite1Part1() {
     expect(acquireMock).not.toHaveBeenCalled()
   })
 
-  it("accepts the UTF-8 HTML MIME used by the artifact publishers", async () => {
-    const prepared = await createPublicArtifactUpload({
-                             ownerEmail: OWNER,
-                             fileName: "report.html",
-                             contentType: "text/html; charset=utf-8",
-                             contentLength: 4,
-                             contextKey: "session:nonce",
-                             idempotencyKey: "idempotency-html",
-                             checksumSha256: CHECKSUM,
-                           })
-    expect(prepared.requiredHeaders["Content-Type"]).toBe(
-      "text/html; charset=utf-8",
-    )
-    const put = signedUrlMock.mock.calls[0]?.[1] as {
-      input: Record<string, unknown>
+  // Reversed deliberately. This used to assert that the UTF-8 HTML MIME was
+  // accepted, back when psd-html-artifact dropped `text/html` into the
+  // unsigned, public-by-link `public-images/` prefix. HTML pages are district
+  // documents and now go to Atrium, where they carry an owner, a visibility
+  // level and a publication record — so `.html` is gone from PUBLIC_EXTENSIONS
+  // and the broker is what enforces that, not the skill's good behaviour.
+  it("refuses HTML entirely — those go to Atrium, not the public prefix", async () => {
+    for (const contentType of ["text/html", "text/html; charset=utf-8"]) {
+      await expect(
+        createPublicArtifactUpload({
+          ownerEmail: OWNER,
+          fileName: "report.html",
+          contentType,
+          contentLength: 4,
+          contextKey: "session:nonce",
+          idempotencyKey: "idempotency-html",
+          checksumSha256: CHECKSUM,
+        }),
+      ).rejects.toThrow("Public artifact type is not allowed")
     }
-    expect(put.input.ContentType).toBe("text/html; charset=utf-8")
+    expect(executeQueryMock).not.toHaveBeenCalled()
+    expect(acquireMock).not.toHaveBeenCalled()
+  })
+
+  it("still accepts every non-HTML public artifact type", async () => {
+    const prepared = await createPublicArtifactUpload({
+      ownerEmail: OWNER,
+      fileName: "chart.png",
+      contentType: "image/png",
+      contentLength: 4,
+      contextKey: "session:nonce",
+      idempotencyKey: "idempotency-png",
+      checksumSha256: CHECKSUM,
+    })
+    expect(prepared.requiredHeaders["Content-Type"]).toBe("image/png")
   })
 
   it("uncharges an old public commit only after exact-version absence is proven", async () => {

--- a/tests/unit/lib/agent-workspace/workspace-allowlist-gaps.test.ts
+++ b/tests/unit/lib/agent-workspace/workspace-allowlist-gaps.test.ts
@@ -32,24 +32,31 @@ describe("allowlist gaps closed from 2026-08-13 prod failures", () => {
     ).not.toThrow()
   })
 
-  it("permits drive +upload on the agent slot", () => {
-    expect(() =>
-      validateWorkspaceCommand(
-        agent(["drive", "+upload", "--upload", "/opt/logo.png"]),
-        "hagelk@psd401.net"
-      )
-    ).not.toThrow()
-  })
-
-  it("still refuses drive +upload on the user slot (impersonation boundary)", () => {
-    // Authoring file CONTENT as the user is the exact thing the boundary
-    // exists to prevent — the helper form must not be a way around it.
-    expect(() =>
-      validateWorkspaceCommand(
-        user(["drive", "+upload", "--upload", "/opt/logo.png"]),
-        "hagelk@psd401.net"
-      )
-    ).toThrow(/agent-owned/)
+  // `drive +upload` was allowlisted and could never execute — see
+  // refuseDriveUploadWithPublishGuidance in command-executor.ts. It is now
+  // refused deliberately, on BOTH slots, with the route that does work.
+  //
+  // This test used to assert the opposite ("permits drive +upload on the agent
+  // slot"), and passed, because it used the FLAG spelling. That is the whole
+  // bug: operationTokens() folds leading positionals into the operation, so
+  // only `--upload <path>` ever matched the allowlist entry, while the natural
+  // `drive +upload <path>` did not — and neither form could reach a container
+  // file from the web tier's empty mkdtemp anyway.
+  it.each([
+    ["agent", agent],
+    ["user", user],
+  ])("refuses drive +upload on the %s slot with the publish route", (
+    _slot,
+    invocation,
+  ) => {
+    for (const argv of [
+      ["drive", "+upload", "--upload", "/opt/logo.png"],
+      ["drive", "+upload", "/home/node/report.pdf"],
+    ]) {
+      expect(() =>
+        validateWorkspaceCommand(invocation(argv), "hagelk@psd401.net")
+      ).toThrow(/psd-publish-file/)
+    }
   })
 
   it("still refuses the send helpers", () => {

--- a/tests/unit/lib/db/query-error.test.ts
+++ b/tests/unit/lib/db/query-error.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "@jest/globals"
 import { describeQueryErrorCause } from "@/lib/db/query-error"
 
 describe("describeQueryErrorCause", () => {
-  it("pulls the postgres detail out from behind Drizzle's wrapper", () => {
+  it("pulls the postgres cause out from behind Drizzle's wrapper, without its row values", () => {
     const driverError = Object.assign(
       new Error(
         'duplicate key value violates unique constraint ' +
@@ -29,8 +29,11 @@ describe("describeQueryErrorCause", () => {
       causeCode: "23505",
       causeConstraint: "uq_workspace_upload_target_active",
       causeTable: "workspace_upload_reservations",
-      causeDetail: "Key (owner_key, target_key)=(a, b) already exists.",
     })
+    // The driver error above CARRIES a `detail` line holding the literal row
+    // values that collided. It must never reach the log payload — the code and
+    // constraint above already identify what failed.
+    expect(describeQueryErrorCause(wrapped)).not.toHaveProperty("causeDetail")
   })
 
   it("returns nothing when there is no cause to report", () => {
@@ -51,7 +54,7 @@ describe("describeQueryErrorCause", () => {
     })
   })
 
-  it("bounds a driver detail line so it cannot flood the log", () => {
+  it("bounds a driver message so it cannot flood the log", () => {
     const wrapped = new Error("Failed query", {
       cause: Object.assign(new Error("x".repeat(5_000)), {
         detail: "y".repeat(5_000),
@@ -60,6 +63,5 @@ describe("describeQueryErrorCause", () => {
     const described = describeQueryErrorCause(wrapped)
 
     expect(described?.causeMessage).toHaveLength(500)
-    expect(described?.causeDetail).toHaveLength(500)
   })
 })

--- a/tests/unit/lib/db/query-error.test.ts
+++ b/tests/unit/lib/db/query-error.test.ts
@@ -1,0 +1,65 @@
+/** @jest-environment node */
+
+import { describe, expect, it } from "@jest/globals"
+import { describeQueryErrorCause } from "@/lib/db/query-error"
+
+describe("describeQueryErrorCause", () => {
+  it("pulls the postgres detail out from behind Drizzle's wrapper", () => {
+    const driverError = Object.assign(
+      new Error(
+        'duplicate key value violates unique constraint ' +
+          '"uq_workspace_upload_target_active"',
+      ),
+      {
+        code: "23505",
+        constraint_name: "uq_workspace_upload_target_active",
+        table_name: "workspace_upload_reservations",
+        detail: "Key (owner_key, target_key)=(a, b) already exists.",
+      },
+    )
+    const wrapped = new Error(
+      'Failed query: insert into "workspace_upload_reservations" …',
+      { cause: driverError },
+    )
+
+    expect(describeQueryErrorCause(wrapped)).toEqual({
+      causeMessage:
+        'duplicate key value violates unique constraint ' +
+        '"uq_workspace_upload_target_active"',
+      causeCode: "23505",
+      causeConstraint: "uq_workspace_upload_target_active",
+      causeTable: "workspace_upload_reservations",
+      causeDetail: "Key (owner_key, target_key)=(a, b) already exists.",
+    })
+  })
+
+  it("returns nothing when there is no cause to report", () => {
+    expect(describeQueryErrorCause(new Error("plain"))).toBeUndefined()
+    expect(describeQueryErrorCause(undefined)).toBeUndefined()
+    expect(describeQueryErrorCause("a string")).toBeUndefined()
+    expect(
+      describeQueryErrorCause(new Error("wrapped", { cause: "text cause" })),
+    ).toBeUndefined()
+  })
+
+  it("terminates on a self-referential cause chain", () => {
+    const looping = new Error("loop") as Error & { cause?: unknown }
+    looping.cause = looping
+
+    expect(describeQueryErrorCause({ cause: looping })).toEqual({
+      causeMessage: "loop",
+    })
+  })
+
+  it("bounds a driver detail line so it cannot flood the log", () => {
+    const wrapped = new Error("Failed query", {
+      cause: Object.assign(new Error("x".repeat(5_000)), {
+        detail: "y".repeat(5_000),
+      }),
+    })
+    const described = describeQueryErrorCause(wrapped)
+
+    expect(described?.causeMessage).toHaveLength(500)
+    expect(described?.causeDetail).toHaveLength(500)
+  })
+})


### PR DESCRIPTION
Fixes this week's agent failures (prod, 2026-08-30 → 09-05). Seven of the eight items from the investigation; item 7 is partly deferred and called out at the bottom.

## The live outage this started as

`<prefix>/agents/main/agent/openclaw-agent.sqlite` grows every turn — it is OpenClaw's own `transcript_events` store, we sync it, nothing prunes it. At `MAX_PRIVATE_UPLOAD_BYTES` (256 MiB) the broker refuses the upload and **the workspace can never be saved again**.

`stittd@psd401.net` reached 268,390,400 of 268,435,456 bytes — 44 KiB of headroom — and went hard-down at 05:49 UTC on 09-05. All three of his schedules failed every 15-minute fire from then on: 75 errors / 34 skips / 2 successes in one day, against ~100% success the day before. Broker log at the moment it broke: `Invalid content length; maximum is 268435456 bytes`.

He was not alone on the curve — chengj 183 MB (+~10 MB/day), brooksdk 185 MB, hagelk 134 MB, robuckt 98 MB.

Profiling his real database: `trajectory_runtime_events` was 128.1 MB of the 268 MB (48%) in only 3,468 rows (~37 KB of `event_json` each). Actual conversation history was 20.3 MB. `VACUUM` alone reclaimed nothing — `freelist_count` was 23 pages.

**Fix:** raise the ceiling to 512 MiB (an app constant, not an S3 limit — single PUT allows 5 GB) *and* prune closed sessions' `trajectory_runtime_events` at finalization, which is what stops the growth. `transcript_events`, `session_windows`, `memory_index_chunks` and `memory_embedding_cache` are never touched.

Two secondary defects the incident exposed, both fixed:
- **The caps disagreed 8×.** `MAX_SYNC_FILE_BYTES` was 2 GiB against the broker's 256 MiB, so the agent built batches the broker could never accept with no client-side detection. Detected before the batch now, naming the file and its size — the old message told users to "retry after the agent service is repaired", which could never work.
- **A refused file stranded its siblings.** The batch is atomic, so the other uploads' reservation rows sat `reserved` for their full 5-minute lease, and any retry inside that window died in ~30 ms on the partial unique index `uq_workspace_upload_target_active`. New `release-upload` operation releases them on abort. Drizzle's `error.cause` is now logged too — the broker had been reporting only `Failed query: insert into "workspace_upload_reservations"…`, which is why the real cause took a schema read to find.

## The other items

| # | Fix |
|---|---|
| 2 | **`drive +upload` could never work**, two independent reasons: `operationTokens()` folds the positional path into the operation string so it misses the allowlist entry, and `gws` runs in a fresh empty tmpdir on the *web tier*, where a container path does not exist. There is a download hand-off, no upload one. New `psd-publish-file` skill wraps the existing `publishArtifact()`; both dead allowlist entries now refuse by naming the route that works. |
| 3 | **HTML artifacts go to Atrium, not S3.** `psd-html-artifact/deliver.js` retargeted to `create-artifact` + `publish --destination intranet`, returning `readerUrl`; `.html` removed from the broker's `PUBLIC_EXTENSIONS` so the rule is enforced at the boundary rather than documented. Every other file type still goes to S3. |
| 4 | **Contention rows settle on success.** stittd's three schedules share one owner workspace lock, so each tick wrote 2 warn rows — ~192/day, burying real failures. A fire that later succeeds now acknowledges its own row; unresolved contention stays visible. |
| 5 | **A scheduled run's reply IS the DM.** `agent-cron` already delivers every scheduled reply to `schedule.dmSpaceName`. rushj's prompt nonetheless ordered the agent to hunt for the DM space with `findDirectMessage` → `spaces list` → `chat +send`, with "just reply" as the last resort — six days of failures for a digest that was being delivered anyway. Authoring rule added, with the narrow carve-out that `chat +send` to a **shared** space stays legitimate (six of hagelk's schedules do exactly that). Scanned all 280 prod schedules: 7 match, only rushj's was wrong. |
| 6 | **Freshservice Service Catalog.** bishopc asked for a catalog item; the skill only did tickets. Adds create/list against `POST /api/v2/service_catalog_items`, and says plainly that a 403 means the caller lacks catalog-admin rights rather than that their key is bad. |
| 8 | **Scheduled runs may read schedules, not write them.** zarlingj's Weekly Improvement Review 403'd every Friday — 08-14, 08-21, 08-28, 09-04 (self-report 22378); parkek once on 08-03. `list`/`runs` now accept `scheduled` mode; `create`/`update`/`delete` stay owner-only, because an autonomous job that can create or delete schedules is a real escalation. Safe because `reportModeMismatch: true` already defers the mode check until after token, proof and nonce verification — same crypto ordering. |

## Review round

Seven reviewers ran over the diff. Four P1s were real and are fixed in `3edc04017`:

1. **A settled row could swallow a real failure.** One `fire_key` can be delivered twice (Scheduler retries while a slow invocation holds the lock), making success-then-real-failure reachable. The upsert rewrote the error text but left `acknowledged = TRUE`, so the new failure would never appear in an unacknowledged view again — the exact burial the settle path exists to prevent.
2. **One failed VACUUM stranded the file permanently.** The DELETE commits before VACUUM, and VACUUM was gated on `deleted > 0`; after a single transient failure every later run found nothing to delete and never vacuumed again. Now driven by `freelist_count`.
3. **The VACUUM had no time bound and ran outside the flush budget.** `sqlite3.connect(timeout=...)` is the *busy* handler — how long a statement waits to acquire a lock, not how long it runs. Now bounded with a progress handler, and both callers compute the deadline *before* the snapshot so one budget spans snapshot and push.
4. **`process.exit()` skipped the temp-dir cleanup**, leaving the model-authored page in `/tmp` on every staging failure.

Also: `foreign_key_check` moved before the commit with a rollback (run after, it proved nothing); the prune sweep no longer matches on basename alone, which had it opening any `openclaw-agent.sqlite` in the tree including under `attachments/`; `settleSucceededFire` now tests for success rather than "not an error", since `skipped` and `promoted` are both reachable without a failure object; `causeDetail` dropped because Postgres DETAIL lines embed the literal row values and this object is logged; `SCHEDULED_READ_OPERATIONS` typed so a typo in its own members is a compile error; `psd-publish-file`'s FERPA warning moved above the command, where a model reading top-down will actually hit it.

Two evals added to close gaps the skill reviewer found: a negative Freshservice 403 case, and a behavioural `psd-schedules` eval that grades the *authored prompt* for DM-space hunting rather than only asserting SKILL.md still says not to.

## Deploy order matters

`BROKER_PRIVATE_UPLOAD_MAX_BYTES` and `release-upload` are in the agent image; their counterparts are in the web tier. **The web tier must ship first.** Ship the agent first and its pre-check passes a file the broker still refuses at the old ceiling, reproducing the same opaque outage for the rollout window. Documented at both constants.

## Verification

`bun run lint` clean · `bun run typecheck` clean · 5,918 jest · 895 agent-image Python · 51 skill JS · 9 cron telemetry · pre-push Playwright 339 passed / 0 failed.

One pre-push failure along the way (`decision-semantic-search.functional.spec.ts`) was the known row-crowding flake, not this diff — 543 accumulated `graph_nodes` rows were crowding the new decision out of a `limit=25` search. `db:cleanup:e2e` then the spec passed in isolation, and the full suite passed on the push.

## Not in this PR

**Item 7 — agent media capability.** OCR is done: scanned PDFs now render to page images and the multimodal model reads them (verified against a synthetic scan with a canary string). The other three asks — ffmpeg (kinneyk), headless HTML→PDF (nashs ×2), speech-to-text (demontek) — are **not built**.

They cannot be a Dockerfile line: `infra/agent-image/Dockerfile` explicitly bars Chromium/FFmpeg/Puppeteer because the AgentCore Firecracker overlay-mount snapshotter cannot carry that native stack, and the image sits ~50 of a 54-layer ceiling. The sanctioned pattern is a container-image Lambda behind the root-owned loopback relay in `mantle_proxy.py` — and that relay is per-capability and hard-wired, so each is a new route, validator, Lambda and CDK wiring. Two design questions are genuinely open: the hyperframes precedent carries its input inline and media cannot, so byte transport needs an S3 hand-off on a private prefix (a scanned IEP does not belong in `public-images/`), and speech-to-text adds an async Transcribe lifecycle with no precedent here. I also cannot build or test the container image from this environment.

Shipping that untested behind a live outage fix would be the wrong trade. Recommend it as its own PR.
