### PR TITLE
feat(agent): HTML-to-PDF, ffmpeg and speech-to-text for the agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,19 @@ jobs:
       env:
         CI: true
 
+    # agent-media (#1738). Root jest ignores /infra/, so like agent-cron above
+    # this container Lambda's suite would otherwise never run. It needs its own
+    # install: the handler resolves @aws-sdk/client-s3 and client-transcribe
+    # from agent-media/package.json, not the root manifest.
+    - name: Install agent-media dependencies
+      working-directory: infra/agent-media
+      run: bun install --frozen-lockfile
+
+    - name: Run agent-media Lambda tests (Bun)
+      run: bun run test:lambda:media
+      env:
+        CI: true
+
     # Freshservice's tests use node:test mock timing and intentionally run
     # under Node rather than Bun's test runner.
     - name: Run psd-freshservice skill tests (Node)

--- a/app/api/agent/invocation-identity/route.ts
+++ b/app/api/agent/invocation-identity/route.ts
@@ -22,5 +22,15 @@ export async function POST(request: NextRequest) {
     log.warn("Invocation identity verification failed", { requestId })
     return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
-  return NextResponse.json({ ownerEmail: invocation.ownerEmail })
+  // `workspacePrefix` is returned alongside the owner because agent-media
+  // (#1738) reads and writes objects inside the caller's own private workspace
+  // prefix, and that prefix must come from the SIGNED context rather than from
+  // the model. Both fields are verified claims from the same token; neither is
+  // selectable by the skill that triggered the call. Additive — the existing
+  // relay consumer reads only `ownerEmail`, so a rolling deploy is safe in
+  // either order.
+  return NextResponse.json({
+    ownerEmail: invocation.ownerEmail,
+    workspacePrefix: invocation.workspacePrefix,
+  })
 }

--- a/infra/agent-image/eval/suites/capability.yaml
+++ b/infra/agent-image/eval/suites/capability.yaml
@@ -10,6 +10,9 @@ tasks:
   - ../../skills/psd-email-triage/evals/generic-inbox-no-config.yaml
   - ../../skills/psd-freshservice/evals/search-open-urgent-tickets.yaml
   - ../../skills/psd-hyperframes/evals/synthetic-title-card.yaml
+  - ../../skills/psd-print-pdf/evals/print-letter-sign.yaml
+  - ../../skills/psd-media/evals/probe-then-convert.yaml
+  - ../../skills/psd-transcribe/evals/transcribe-spoken-canary.yaml
   - ../../skills/psd-image-gen/evals/capability-denied.yaml
   - ../../skills/psd-last30days/evals/keyless-eval-reliability-brief.yaml
   - ../../skills/psd-learning-page/evals/accessibility-contract.yaml

--- a/infra/agent-image/mantle_proxy.py
+++ b/infra/agent-image/mantle_proxy.py
@@ -136,6 +136,26 @@ HYPERFRAMES_RELAY_TIMEOUT_SECONDS = (
 # the relay ceiling; workspace flushing retains its separate 120-second budget
 # in agentcore_wrapper.py.
 FINALIZATION_DRAIN_TIMEOUT_SECONDS = HYPERFRAMES_RELAY_TIMEOUT_SECONDS + 5
+# agent-media (#1738). Same relay shape as HyperFrames — one fixed function, no
+# caller-selected target — with its own caps because the payloads differ: an
+# HTML page in, or a workspace-relative media path in and a bounded result out.
+AGENT_MEDIA_OPERATIONS = ("html-to-pdf", "media", "transcribe")
+AGENT_MEDIA_HTTP_REQUEST_MAX_BYTES = 6 * 1024 * 1024
+AGENT_MEDIA_INVOKE_PAYLOAD_MAX_BYTES = 6 * 1024 * 1024
+AGENT_MEDIA_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
+AGENT_MEDIA_HTML_MAX_BYTES = 4 * 1024 * 1024
+AGENT_MEDIA_LAMBDA_READ_TIMEOUT_SECONDS = 780
+AGENT_MEDIA_RELAY_TIMEOUT_SECONDS = (
+    HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS
+    + HYPERFRAMES_LAMBDA_CONNECT_TIMEOUT_SECONDS
+    + AGENT_MEDIA_LAMBDA_READ_TIMEOUT_SECONDS
+    + HYPERFRAMES_RELAY_TRANSPORT_MARGIN_SECONDS
+)
+# Mirrors the handler's own path rule. Validated HERE too so a malformed path
+# never reaches the function: the relay is the trust boundary the model cannot
+# edit, and re-proving it costs nothing.
+AGENT_MEDIA_PATH_RE = re.compile(r"^(?!/)(?!.*//)(?!.*(?:^|/)\.\.?(?:/|$))[^\\\x00-\x1f\x7f]{1,768}$")
+
 HYPERFRAMES_MAX_DURATION_SECONDS = 180
 HYPERFRAMES_MAX_FRAMES = 3_600
 HYPERFRAMES_MIN_DIMENSION = 16
@@ -258,6 +278,141 @@ def _read_bounded_aws_stream(stream, max_bytes: int) -> bytes:
         if callable(close):
             close()
     return bytes(body)
+
+
+def _validate_agent_media_payload(payload: object) -> dict:
+    """Constrain the media relay independently of both the skill and the Lambda.
+
+    Identity fields are deliberately absent from the allowlist: the caller never
+    states who it is, and `workspacePrefix`/`userEmail` are injected below from
+    the freshly verified invocation context. A payload that tries to supply
+    either is rejected outright rather than quietly overwritten, so an attempt to
+    reach another owner's workspace is visible instead of silently corrected.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("invalid media request")
+    operation = payload.get("operation")
+    if operation not in AGENT_MEDIA_OPERATIONS:
+        raise ValueError("invalid media operation")
+
+    if operation == "html-to-pdf":
+        allowed = {"operation", "html", "pageSize", "landscape", "marginInches", "scale",
+                   "printBackground"}
+        if set(payload) - allowed:
+            raise ValueError("invalid media fields")
+        html = payload.get("html")
+        if not isinstance(html, str) or not html.strip():
+            raise ValueError("invalid media html")
+        if len(html.encode("utf-8")) > AGENT_MEDIA_HTML_MAX_BYTES:
+            raise ValueError("media html exceeds the configured limit")
+        for key in ("landscape", "printBackground"):
+            if key in payload and not isinstance(payload[key], bool):
+                raise ValueError(f"invalid media {key}")
+        for key in ("marginInches", "scale"):
+            if key in payload:
+                value = payload[key]
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    raise ValueError(f"invalid media {key}")
+                if not math.isfinite(value):
+                    raise ValueError(f"invalid media {key}")
+        if "pageSize" in payload and not isinstance(payload["pageSize"], str):
+            raise ValueError("invalid media pageSize")
+        return dict(payload)
+
+    if operation == "media":
+        allowed = {"operation", "action", "inputPath", "outputPath", "preset"}
+        if set(payload) - allowed:
+            raise ValueError("invalid media fields")
+        for key in ("inputPath", "outputPath"):
+            if key in payload:
+                value = payload[key]
+                if not isinstance(value, str) or not AGENT_MEDIA_PATH_RE.fullmatch(value):
+                    raise ValueError(f"invalid media {key}")
+        for key in ("action", "preset"):
+            if key in payload and not isinstance(payload[key], str):
+                raise ValueError(f"invalid media {key}")
+        return dict(payload)
+
+    allowed = {"operation", "inputPath", "languageCode"}
+    if set(payload) - allowed:
+        raise ValueError("invalid media fields")
+    input_path = payload.get("inputPath")
+    if not isinstance(input_path, str) or not AGENT_MEDIA_PATH_RE.fullmatch(input_path):
+        raise ValueError("invalid media inputPath")
+    if "languageCode" in payload and not isinstance(payload["languageCode"], str):
+        raise ValueError("invalid media languageCode")
+    return dict(payload)
+
+
+def _validate_workspace_prefix(value: object) -> str:
+    """Accept only the prefix shape the workspace actually uses."""
+    if (
+        not isinstance(value, str)
+        or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}/?", value)
+    ):
+        raise RuntimeError("Invocation workspace prefix is invalid")
+    return value if value.endswith("/") else f"{value}/"
+
+
+async def _resolve_invocation_identity() -> tuple[str, str]:
+    """Resolve the signed owner AND workspace prefix for a media invocation.
+
+    Unlike _resolve_invocation_owner there is deliberately NO old-tier fallback.
+    The prefix decides which owner's objects the function may touch, so if the
+    web tier is too old to return it this fails closed and media stays
+    unavailable until the deploy catches up — the same web-tier-first ordering
+    every other cross-unit change in this repo follows.
+    """
+    try:
+        status, response_body = await asyncio.wait_for(
+            _post_signed_identity_request(INVOCATION_IDENTITY_ROUTE),
+            timeout=HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError as exc:
+        raise RuntimeError("Invocation identity verification timed out") from exc
+    if status != 200:
+        raise RuntimeError("Invocation identity verification failed")
+    try:
+        result = json.loads(response_body)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Invocation identity response is invalid") from exc
+    if not isinstance(result, dict):
+        raise RuntimeError("Invocation identity response is invalid")
+    owner = _validate_invocation_owner(result.get("ownerEmail"))
+    prefix = _validate_workspace_prefix(result.get("workspacePrefix"))
+    return owner, prefix
+
+
+def _serialize_agent_media_payload(payload: dict) -> bytes:
+    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(body) > AGENT_MEDIA_INVOKE_PAYLOAD_MAX_BYTES:
+        raise ValueError("media serialized payload exceeds the configured limit")
+    return body
+
+
+def _invoke_agent_media(payload: dict) -> dict:
+    """Invoke only the configured media Lambda with root-owned AWS authority."""
+    function_name = os.environ.get("AGENT_MEDIA_FUNCTION", "")
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", function_name):
+        raise RuntimeError("Agent media function is not configured")
+    response = _new_lambda_client().invoke(
+        FunctionName=function_name,
+        InvocationType="RequestResponse",
+        Payload=_serialize_agent_media_payload(payload),
+    )
+    stream = response.get("Payload")
+    if stream is None:
+        raise RuntimeError("Agent media returned no payload")
+    body = _read_bounded_aws_stream(stream, AGENT_MEDIA_RESPONSE_MAX_BYTES)
+    if response.get("FunctionError"):
+        raise RuntimeError("Agent media Lambda reported a function error")
+    try:
+        result = json.loads(body)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Agent media returned invalid JSON") from exc
+    if not isinstance(result, dict):
+        raise RuntimeError("Agent media returned an invalid response")
+    return result
 
 
 def _validate_polly_payload(payload: object) -> dict:
@@ -1724,6 +1879,34 @@ async def handle_hyperframes_invoke(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
+async def handle_agent_media_invoke(request: web.Request) -> web.Response:
+    """Invoke only the configured media function; never accept an ARN or identity."""
+    if not _invocation_authority_is_available():
+        return web.json_response({"error": "Invocation authority is unavailable"}, status=503)
+    try:
+        payload = _validate_agent_media_payload(
+            await _read_fixed_aws_request(
+                request, max_bytes=AGENT_MEDIA_HTTP_REQUEST_MAX_BYTES
+            )
+        )
+    except ValueError:
+        return web.json_response({"error": "Invalid media request"}, status=400)
+    try:
+        owner_email, workspace_prefix = await _resolve_invocation_identity()
+        # Injected AFTER validation so a caller-supplied value cannot survive:
+        # the allowlist above already rejects these keys outright.
+        bound = {
+            **payload,
+            "userEmail": owner_email,
+            "workspacePrefix": workspace_prefix,
+        }
+        result = await asyncio.to_thread(_invoke_agent_media, bound)
+    except Exception as exc:  # noqa: BLE001
+        log.warning(j("agent_media_invoke_failed", error=type(exc).__name__))
+        return web.json_response({"error": "Media invocation failed"}, status=502)
+    return web.json_response(result)
+
+
 AGENT_BROKER_RESPONSE_MAX_BYTES = 64 * 1024 * 1024
 
 
@@ -2360,6 +2543,7 @@ def main() -> None:
     )
     app.router.add_post("/aws-skill/polly/synthesize", handle_polly_synthesize)
     app.router.add_post("/aws-skill/hyperframes/invoke", handle_hyperframes_invoke)
+    app.router.add_post("/aws-skill/media/invoke", handle_agent_media_invoke)
     app.router.add_route("*", "/agent-broker/{route:.*}", handle_agent_broker)
     app.router.add_route("*", "/{path:.*}", handle_proxy)
     log.info(

--- a/infra/agent-image/skills/_shared/media-relay.js
+++ b/infra/agent-image/skills/_shared/media-relay.js
@@ -1,0 +1,213 @@
+'use strict';
+
+const { validatedFs } = require("../../../validated-fs.cjs");
+
+/**
+ * Shared transport for the three media skills (#1738).
+ *
+ * Two hops, and the split matters:
+ *
+ *   1. BYTES go through the workspace-storage broker into the owner's own
+ *      private prefix, under `.media-scratch/`.
+ *   2. WORK is requested through the root-owned loopback relay, which injects
+ *      the web-verified owner and workspace prefix and invokes the media
+ *      Lambda. The skill never names an owner, a bucket or a function.
+ *
+ * Why `.media-scratch/` specifically. It is listed in
+ * lib/agent-workspace/workspace-policy.json under `checkpointExclusions`, so it
+ * is invisible to the workspace generation hash. That is not tidiness — an
+ * ad-hoc upload into a checkpoint-MANAGED path is deleted by the next
+ * `ensureWorkspaceCheckpoint`, which rolls the workspace back to its manifest
+ * and delete-markers anything unexpected. Scratch objects would silently
+ * vanish mid-turn. Being excluded also means they are never synced down into
+ * the container, which is what we want: they are a transport, not history.
+ */
+
+const http = require('node:http');
+const { randomUUID } = require('node:crypto');
+const path = require('node:path');
+const { requestAgentBroker } = require('./agent-broker');
+
+const AWS_RELAY_HOST = '127.0.0.1';
+const AWS_RELAY_PORT = 18791;
+const AWS_RELAY_PATH = '/aws-skill/media/invoke';
+const SCRATCH_PREFIX = '.media-scratch/';
+
+// Mirrors the Lambda's own ceilings — see infra/agent-media/README.md. Checked
+// here so an oversized file fails before it is uploaded rather than after.
+const MAX_UPLOAD_BYTES = 512 * 1024 * 1024;
+const MAX_RELAY_RESPONSE_BYTES = 8 * 1024 * 1024;
+// The Lambda may spend 780s; the relay then needs its identity round-trip and
+// transport margin on top. Matches the arithmetic in psd-hyperframes/render.js.
+const RELAY_TIMEOUT_MS = 825_000;
+
+function fail(message, code) {
+  const error = new Error(message);
+  error.code = code || 'media_failed';
+  throw error;
+}
+
+/** One scratch path, in the excluded prefix, with the extension preserved. */
+function scratchPath(extension) {
+  const clean = String(extension || '').toLowerCase();
+  if (clean && !/^\.[a-z0-9]{1,8}$/.test(clean)) {
+    fail(`unsupported file extension: ${extension}`, 'bad_args');
+  }
+  return `${SCRATCH_PREFIX}${randomUUID()}${clean}`;
+}
+
+/**
+ * Put a local file into the owner's private scratch prefix.
+ *
+ * Deliberately NOT generation-fenced: `complete-upload`'s generation argument is
+ * optional, and a mid-turn skill upload must not participate in the turn's
+ * finalization protocol. Because the target is checkpoint-excluded, an unfenced
+ * write here cannot desync the workspace generation either way.
+ */
+async function uploadScratch(localPath) {
+  let stat;
+  try {
+    stat = validatedFs.statSync(localPath);
+  } catch (error) {
+    fail(`cannot read ${localPath}: ${error.message}`, 'bad_args');
+  }
+  if (!stat.isFile()) fail(`${localPath} is not a file`, 'bad_args');
+  if (stat.size === 0) fail(`${localPath} is empty`, 'bad_args');
+  if (stat.size > MAX_UPLOAD_BYTES) {
+    fail(
+      `${localPath} is ${stat.size} bytes, over the ${MAX_UPLOAD_BYTES}-byte limit`,
+      'too_large',
+    );
+  }
+
+  const workspacePath = scratchPath(path.extname(localPath));
+  const prepared = await requestAgentBroker('/api/agent/workspace-storage', {
+    operation: 'upload',
+    path: workspacePath,
+    contentLength: stat.size,
+    idempotencyKey: randomUUID(),
+  });
+  if (typeof prepared?.uploadUrl !== 'string' || typeof prepared?.reservationId !== 'string') {
+    fail('workspace upload was not prepared');
+  }
+
+  const response = await fetch(prepared.uploadUrl, {
+    method: 'PUT',
+    headers: prepared.requiredHeaders || {},
+    body: validatedFs.readFileSync(localPath),
+    redirect: 'error',
+    signal: AbortSignal.timeout(300_000),
+  });
+  if (!response.ok) fail(`workspace upload failed: HTTP ${response.status}`);
+
+  await requestAgentBroker('/api/agent/workspace-storage', {
+    operation: 'complete-upload',
+    reservationId: prepared.reservationId,
+  });
+  return workspacePath;
+}
+
+/** Pull a scratch object back down to a local path. */
+async function downloadScratch(workspacePath, localPath) {
+  const prepared = await requestAgentBroker('/api/agent/workspace-storage', {
+    operation: 'download',
+    path: workspacePath,
+  });
+  if (typeof prepared?.downloadUrl !== 'string') {
+    fail('workspace download was not prepared');
+  }
+  const response = await fetch(prepared.downloadUrl, {
+    headers: prepared.requiredHeaders || {},
+    redirect: 'error',
+    signal: AbortSignal.timeout(300_000),
+  });
+  if (!response.ok) fail(`workspace download failed: HTTP ${response.status}`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  validatedFs.writeFileSync(localPath, bytes);
+  return bytes.length;
+}
+
+/**
+ * Remove a scratch object. Best-effort by contract: a retained scratch object
+ * is untidy, never a failure, and must not turn a completed conversion into an
+ * error the user sees.
+ */
+async function deleteScratch(workspacePath) {
+  try {
+    await requestAgentBroker('/api/agent/workspace-storage', {
+      operation: 'delete',
+      path: workspacePath,
+    });
+  } catch {
+    /* the workspace lifecycle reaps it */
+  }
+}
+
+/** Ask the root relay to run one media operation. */
+function callMediaRelay(payload) {
+  const body = JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        host: AWS_RELAY_HOST,
+        port: AWS_RELAY_PORT,
+        path: AWS_RELAY_PATH,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+        timeout: RELAY_TIMEOUT_MS,
+      },
+      (response) => {
+        const chunks = [];
+        let total = 0;
+        response.on('data', (chunk) => {
+          total += chunk.length;
+          if (total > MAX_RELAY_RESPONSE_BYTES) {
+            request.destroy(new Error('media relay response exceeded the limit'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        response.on('end', () => {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          if (response.statusCode !== 200) {
+            reject(new Error(`media relay returned HTTP ${response.statusCode || 502}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(raw));
+          } catch {
+            reject(new Error('media relay returned invalid JSON'));
+          }
+        });
+      },
+    );
+    request.on('timeout', () => request.destroy(new Error('media relay timed out')));
+    request.on('error', reject);
+    request.end(body);
+  });
+}
+
+/** Run one operation and surface a Lambda-reported error as a thrown Error. */
+async function runMedia(payload) {
+  const result = await callMediaRelay(payload);
+  if (!result || typeof result !== 'object') fail('media relay returned no result');
+  if (result.status !== 'ok') {
+    const error = new Error(result.message || 'the media operation failed');
+    error.code = result.error || 'media_failed';
+    throw error;
+  }
+  return result;
+}
+
+module.exports = {
+  runMedia,
+  uploadScratch,
+  downloadScratch,
+  deleteScratch,
+  scratchPath,
+  SCRATCH_PREFIX,
+  MAX_UPLOAD_BYTES,
+};

--- a/infra/agent-image/skills/psd-media/SKILL.md
+++ b/infra/agent-image/skills/psd-media/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: psd-media
+summary: Inspect and convert video and audio with ffmpeg — check a file, or convert it for Facebook, Instagram, the web, or audio-only MP3.
+description: Probe a media file (codec, resolution, frame rate, duration, audio channels) or convert it with a named preset. Use when the user uploads or points at a video or audio file and asks whether it will work somewhere, asks to convert, compress, re-encode, or fix a video, wants an MP4 for social media, or wants the audio pulled out of a video. Handles .mov, .mp4, .avi, .mkv, .webm, .m4a, .wav and anything else ffmpeg reads.
+allowed-tools: Bash(node:*)
+---
+
+# psd-media
+
+Answer "will this video work?" and "convert it so it does".
+
+```bash
+# What IS this file?
+node /opt/psd-skills/psd-media/media.js --probe --file /tmp/clip.mov
+
+# Make it work for Facebook / Instagram / YouTube
+node /opt/psd-skills/psd-media/media.js --convert --file /tmp/clip.mov \
+  --out /tmp/clip.mp4 --preset social-mp4
+```
+
+## Probe first when the question is "will this work"
+
+`--probe` returns codec, resolution, frame rate, pixel format, duration and
+audio layout. Answer from those facts rather than guessing from the extension —
+a `.mov` can contain almost anything, and the extension tells you nothing about
+whether an uploader will accept it.
+
+```json
+{
+  "action": "probe", "file": "/tmp/clip.mov", "bytes": 3559763,
+  "durationSeconds": 2.0, "formatName": "mov,mp4,m4a",
+  "video": { "codec": "prores", "width": 640, "height": 480, "fps": 30, "pixelFormat": "yuv422p10le" },
+  "audio": { "codec": "pcm_s16le", "channels": 1, "sampleRate": 44100 }
+}
+```
+
+That example needs converting: ProRes and PCM are editing formats, not upload
+formats.
+
+## Presets
+
+| preset | output | for |
+|---|---|---|
+| `social-mp4` | `.mp4` | Facebook, Instagram, YouTube. H.264 High / yuv420p + AAC, `+faststart` |
+| `web-mp4` | `.mp4` | same, capped at 720p — embedding in a page or email |
+| `audio-mp3` | `.mp3` | audio only; any video is discarded |
+
+There is no raw-ffmpeg-arguments option, deliberately. If a request genuinely
+needs a shape none of these cover, say so rather than improvising.
+
+**Why `social-mp4` is specified the way it is:** `yuv420p` and `+faststart` are
+the two settings whose absence makes an upload fail or be rejected as corrupt,
+and they are the reason "it's already an MP4" is not the same as "it will
+upload". Worth saying to a user who asks why their file needed converting.
+
+## Limits
+
+- Input: **512 MB**.
+- A long transcode has to finish inside the turn. Minutes of 1080p are fine;
+  an hour of 4K is not — probe first and say so if it looks marginal.
+
+## After it runs
+
+The output is a **local file**. Not shared, not published, no link.
+
+- To hand over a link, publish it deliberately with `psd-publish-file`.
+- To transcribe it, `psd-transcribe` takes the file directly — no need to
+  convert first unless the extension is one Transcribe does not accept.
+
+## Errors
+
+| `error` | meaning |
+|---|---|
+| `bad_args` | missing/invalid flag, unknown preset, or wrong output extension |
+| `too_large` | input over 512 MB |
+| `media_failed` | ffmpeg or ffprobe failed; the message carries its diagnostic |
+
+A `bad_args` naming a preset mismatch is usually the output extension: `.mp4`
+for the video presets, `.mp3` for `audio-mp3`.

--- a/infra/agent-image/skills/psd-media/evals/probe-then-convert.yaml
+++ b/infra/agent-image/skills/psd-media/evals/probe-then-convert.yaml
@@ -1,0 +1,13 @@
+id: media-probe-then-convert
+skill: psd-media
+level: L2
+workspace: mutating
+suite: capability
+# The kinneyk shape: "will this upload to Facebook?" The right answer probes
+# first and reports actual codecs, rather than guessing from the extension.
+prompt: "Using ffmpeg's built-in test sources, create a two-second test video at /tmp/eval1426.mov encoded as ProRes with PCM audio. Then use psd-media to probe it, tell me whether it is ready to upload to Facebook, and if not convert it with the social-mp4 preset and report the codecs before and after. This is synthetic test data."
+trials: 3
+graders:
+  - {"type":"output_match","pattern":"(?i)prores"}
+  - {"type":"output_match","pattern":"(?i)h\\.?264"}
+  - {"type":"output_match","pattern":"(?i)yuv420p|faststart|aac"}

--- a/infra/agent-image/skills/psd-media/media.js
+++ b/infra/agent-image/skills/psd-media/media.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * psd-media — inspect and convert audio/video with ffmpeg.
+ *
+ * The failure this exists to end (kinneyk, 2026-09-01): a .mov was uploaded and
+ * the user asked whether it would work for Facebook and Instagram. There was no
+ * ffmpeg and no ffprobe in the container, so the agent could neither answer nor
+ * convert, and the turn ended with nothing delivered.
+ *
+ * Presets, not raw ffmpeg arguments. Arbitrary argv into ffmpeg is a
+ * command-injection and resource-exhaustion surface, and every real request so
+ * far has been one of these three shapes.
+ */
+
+'use strict';
+
+const { validatedFs } = require("../../../validated-fs.cjs");
+
+const path = require('node:path');
+const {
+  runMedia,
+  uploadScratch,
+  downloadScratch,
+  deleteScratch,
+  scratchPath,
+  MAX_UPLOAD_BYTES,
+} = require('../_shared/media-relay');
+
+const PRESETS = {
+  'social-mp4': '.mp4',
+  'web-mp4': '.mp4',
+  'audio-mp3': '.mp3',
+};
+
+function emit(object) {
+  process.stdout.write(`${JSON.stringify(object, null, 2)}\n`);
+}
+
+function fail(message, code = 'error') {
+  process.stderr.write(`Error: ${message}\n`);
+  process.stdout.write(`${JSON.stringify({ error: code, message })}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) fail(`Unexpected positional argument: ${arg}`, 'bad_args');
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function valued(args, key, flag) {
+  const value = args[key];
+  if (value === undefined) return undefined;
+  if (value === true) fail(`${flag} needs a value`, 'bad_args');
+  return String(value);
+}
+
+/** Validate the --convert flags. Split out to keep main() flat. */
+function convertOptions(args) {
+  const preset = valued(args, 'preset', '--preset');
+  const out = valued(args, 'out', '--out');
+  if (!preset) fail('--preset is required with --convert', 'bad_args');
+  if (!Object.hasOwn(PRESETS, preset)) {
+    fail(`--preset must be one of ${Object.keys(PRESETS).join(', ')}`, 'bad_args');
+  }
+  if (!out) fail('--out <output> is required with --convert', 'bad_args');
+  if (path.extname(out).toLowerCase() !== PRESETS[preset]) {
+    fail(`--out must end in ${PRESETS[preset]} for ${preset}`, 'bad_args');
+  }
+  return { preset, out };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(
+      'Usage:\n' +
+        '  media.js --probe   --file <input>\n' +
+        '  media.js --convert --file <input> --out <output> --preset <name>\n' +
+        '\n' +
+        `Presets: ${Object.keys(PRESETS).join(', ')}\n` +
+        '  social-mp4  H.264/yuv420p + AAC, +faststart — Facebook, Instagram, YouTube\n' +
+        '  web-mp4     same, capped at 720p — embedding in a page or email\n' +
+        '  audio-mp3   audio only, video discarded\n',
+    );
+    return;
+  }
+
+  const file = valued(args, 'file', '--file');
+  if (!file) fail('--file <input> is required', 'bad_args');
+  const wantsConvert = args.convert === true;
+  if (!wantsConvert && args.probe !== true) {
+    fail('pass --probe or --convert', 'bad_args');
+  }
+  if (wantsConvert && args.probe === true) {
+    fail('pass either --probe or --convert, not both', 'bad_args');
+  }
+
+  let stat;
+  try {
+    stat = validatedFs.statSync(file);
+  } catch (error) {
+    fail(`cannot read ${file}: ${error.message}`, 'bad_args');
+  }
+  if (stat.size > MAX_UPLOAD_BYTES) {
+    fail(
+      `${file} is ${stat.size} bytes, over the ${MAX_UPLOAD_BYTES}-byte limit`,
+      'too_large',
+    );
+  }
+
+  const { preset, out } = wantsConvert
+    ? convertOptions(args)
+    : { preset: null, out: null };
+
+  // Upload, work, download, clean up. The scratch objects live in the owner's
+  // own checkpoint-excluded prefix and are removed on every exit path so a
+  // large video does not linger in the workspace bucket.
+  const uploaded = [];
+  try {
+    const inputPath = await uploadScratch(file);
+    uploaded.push(inputPath);
+
+    if (!wantsConvert) {
+      const result = await runMedia({ operation: 'media', action: 'probe', inputPath });
+      emit({ action: 'probe', file, bytes: result.inputBytes, ...result.probe });
+      return;
+    }
+
+    const outputPath = scratchPath(PRESETS[preset]);
+    const result = await runMedia({
+      operation: 'media',
+      action: 'convert',
+      inputPath,
+      outputPath,
+      preset,
+    });
+    uploaded.push(outputPath);
+    const bytes = await downloadScratch(outputPath, out);
+    emit({
+      action: 'convert',
+      preset,
+      file: out,
+      bytes,
+      inputBytes: result.inputBytes,
+      before: result.probe,
+      after: result.outputProbe,
+      sharing: 'local-file-not-published',
+    });
+  } catch (error) {
+    fail(error.message, error.code || 'media_failed');
+  } finally {
+    for (const workspacePath of uploaded) {
+      await deleteScratch(workspacePath);
+    }
+  }
+}
+
+main().catch((error) => fail(error.message));

--- a/infra/agent-image/skills/psd-media/package.json
+++ b/infra/agent-image/skills/psd-media/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "psd-media",
+  "version": "1.0.0",
+  "private": true,
+  "description": "OpenClaw skill: ffprobe inspection and ffmpeg preset conversion via the agent-media Lambda (#1738).",
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/infra/agent-image/skills/psd-print-pdf/SKILL.md
+++ b/infra/agent-image/skills/psd-print-pdf/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: psd-print-pdf
+summary: Turn an HTML page into a real printable PDF — 8.5x11, letter, A4, landscape. Use when asked to save, print, or download a page or artifact as a PDF.
+description: Convert a local HTML file into a true PDF using headless Chromium, honouring @page CSS, flexbox, embedded images and web fonts. Use when the user asks to save a page, sign, flyer, report or HTML artifact as a PDF, wants something printable, or asks for an 8.5x11 / letter / A4 version of a page. Produces a local .pdf file; publishing it is a separate step.
+allowed-tools: Bash(node:*)
+---
+
+# psd-print-pdf
+
+You have an HTML file. The user wants a PDF they can print.
+
+```bash
+node /opt/psd-skills/psd-print-pdf/print.js --file /tmp/sign.html --out /tmp/sign.pdf
+```
+
+Returns JSON:
+
+```json
+{
+  "file": "/tmp/sign.pdf",
+  "bytes": 20924,
+  "pages": 1,
+  "pageSize": "letter",
+  "landscape": false,
+  "sharing": "local-file-not-published"
+}
+```
+
+## What it renders faithfully
+
+Real headless Chromium, so the PDF matches what a browser prints: `@page` CSS,
+flexbox and grid, CSS gradients, embedded `data:` images, web fonts, and
+backgrounds. This is the whole point of the skill — the previous fallback
+(PyMuPDF) silently dropped every one of those and produced a wrong-sized page
+that looked broken to the person who opened it.
+
+**The page's own `@page` CSS wins over `--page-size`.** A page already laid out
+for 8.5×11 needs no flags at all.
+
+## Options
+
+| flag | default | notes |
+|---|---|---|
+| `--page-size` | `letter` | `letter`, `legal`, `tabloid`, `a4`, `a3` |
+| `--landscape` | portrait | |
+| `--margin-inches` | `0` | 0–3. Zero is right for a full-bleed design |
+| `--scale` | `1` | 0.1–2 |
+| `--no-background` | backgrounds printed | use for a draft that must not burn ink |
+
+## Limits
+
+- Input HTML: **4 MB**. Large embedded base64 images are the usual cause of
+  going over — reference them by public `https` URL instead.
+- Output PDF: **4 MB**. Above that, split the document.
+
+## After it runs
+
+The PDF is a **local file and nothing else**. It is not shared, not published,
+and not reachable by a link.
+
+- If the user wants to keep or print it, say where it is and stop.
+- If the user wants a **link**, publish it deliberately with
+  `psd-publish-file`, which will make you decide whether the contents are safe
+  for an unguessable public URL. A staff flyer, yes. A student record, no.
+- Do not paste the local path as if it were a URL.
+
+## Working with psd-html-artifact
+
+The natural pairing: `psd-html-artifact` for the design, this for the print
+copy. Build the page first, write it to `/tmp`, then print it.
+
+Note that `psd-html-artifact` publishes to Atrium and returns a reader URL,
+which is a different deliverable — a page to read online, not a file to print.
+When someone asks for both, do both; they are not substitutes.
+
+## Errors
+
+| `error` | meaning |
+|---|---|
+| `bad_args` | a flag is missing, unparseable, or out of range — the message names which |
+| `too_large` | input HTML or output PDF over the 4 MB limit |
+| `render_failed` | Chromium could not render the page; the message carries its diagnostic |
+
+A failure here is worth reporting plainly. Do **not** fall back to telling the
+user to print the page themselves — that is the exact dead end this skill
+replaced.

--- a/infra/agent-image/skills/psd-print-pdf/evals/print-letter-sign.yaml
+++ b/infra/agent-image/skills/psd-print-pdf/evals/print-letter-sign.yaml
@@ -1,0 +1,15 @@
+id: print-pdf-letter-sign
+skill: psd-print-pdf
+level: L2
+workspace: mutating
+suite: capability
+# Reproduces the request that failed on 2026-09-01: an 8.5x11 sign saved as a
+# printable PDF. The old fallback returned a valid PDF at the WRONG size, so a
+# grader that only checked "a pdf exists" would have passed the broken
+# behaviour. Assert the reported page size instead.
+prompt: "Write a one-page 8.5x11 HTML sign that reads \"EVAL 1426 BACK TO SCHOOL\" on a dark background using @page CSS, save it to /tmp, then convert it to a printable PDF with psd-print-pdf and tell me the file path, the page count and the page size."
+trials: 3
+graders:
+  - {"type":"output_match","pattern":"(?i)\\.pdf"}
+  - {"type":"output_match","pattern":"(?i)letter|8\\.5"}
+  - {"type":"output_match","pattern":"(?i)1 page|one page|\"pages\":\\s*1"}

--- a/infra/agent-image/skills/psd-print-pdf/package.json
+++ b/infra/agent-image/skills/psd-print-pdf/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "psd-print-pdf",
+  "version": "1.0.0",
+  "private": true,
+  "description": "OpenClaw skill: render a local HTML file to a real PDF via the agent-media Lambda's headless Chromium (#1738).",
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/infra/agent-image/skills/psd-print-pdf/print.js
+++ b/infra/agent-image/skills/psd-print-pdf/print.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+/**
+ * psd-print-pdf — turn an HTML file into a real PDF via headless Chromium.
+ *
+ * The failure this exists to end (nashs, 2026-09-01): asked to save an 8.5x11
+ * back-to-school sign as a printable PDF, the agent had no browser, fell back
+ * to PyMuPDF's HTML renderer, and produced a 400x600pt page with the flexbox
+ * layout collapsed, the base64 logo dropped and the web fonts substituted. The
+ * advice given was "open the link and use Print > Save as PDF yourself".
+ */
+
+'use strict';
+
+const { validatedFs } = require("../../../validated-fs.cjs");
+
+const path = require('node:path');
+const { runMedia } = require('../_shared/media-relay');
+
+const PAGE_SIZES = ['letter', 'legal', 'tabloid', 'a4', 'a3'];
+const MAX_HTML_BYTES = 4 * 1024 * 1024;
+
+function emit(object) {
+  process.stdout.write(`${JSON.stringify(object, null, 2)}\n`);
+}
+
+function fail(message, code = 'error') {
+  process.stderr.write(`Error: ${message}\n`);
+  process.stdout.write(`${JSON.stringify({ error: code, message })}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) fail(`Unexpected positional argument: ${arg}`, 'bad_args');
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+/** A flag that needs a value must not be silently ignored when given none. */
+function valued(args, key, flag) {
+  const value = args[key];
+  if (value === undefined) return undefined;
+  if (value === true) {
+    fail(`${flag} needs a value`, 'bad_args');
+  }
+  return String(value);
+}
+
+/** One bounded numeric flag, or undefined when it was not supplied. */
+function boundedFlag(args, key, flag, minimum, maximum) {
+  const raw = valued(args, key, flag);
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < minimum || value > maximum) {
+    fail(`${flag} must be between ${minimum} and ${maximum}`, 'bad_args');
+  }
+  return value;
+}
+
+/** Turn parsed argv into the relay payload. Split out to keep main() flat. */
+function buildPayload(args, html) {
+  const pageSize = valued(args, 'page_size', '--page-size') || 'letter';
+  if (!PAGE_SIZES.includes(pageSize)) {
+    fail(`--page-size must be one of ${PAGE_SIZES.join(', ')}`, 'bad_args');
+  }
+  const payload = { operation: 'html-to-pdf', html, pageSize };
+  if (args.landscape === true) payload.landscape = true;
+  if (args.no_background === true) payload.printBackground = false;
+
+  const marginInches = boundedFlag(args, 'margin_inches', '--margin-inches', 0, 3);
+  if (marginInches !== undefined) payload.marginInches = marginInches;
+  const scale = boundedFlag(args, 'scale', '--scale', 0.1, 2);
+  if (scale !== undefined) payload.scale = scale;
+  return payload;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(
+      'Usage: print.js --file <page.html> --out <output.pdf> [options]\n' +
+        '\n' +
+        `  --page-size   ${PAGE_SIZES.join(' | ')}   (default letter)\n` +
+        '  --landscape                                (default portrait)\n' +
+        '  --margin-inches <0..3>                     (default 0)\n' +
+        '  --scale <0.1..2>                           (default 1)\n' +
+        '  --no-background                            omit printed backgrounds\n' +
+        '\n' +
+        "The page's own @page CSS wins over --page-size, which is what a page\n" +
+        'already laid out for 8.5x11 relies on.',
+    );
+    return;
+  }
+
+  const file = valued(args, 'file', '--file');
+  const out = valued(args, 'out', '--out');
+  if (!file) fail('--file <page.html> is required', 'bad_args');
+  if (!out) fail('--out <output.pdf> is required', 'bad_args');
+  if (!/\.html?$/i.test(file)) {
+    fail(`--file must be an .html file (got ${path.extname(file) || 'no extension'})`, 'bad_args');
+  }
+  if (!/\.pdf$/i.test(out)) fail('--out must end in .pdf', 'bad_args');
+
+  let html;
+  try {
+    html = validatedFs.readFileSync(file, 'utf8');
+  } catch (error) {
+    fail(`cannot read ${file}: ${error.message}`, 'bad_args');
+  }
+  if (html.trim() === '') fail(`${file} is empty`, 'bad_args');
+  const bytes = Buffer.byteLength(html, 'utf8');
+  if (bytes > MAX_HTML_BYTES) {
+    fail(
+      `${file} is ${bytes} bytes, over the ${MAX_HTML_BYTES}-byte limit. ` +
+        'Large embedded images are the usual cause — reference them by https URL instead.',
+      'too_large',
+    );
+  }
+
+  const payload = buildPayload(args, html);
+
+  let result;
+  try {
+    result = await runMedia(payload);
+  } catch (error) {
+    fail(error.message, error.code || 'render_failed');
+  }
+
+  const pdf = Buffer.from(result.pdfBase64, 'base64');
+  if (pdf.subarray(0, 5).toString() !== '%PDF-') {
+    fail('the renderer returned something that is not a PDF', 'render_failed');
+  }
+  validatedFs.writeFileSync(out, pdf);
+
+  emit({
+    file: out,
+    bytes: pdf.length,
+    pages: result.pages,
+    pageSize: result.pageSize,
+    landscape: result.landscape,
+    // Said explicitly because the next step is a judgement call the agent has
+    // to make deliberately: this file is LOCAL and private until someone
+    // publishes it.
+    sharing: 'local-file-not-published',
+  });
+}
+
+main().catch((error) => fail(error.message));

--- a/infra/agent-image/skills/psd-transcribe/SKILL.md
+++ b/infra/agent-image/skills/psd-transcribe/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: psd-transcribe
+summary: Turn a recording into text — transcribe audio or video into a transcript, script, or notes. Handles m4a, mp3, mp4, wav and more.
+description: Transcribe speech from an audio or video file into text using Amazon Transcribe. Use when the user shares a recording, voice memo, meeting audio, podcast, or video and asks for a transcript, a script, notes, a summary of what was said, or asks what is in the recording. Accepts .m4a, .mp3, .mp4, .wav, .flac, .ogg, .amr and .webm; other formats convert first with psd-media.
+allowed-tools: Bash(node:*)
+---
+
+# psd-transcribe
+
+Speech in a file, text out.
+
+```bash
+node /opt/psd-skills/psd-transcribe/transcribe.js --file /tmp/recording.m4a
+```
+
+Returns JSON with the transcript inline:
+
+```json
+{ "transcript": "Starting our week off strong…", "characters": 4820,
+  "truncated": false, "language": "en-US" }
+```
+
+Add `--out /tmp/transcript.txt` to also write it to a file — useful when the
+next step is turning it into a document rather than reading it in chat.
+
+## Accepted formats
+
+`.m4a` `.mp3` `.mp4` `.wav` `.flac` `.ogg` `.amr` `.webm`
+
+Anything else — `.aiff`, `.wma`, an odd container — convert first:
+
+```bash
+node /opt/psd-skills/psd-media/media.js --convert --file /tmp/odd.aiff \
+  --out /tmp/audio.mp3 --preset audio-mp3
+```
+
+Video works directly; there is no need to strip the audio yourself.
+
+## Language
+
+Defaults to `en-US`. Pass `--language es-US` (or any `xx-XX` code) when the
+recording is not English. Getting this wrong produces confident nonsense rather
+than an error, so if a user mentions the recording is in another language, set
+it.
+
+## Limits
+
+- Input: **512 MB**.
+- Transcription must finish inside the turn. A short recording is quick; an
+  hour-long one is close to the ceiling — if it times out, say so plainly.
+- Transcript: 600k characters, then truncated with `truncated: true`. Report
+  that honestly rather than presenting a partial transcript as complete.
+
+## What to do with the result
+
+The transcript is **raw**: no speaker labels, punctuation from the recogniser,
+and verbatim filler. That is usually not what the user wants as a deliverable.
+
+- Asked for a **script** or **notes** — clean it up and structure it yourself.
+  That is your work, not the recogniser's.
+- Asked for a **printable** version — write the cleaned text to HTML and use
+  `psd-print-pdf`.
+- Asked for the **exact words** — hand back the transcript as-is and say it is
+  unedited.
+
+## Privacy
+
+A recording is someone's voice, and often a meeting they did not expect to be
+republished. The transport copy is deleted after transcription, and nothing here
+publishes anything. Do not publish the audio or the transcript with
+`psd-publish-file` unless the user explicitly asks — an unguessable public link
+is still a public link.
+
+## Errors
+
+| `error` | meaning |
+|---|---|
+| `bad_args` | unsupported extension (the message gives the conversion command) or a bad `--language` |
+| `too_large` | over 512 MB |
+| `empty_transcript` | no speech detected — check the file has audible speech and the language matches |
+| `transcribe_failed` | the job failed or timed out; the message carries the reason |

--- a/infra/agent-image/skills/psd-transcribe/evals/transcribe-spoken-canary.yaml
+++ b/infra/agent-image/skills/psd-transcribe/evals/transcribe-spoken-canary.yaml
@@ -1,0 +1,14 @@
+id: transcribe-spoken-canary
+skill: psd-transcribe
+level: L2
+workspace: mutating
+suite: capability
+# demontek's shape: a recording in, readable text out. The canary phrase can
+# only appear if speech recognition actually ran, so this cannot be satisfied
+# by a model that merely describes the skill.
+prompt: "Use psd-tts to synthesize the sentence \"The enrollment count is one thousand two hundred four.\" to an audio file in /tmp, then transcribe that audio back to text with psd-transcribe and report exactly what the transcript says. This is synthetic test data."
+trials: 3
+graders:
+  - {"type":"output_match","pattern":"(?i)enrollment"}
+  - {"type":"output_match","pattern":"(?i)(1,?204|one thousand two hundred (and )?four|twelve oh four)"}
+  - {"type":"output_match","pattern":"(?is)\\A(?!.*(cannot be transcribed|no speech-to-text|not available))"}

--- a/infra/agent-image/skills/psd-transcribe/package.json
+++ b/infra/agent-image/skills/psd-transcribe/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "psd-transcribe",
+  "version": "1.0.0",
+  "private": true,
+  "description": "OpenClaw skill: speech-to-text over a workspace recording via the agent-media Lambda and Amazon Transcribe (#1738).",
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/infra/agent-image/skills/psd-transcribe/transcribe.js
+++ b/infra/agent-image/skills/psd-transcribe/transcribe.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/**
+ * psd-transcribe — turn a recording into text with Amazon Transcribe.
+ *
+ * The failure this exists to end (demontek, 2026-09-03): an .m4a from Drive was
+ * downloaded successfully, and then nothing. No Whisper key, no Transcribe
+ * permission on the execution role, and the configured Bedrock model takes text
+ * and images but not audio. The self-report named the cause exactly.
+ */
+
+'use strict';
+
+const { validatedFs } = require("../../../validated-fs.cjs");
+
+const path = require('node:path');
+const {
+  runMedia,
+  uploadScratch,
+  deleteScratch,
+  MAX_UPLOAD_BYTES,
+} = require('../_shared/media-relay');
+
+// What Transcribe itself accepts. Anything else needs psd-media first.
+const TRANSCRIBABLE = ['.mp3', '.mp4', '.m4a', '.wav', '.flac', '.ogg', '.amr', '.webm'];
+const LANGUAGE_RE = /^[a-z]{2}-[A-Z]{2}$/;
+
+function emit(object) {
+  process.stdout.write(`${JSON.stringify(object, null, 2)}\n`);
+}
+
+function fail(message, code = 'error') {
+  process.stderr.write(`Error: ${message}\n`);
+  process.stdout.write(`${JSON.stringify({ error: code, message })}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) fail(`Unexpected positional argument: ${arg}`, 'bad_args');
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function valued(args, key, flag) {
+  const value = args[key];
+  if (value === undefined) return undefined;
+  if (value === true) fail(`${flag} needs a value`, 'bad_args');
+  return String(value);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(
+      'Usage: transcribe.js --file <recording.m4a> [--language en-US] [--out transcript.txt]\n' +
+        '\n' +
+        `Accepts: ${TRANSCRIBABLE.join(', ')}\n` +
+        'Anything else: convert it first with psd-media --preset audio-mp3.\n' +
+        '\n' +
+        'Prints the transcript as JSON. --out also writes it to a text file.',
+    );
+    return;
+  }
+
+  const file = valued(args, 'file', '--file');
+  if (!file) fail('--file <recording> is required', 'bad_args');
+  const extension = path.extname(file).toLowerCase();
+  if (!TRANSCRIBABLE.includes(extension)) {
+    fail(
+      `${extension || '(no extension)'} cannot be transcribed. Accepted: ` +
+        `${TRANSCRIBABLE.join(', ')}. Convert it first:\n` +
+        `  node /opt/psd-skills/psd-media/media.js --convert --file ${file} ` +
+        '--out /tmp/audio.mp3 --preset audio-mp3',
+      'bad_args',
+    );
+  }
+
+  let stat;
+  try {
+    stat = validatedFs.statSync(file);
+  } catch (error) {
+    fail(`cannot read ${file}: ${error.message}`, 'bad_args');
+  }
+  if (stat.size === 0) fail(`${file} is empty`, 'bad_args');
+  if (stat.size > MAX_UPLOAD_BYTES) {
+    fail(`${file} is ${stat.size} bytes, over the ${MAX_UPLOAD_BYTES}-byte limit`, 'too_large');
+  }
+
+  const language = valued(args, 'language', '--language') || 'en-US';
+  if (!LANGUAGE_RE.test(language)) {
+    fail('--language must look like en-US or es-US', 'bad_args');
+  }
+  const out = valued(args, 'out', '--out');
+
+  let inputPath = null;
+  try {
+    inputPath = await uploadScratch(file);
+    const result = await runMedia({
+      operation: 'transcribe',
+      inputPath,
+      languageCode: language,
+    });
+    if (out) validatedFs.writeFileSync(out, `${result.transcript}\n`, 'utf8');
+    emit({
+      transcript: result.transcript,
+      characters: result.characters,
+      truncated: result.truncated,
+      language: result.languageCode,
+      ...(out ? { file: out } : {}),
+    });
+  } catch (error) {
+    fail(error.message, error.code || 'transcribe_failed');
+  } finally {
+    // The recording is someone's voice. Remove the transport copy on every
+    // path rather than leaving it in the bucket for a lifecycle rule.
+    if (inputPath) await deleteScratch(inputPath);
+  }
+}
+
+main().catch((error) => fail(error.message));

--- a/infra/agent-image/test_mantle_proxy.py
+++ b/infra/agent-image/test_mantle_proxy.py
@@ -85,6 +85,8 @@ from mantle_proxy import (  # noqa: E402
     _UsageAccumulator,
     _validate_hyperframes_payload,
     _validate_polly_payload,
+    _validate_agent_media_payload,
+    _validate_workspace_prefix,
     _workspace_flush_request_allowed,
     _extract_usage,
     _is_anthropic_model,
@@ -1362,3 +1364,107 @@ class TestParseAnthropicResponse(unittest.TestCase):
         # Delegates to the stream parser when SSE data lines are present.
         content, *_ = _parse_anthropic_response(TestParseAnthropicStream.STREAM)
         self.assertEqual(content, "Hello")
+
+
+class TestAgentMediaRelayValidation(unittest.TestCase):
+    """The relay is the boundary the model cannot edit — prove it holds.
+
+    agent-media (#1738) reaches into the caller's own workspace prefix, so a
+    path that escapes it, or a payload that supplies its own identity, must die
+    here rather than at the Lambda. The handler re-checks everything too; this
+    is the outer of two independent gates.
+    """
+
+    def test_accepts_each_operation_in_its_documented_shape(self):
+        for payload in (
+            {"operation": "html-to-pdf", "html": "<p>hi</p>"},
+            {"operation": "html-to-pdf", "html": "<p>hi</p>", "pageSize": "letter",
+             "landscape": True, "marginInches": 0.5, "scale": 1.0},
+            {"operation": "media", "action": "probe", "inputPath": "in/clip.mov"},
+            {"operation": "media", "action": "convert", "inputPath": "in/clip.mov",
+             "outputPath": "out/clip.mp4", "preset": "social-mp4"},
+            {"operation": "transcribe", "inputPath": "audio/talk.m4a"},
+            {"operation": "transcribe", "inputPath": "a.m4a", "languageCode": "es-US"},
+        ):
+            self.assertEqual(
+                _validate_agent_media_payload(payload)["operation"],
+                payload["operation"],
+            )
+
+    def test_refuses_a_caller_supplied_identity_instead_of_overwriting_it(self):
+        # Rejected outright, not silently replaced: an attempt to reach another
+        # owner's workspace should be visible, not quietly corrected.
+        for field in ("workspacePrefix", "userEmail"):
+            with self.assertRaises(ValueError):
+                _validate_agent_media_payload(
+                    {"operation": "transcribe", "inputPath": "a.m4a", field: "someone-else/"}
+                )
+
+    def test_refuses_every_path_that_could_escape_the_owner_prefix(self):
+        for bad in (
+            "/etc/passwd",
+            "../other-owner/secret.mp4",
+            "a/../b.mp4",
+            "a/./b.mp4",
+            "a//b.mp4",
+            "..",
+            ".",
+            "dir\\file.mp4",
+            "",
+            "x" * 769,
+            "clip\x00.mov",
+            "clip\x1f.mov",
+            "clip\x7f.mov",
+        ):
+            with self.assertRaises(ValueError, msg=f"accepted {bad!r}"):
+                _validate_agent_media_payload(
+                    {"operation": "transcribe", "inputPath": bad}
+                )
+
+    def test_refuses_an_unknown_operation_or_stray_field(self):
+        with self.assertRaises(ValueError):
+            _validate_agent_media_payload({"operation": "rm-rf"})
+        with self.assertRaises(ValueError):
+            _validate_agent_media_payload(
+                {"operation": "html-to-pdf", "html": "<p>x</p>", "chromiumArgs": "--foo"}
+            )
+        with self.assertRaises(ValueError):
+            _validate_agent_media_payload(
+                {"operation": "media", "inputPath": "a.mov", "ffmpegArgs": "-y"}
+            )
+
+    def test_refuses_an_oversized_or_empty_html_body(self):
+        with self.assertRaises(ValueError):
+            _validate_agent_media_payload({"operation": "html-to-pdf", "html": "   "})
+        with self.assertRaises(ValueError):
+            _validate_agent_media_payload(
+                {"operation": "html-to-pdf", "html": "x" * (4 * 1024 * 1024 + 1)}
+            )
+
+    def test_refuses_non_finite_numbers(self):
+        for value in (float("nan"), float("inf")):
+            with self.assertRaises(ValueError):
+                _validate_agent_media_payload(
+                    {"operation": "html-to-pdf", "html": "<p>x</p>", "scale": value}
+                )
+
+    def test_booleans_are_not_accepted_as_numbers(self):
+        # bool is an int subclass in Python; without an explicit check True
+        # would sail through as a margin of 1 inch.
+        with self.assertRaises(ValueError):
+            _validate_agent_media_payload(
+                {"operation": "html-to-pdf", "html": "<p>x</p>", "marginInches": True}
+            )
+
+
+class TestWorkspacePrefixValidation(unittest.TestCase):
+    def test_normalises_a_trailing_slash(self):
+        self.assertEqual(_validate_workspace_prefix("owner-abc123"), "owner-abc123/")
+        self.assertEqual(_validate_workspace_prefix("owner-abc123/"), "owner-abc123/")
+
+    def test_refuses_anything_that_could_widen_scope(self):
+        for bad in (None, "", "/absolute/", "../escape/", "two/levels/", "has space/",
+                    ".hidden/", "x" * 200):
+            with self.assertRaises(RuntimeError, msg=f"accepted {bad!r}"):
+                _validate_workspace_prefix(bad)
+

--- a/infra/agent-media/.gitignore
+++ b/infra/agent-media/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/infra/agent-media/Dockerfile
+++ b/infra/agent-media/Dockerfile
@@ -1,0 +1,93 @@
+# agent-media — container-image Lambda giving the agent the three media
+# capabilities it kept having to refuse (issue #1738):
+#
+#   html-to-pdf  headless Chromium print-to-PDF, honouring @page CSS
+#                (nashs, 2026-09-01: "save this 8.5x11 sign as a PDF" — the
+#                 PyMuPDF fallback produced a garbled 400x600pt page)
+#   media        ffmpeg transcode + ffprobe inspection
+#                (kinneyk, 2026-09-01: a .mov to verify for Facebook/Instagram)
+#   transcribe   Amazon Transcribe over audio in the owner's workspace
+#                (demontek, 2026-09-03: an .m4a to turn into a printable script)
+#
+# Chromium and FFmpeg live HERE, never in the agent image: the AgentCore
+# Firecracker overlay-mount snapshotter cannot carry that native stack, and the
+# agent image sits near its 54-layer ceiling (see infra/agent-image/Dockerfile).
+# Lambda's 10 GB image limit is ample.
+#
+# SEPARATE from hyperframes-render deliberately, despite the overlapping tool
+# set. That function's role may write ONLY to public-images/; this one reads and
+# writes the owner's PRIVATE workspace prefix, because a scanned IEP or a staff
+# recording must never land in a public-by-link bucket. Merging them would widen
+# a production role to avoid a second image — the wrong trade.
+FROM node:22-bookworm-slim
+
+# Runtime deps: chromium + the shared libs it needs, fonts so a rendered page
+# looks like the page its author saw, and the build deps for aws-lambda-ric's
+# native addon. No @puppeteer/browsers here — unlike hyperframes, print-to-PDF
+# needs no BeginFrame-deterministic capture, so Debian's chromium is enough and
+# the image stays smaller.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl unzip xz-utils chromium \
+    libgbm1 libnss3 libatk-bridge2.0-0 libdrm2 libxcomposite1 \
+    libxdamage1 libxrandr2 libcups2 libasound2 libpangocairo-1.0-0 \
+    libxshmfence1 libgtk-3-0 \
+    fonts-liberation fonts-noto-color-emoji fonts-noto-cjk fonts-noto-core \
+    fonts-noto-extra fonts-noto-ui-core fonts-freefont-ttf fonts-dejavu-core \
+    fontconfig \
+    g++ make cmake libcurl4-openssl-dev python3 \
+    && rm -rf /var/lib/apt/lists/* && apt-get clean && fc-cache -fv
+
+ENV CHROMIUM_PATH=/usr/bin/chromium
+ENV CONTAINER=true
+
+# Self-contained ffmpeg/ffprobe, copied from a registry image pinned BY DIGEST.
+# Two hard-won reasons, both carried over from infra/hyperframes-render:
+#   1. Debian's ffmpeg dynamically loads 40+ shared libraries and its preflight
+#      FAILS inside the Lambda sandbox ("FFmpeg cannot start"), while a fully
+#      static build starts cleanly.
+#   2. BtbN's autobuild tags 404 after ~2-3 weeks — that publisher keeps no
+#      permanent version tags, so any autobuild pin rots on a timer and breaks
+#      the deploy. A registry digest cannot expire.
+# mwader/static-ffmpeg is third-party and single-maintainer; the digest pin is
+# what makes that acceptable — the exact bytes verified here are the only bytes
+# a later build can copy.
+COPY --from=mwader/static-ffmpeg:7.1.1-amd64@sha256:6769881cc02c80d33e387750a8e144d162adfab2775e934dd97899261dda3a0c \
+    /ffmpeg /ffprobe /opt/ffmpeg/
+# Prove both binaries execute in THIS base image rather than trusting the copy —
+# a static binary from a musl image running on Debian is exactly the combination
+# worth verifying at build time.
+RUN /opt/ffmpeg/ffmpeg -version | head -1 && /opt/ffmpeg/ffprobe -version | head -1
+ENV FFMPEG_PATH=/opt/ffmpeg/ffmpeg
+ENV FFPROBE_PATH=/opt/ffmpeg/ffprobe
+
+# Prove Chromium can actually produce a PDF at build time. A missing shared
+# library or a rejected sandbox flag otherwise surfaces as a runtime failure on
+# a real user's document, long after the image shipped.
+RUN printf '<!doctype html><title>probe</title><p>probe</p>' > /tmp/probe.html \
+    && /usr/bin/chromium --headless --no-sandbox --disable-gpu --disable-dev-shm-usage \
+       --no-pdf-header-footer --print-to-pdf=/tmp/probe.pdf /tmp/probe.html \
+    && head -c 5 /tmp/probe.pdf | grep -q '%PDF-' \
+    && rm -f /tmp/probe.html /tmp/probe.pdf \
+    && echo "chromium print-to-pdf OK"
+
+WORKDIR /var/task
+COPY agent-media/package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+COPY agent-media/handler.js ./
+# handler.js resolves ../validated-fs.cjs to /var/validated-fs.cjs at runtime.
+# Built from the infra/ context so this is the canonical shared implementation,
+# not a duplicate that can drift from the repository security wrapper.
+COPY validated-fs.cjs /var/validated-fs.cjs
+COPY agent-media/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Runtime Interface Emulator — local `docker run` smoke testing only. Real
+# Lambda sets AWS_LAMBDA_RUNTIME_API, so the entrypoint bypasses it there.
+# Pinned to a release, not `latest`, so rebuilds don't silently bake a different
+# binary; the x86_64 asset matches the Architecture.X86_64 function.
+ARG AWS_LAMBDA_RIE_VERSION=v1.35
+ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${AWS_LAMBDA_RIE_VERSION}/aws-lambda-rie-x86_64 /usr/local/bin/aws-lambda-rie
+RUN chmod +x /usr/local/bin/aws-lambda-rie
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["handler.handler"]

--- a/infra/agent-media/README.md
+++ b/infra/agent-media/README.md
@@ -1,0 +1,92 @@
+# agent-media
+
+Container-image Lambda giving the agent three capabilities it kept having to
+refuse (#1738). Each traces to a real prod refusal:
+
+| operation | request that failed | what it does |
+|---|---|---|
+| `html-to-pdf` | nashs, 2026-09-01 — "save this 8.5×11 sign as a PDF" | headless Chromium print-to-PDF, honouring `@page` CSS |
+| `media` | kinneyk, 2026-09-01 — a `.mov` to verify for Facebook/Instagram | ffprobe inspection, ffmpeg transcode via named presets |
+| `transcribe` | demontek, 2026-09-03 — an `.m4a` to turn into a script | Amazon Transcribe over audio in the owner's workspace |
+
+## Why this is a separate function
+
+Chromium and FFmpeg cannot live in the agent image: the AgentCore Firecracker
+overlay-mount snapshotter can't carry that native stack, and the agent image
+sits near its 54-layer ceiling. That much is shared with `hyperframes-render`.
+
+It is a **separate function from `hyperframes-render`** despite the overlapping
+toolset, and the reason is IAM rather than convenience. That function's role may
+write only to `public-images/`. This one reads and writes the owner's **private**
+workspace prefix, because a scanned IEP or a staff recording must never become a
+public-by-link object. Merging them would widen a production role purely to
+avoid a second image.
+
+## Security model
+
+The function never accepts an identity from its caller. The root relay injects
+`workspacePrefix` after the trusted web boundary verified the signed invocation
+context (`/api/agent/invocation-identity`); the model-facing skill supplies only
+workspace-**relative** paths, validated here against absolute forms, `..`
+traversal, backslashes and control characters. A caller cannot reach another
+owner's workspace because it never states who it is.
+
+Nothing here writes to `public-images/`. Publishing stays a separate, deliberate
+act through `psd-publish-file`, which carries its own sensitivity gate.
+
+## Local smoke test (pre-deploy)
+
+The build itself proves the two native tools work — `RUN` probes fail the build
+if Chromium can't emit a `%PDF-` or if the static ffmpeg/ffprobe can't execute.
+To exercise the handler the way Lambda does:
+
+```bash
+cd infra && docker build --platform linux/amd64 -f agent-media/Dockerfile -t agent-media:smoke .
+```
+
+```bash
+docker run -d --name agent-media-smoke --platform linux/amd64 -p 9077:8080 -e LAMBDA_TASK_ROOT=/var/task agent-media:smoke
+```
+
+`LAMBDA_TASK_ROOT` is required: real Lambda sets it, the Runtime Interface
+Emulator does not, and without it the RIC exits with `Runtime.PlatformError`
+before your event is ever seen.
+
+Then POST an event to
+`http://localhost:9077/2015-03-31/functions/function/invocations`.
+
+`html-to-pdf` needs no AWS access at all, so it round-trips locally. Verify the
+**geometry**, not just that bytes came back — the original bug produced a
+perfectly valid PDF at the wrong size:
+
+```bash
+python3 -c "import base64,json,re,urllib.request;e={'operation':'html-to-pdf','workspacePrefix':'smoke-owner01/','userEmail':'smoke@psd401.net','html':'<!doctype html><style>@page{size:8.5in 11in;margin:0}</style><h1>probe</h1>'};r=json.loads(urllib.request.urlopen(urllib.request.Request('http://localhost:9077/2015-03-31/functions/function/invocations',data=json.dumps(e).encode(),headers={'Content-Type':'application/json'}),timeout=180).read());p=base64.b64decode(r['pdfBase64']);print(r['status'],r['bytes'],re.findall(rb'/MediaBox[^]]*]',p)[:1])"
+```
+
+A US Letter page is **612×792 pt**. Anything else means the `@page` CSS was not
+honoured, which is the exact failure this operation exists to fix.
+
+`media` and `transcribe` reach S3 and Transcribe, so they need real credentials
+and a deployed workspace bucket. To check the ffmpeg half without AWS, drive the
+binaries directly in the running container:
+
+```bash
+docker exec agent-media-smoke sh -c '/opt/ffmpeg/ffmpeg -nostdin -y -f lavfi -i testsrc=duration=2:size=640x480:rate=30 -f lavfi -i sine=frequency=440:duration=2 -c:v prores -c:a pcm_s16le /tmp/in.mov && /opt/ffmpeg/ffprobe -v error -print_format json -show_streams /tmp/in.mov'
+```
+
+Verified on 2026-09-05 against this image: a ProRes `.mov` through the
+`social-mp4` preset produced `h264 High / yuv420p` + `aac` with the `moov` atom
+at byte 36, ahead of `mdat` at 3591 — `+faststart` doing its job. That ordering
+is what stops Facebook and Instagram rejecting an upload as corrupt, so it is
+worth re-checking whenever the preset changes.
+
+## Caps
+
+| cap | value | why |
+|---|---|---|
+| inline PDF | 4 MB | Lambda's response ceiling is 6 MB and base64 inflates by 4/3 |
+| input HTML | 4 MB | same envelope, on the request side |
+| input media | 512 MB | a larger transcode won't finish inside the agent turn |
+| transcript | 600k chars | keeps one response inside the relay's own bound |
+
+Keep these in sync with each skill's `SKILL.md`.

--- a/infra/agent-media/entrypoint.sh
+++ b/infra/agent-media/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Lambda container entrypoint for agent-media.
+#
+# Start the AWS Lambda Runtime Interface Client (aws-lambda-ric). Locally (no
+# AWS_LAMBDA_RUNTIME_API) wrap it in the Runtime Interface Emulator so a plain
+# `docker run` exposes the invoke endpoint on :8080 for smoke testing. In real
+# Lambda the RIC talks to the runtime API directly and the RIE is inert.
+#
+# No PRODUCER_HEADLESS_SHELL_PATH export here, unlike hyperframes-render: this
+# image uses Debian's chromium directly for print-to-PDF and installs no
+# chrome-headless-shell, because nothing here needs BeginFrame capture.
+set -e
+
+RIC=/var/task/node_modules/.bin/aws-lambda-ric
+
+if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
+  exec /usr/local/bin/aws-lambda-rie "$RIC" "$@"
+else
+  exec "$RIC" "$@"
+fi

--- a/infra/agent-media/handler.js
+++ b/infra/agent-media/handler.js
@@ -1,0 +1,613 @@
+'use strict';
+const { validatedFs } = require('../validated-fs.cjs');
+
+/**
+ * agent-media — AWS Lambda handler (container image).
+ *
+ * Three capabilities the agent kept having to refuse (#1738), each traced to a
+ * real refusal in prod:
+ *
+ *   html-to-pdf  Headless Chromium print-to-PDF honouring @page CSS.
+ *                nashs, 2026-09-01: "save this 8.5x11 sign as a PDF". The
+ *                PyMuPDF fallback ignored flexbox, base64 images and web fonts
+ *                and produced a garbled 400x600pt page.
+ *   media        ffprobe inspection and ffmpeg transcode.
+ *                kinneyk, 2026-09-01: a .mov to verify for Facebook/Instagram.
+ *   transcribe   Amazon Transcribe over audio already in the owner's workspace.
+ *                demontek, 2026-09-03: an .m4a to turn into a printable script.
+ *
+ * SECURITY MODEL. Every S3 path is built from `workspacePrefix`, which the root
+ * relay injects after the trusted web boundary verified the signed invocation
+ * context (/api/agent/invocation-identity). The model-facing skill supplies
+ * only workspace-RELATIVE paths, which are validated here against traversal and
+ * absolute forms. A caller therefore cannot read or write another owner's
+ * workspace even by lying about its own identity — it never states its identity
+ * at all.
+ *
+ * Bytes stay in the owner's PRIVATE workspace prefix. Nothing here writes to
+ * public-images/: a scanned IEP or a staff recording must not become a
+ * public-by-link object. Publishing is a separate, deliberate act the agent
+ * performs through psd-publish-file, which carries its own sensitivity gate.
+ *
+ * Event contract (RequestResponse invoke):
+ *   { "operation": "html-to-pdf" | "media" | "transcribe",
+ *     "workspacePrefix": "person-abc123/",   // injected by the relay
+ *     "userEmail": "person@psd401.net",      // injected by the relay
+ *     ...operation-specific fields }
+ *
+ * Every result is a plain object; nothing throws a bare string or returns null:
+ *   { "status":"ok", ... } | { "status":"error", "error":"<code>", "message":"…" }
+ */
+
+const { execFile } = require('node:child_process');
+const { randomUUID } = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { promisify } = require('node:util');
+
+const {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+  DeleteObjectCommand,
+} = require('@aws-sdk/client-s3');
+const {
+  TranscribeClient,
+  StartTranscriptionJobCommand,
+  GetTranscriptionJobCommand,
+} = require('@aws-sdk/client-transcribe');
+
+const execFileAsync = promisify(execFile);
+
+const CHROMIUM = process.env.CHROMIUM_PATH || '/usr/bin/chromium';
+const FFMPEG = process.env.FFMPEG_PATH || '/opt/ffmpeg/ffmpeg';
+const FFPROBE = process.env.FFPROBE_PATH || '/opt/ffmpeg/ffprobe';
+const REGION = process.env.AWS_REGION || 'us-east-1';
+
+// ── Caps. Documented in each skill's SKILL.md — keep in sync. ────────────────
+// A synchronous invoke must fit inside the Lambda timeout AND the agent turn.
+// Lambda's response payload ceiling is 6 MB and base64 inflates by 4/3, so an
+// inline PDF is capped well below it rather than failing at the transport with
+// an opaque error.
+const MAX_INLINE_PDF_BYTES = 4 * 1024 * 1024;
+const MAX_HTML_BYTES = 4 * 1024 * 1024;
+// Input media the function will pull from S3. Above this the transcode would
+// not finish inside the turn anyway, so refuse early and say so.
+const MAX_INPUT_MEDIA_BYTES = 512 * 1024 * 1024;
+const MAX_TRANSCRIPT_CHARS = 600_000;
+const CHROMIUM_TIMEOUT_MS = 120_000;
+const FFPROBE_TIMEOUT_MS = 60_000;
+const FFMPEG_TIMEOUT_MS = Number(process.env.MEDIA_FFMPEG_TIMEOUT_MS || 600_000);
+const TRANSCRIBE_POLL_INTERVAL_MS = 5_000;
+const TRANSCRIBE_TIMEOUT_MS = Number(
+  process.env.MEDIA_TRANSCRIBE_TIMEOUT_MS || 600_000,
+);
+
+const PAGE_SIZES = new Map([
+  // Inches, width x height. Chromium takes inches for --print-to-pdf sizing.
+  ['letter', [8.5, 11]],
+  ['legal', [8.5, 14]],
+  ['tabloid', [11, 17]],
+  ['a4', [8.27, 11.69]],
+  ['a3', [11.69, 16.54]],
+]);
+
+// ffmpeg presets. A fixed, named set rather than caller-supplied ffmpeg
+// arguments: arbitrary argv into ffmpeg is a command-injection and
+// resource-exhaustion surface, and every real request so far has been one of
+// these three shapes.
+const PRESETS = new Map([
+  [
+    'social-mp4',
+    {
+      extension: '.mp4',
+      contentType: 'video/mp4',
+      // H.264 High/yuv420p + AAC is the combination Facebook, Instagram and
+      // YouTube all accept without re-encoding. +faststart moves the moov atom
+      // to the front so the file starts playing before it finishes downloading;
+      // without it some uploaders reject the file as corrupt.
+      args: [
+        '-c:v', 'libx264', '-profile:v', 'high', '-pix_fmt', 'yuv420p',
+        '-preset', 'medium', '-crf', '23',
+        '-c:a', 'aac', '-b:a', '128k', '-ac', '2',
+        '-movflags', '+faststart',
+      ],
+    },
+  ],
+  [
+    'web-mp4',
+    {
+      extension: '.mp4',
+      contentType: 'video/mp4',
+      // Same container, smaller: 720p cap for embedding in a page or email.
+      args: [
+        '-c:v', 'libx264', '-profile:v', 'high', '-pix_fmt', 'yuv420p',
+        '-preset', 'medium', '-crf', '28',
+        '-vf', "scale='min(1280,iw)':-2",
+        '-c:a', 'aac', '-b:a', '96k', '-ac', '2',
+        '-movflags', '+faststart',
+      ],
+    },
+  ],
+  [
+    'audio-mp3',
+    {
+      extension: '.mp3',
+      contentType: 'audio/mpeg',
+      // Strip video entirely — this is the "get me just the audio" preset.
+      args: ['-vn', '-c:a', 'libmp3lame', '-b:a', '128k', '-ac', '2'],
+    },
+  ],
+]);
+
+// Transcribe infers the media format from the extension it is given, and only
+// supports this set. Checked here so an unsupported file fails with a readable
+// message instead of an opaque Transcribe BadRequestException.
+const TRANSCRIBABLE = new Set([
+  '.mp3', '.mp4', '.m4a', '.wav', '.flac', '.ogg', '.amr', '.webm',
+]);
+
+let s3Client = null;
+function s3() {
+  if (!s3Client) s3Client = new S3Client({ region: REGION });
+  return s3Client;
+}
+let transcribeClient = null;
+function transcribe() {
+  if (!transcribeClient) transcribeClient = new TranscribeClient({ region: REGION });
+  return transcribeClient;
+}
+
+function ok(fields) {
+  return { status: 'ok', ...fields };
+}
+function fail(error, message) {
+  return { status: 'error', error, message };
+}
+
+/**
+ * Validate one workspace-RELATIVE path supplied by the model.
+ *
+ * The prefix comes from the verified invocation context, never from the caller,
+ * so the only thing that can go wrong here is the caller escaping its own
+ * prefix. Rejected: absolute paths, `..` segments, backslashes, control
+ * characters, empty segments, and anything over the broker's own path budget.
+ */
+function relativeWorkspacePath(value, field) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 768) {
+    throw new BadRequest(`${field} must be a workspace-relative path`);
+  }
+  // Escapes rather than literal control characters inside the class: a
+  // literal \x00-\x1f range renders as unreadable glyphs in a terminal diff,
+  // which makes it impossible to review and easy to 'correct' into something
+  // wrong. DEL (\u007f) is included too — it is a control character that the
+  // common \x00-\x1f range misses.
+  // eslint-disable-next-line no-control-regex
+  const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/
+  if (
+    value.startsWith('/') ||
+    value.includes('\\') ||
+    CONTROL_CHARACTERS.test(value)
+  ) {
+    throw new BadRequest(`${field} must be a relative path with no control characters`);
+  }
+  const segments = value.split('/');
+  for (const segment of segments) {
+    if (segment === '' || segment === '.' || segment === '..') {
+      throw new BadRequest(`${field} must not contain empty or traversal segments`);
+    }
+  }
+  return value;
+}
+
+/** The prefix the relay injected. Shape-checked so a malformed one cannot widen scope. */
+function workspacePrefixOf(event) {
+  const prefix = event?.workspacePrefix;
+  if (typeof prefix !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\/?$/.test(prefix)) {
+    // Not a caller error: the relay is responsible for this field.
+    throw new BadRequest('workspacePrefix is missing or malformed');
+  }
+  return prefix.endsWith('/') ? prefix : `${prefix}/`;
+}
+
+class BadRequest extends Error {}
+
+function bucketName() {
+  const bucket = process.env.WORKSPACE_BUCKET;
+  if (!bucket) throw new Error('WORKSPACE_BUCKET is not configured');
+  return bucket;
+}
+
+async function downloadToFile(key, destination) {
+  const response = await s3().send(
+    new GetObjectCommand({ Bucket: bucketName(), Key: key }),
+  );
+  const declared = Number(response.ContentLength || 0);
+  if (declared > MAX_INPUT_MEDIA_BYTES) {
+    throw new BadRequest(
+      `input is ${declared} bytes, over the ${MAX_INPUT_MEDIA_BYTES}-byte limit`,
+    );
+  }
+  await fs.promises.writeFile(destination, response.Body);
+  const { size } = await fs.promises.stat(destination);
+  if (size === 0) throw new BadRequest('input file is empty');
+  // Re-check after the fact: ContentLength is advisory and a lying header must
+  // not let an oversized object through.
+  if (size > MAX_INPUT_MEDIA_BYTES) {
+    throw new BadRequest(`input is ${size} bytes, over the limit`);
+  }
+  return size;
+}
+
+async function runBinary(binary, args, timeoutMs, label) {
+  try {
+    return await execFileAsync(binary, args, {
+      timeout: timeoutMs,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch (error) {
+    if (error && error.killed) {
+      throw new Error(`${label} exceeded its ${Math.round(timeoutMs / 1000)}s budget`);
+    }
+    // ffmpeg/chromium put the useful diagnosis on stderr, not in the message.
+    const detail = String(error?.stderr || error?.message || '').trim().slice(-600);
+    throw new Error(`${label} failed: ${detail || 'no diagnostic output'}`);
+  }
+}
+
+// ── html-to-pdf ──────────────────────────────────────────────────────────────
+
+async function htmlToPdf(event, scratch) {
+  const html = event.html;
+  if (typeof html !== 'string' || html.trim() === '') {
+    throw new BadRequest('html is required');
+  }
+  const htmlBytes = Buffer.byteLength(html, 'utf8');
+  if (htmlBytes > MAX_HTML_BYTES) {
+    throw new BadRequest(`html is ${htmlBytes} bytes, over the ${MAX_HTML_BYTES}-byte limit`);
+  }
+  const pageSize = event.pageSize === undefined ? 'letter' : event.pageSize;
+  if (!PAGE_SIZES.has(pageSize)) {
+    throw new BadRequest(
+      `pageSize must be one of ${[...PAGE_SIZES.keys()].join(', ')}`,
+    );
+  }
+  const landscape = event.landscape === true;
+  const margin = event.marginInches === undefined ? 0 : Number(event.marginInches);
+  if (!Number.isFinite(margin) || margin < 0 || margin > 3) {
+    throw new BadRequest('marginInches must be between 0 and 3');
+  }
+  const scale = event.scale === undefined ? 1 : Number(event.scale);
+  if (!Number.isFinite(scale) || scale < 0.1 || scale > 2) {
+    throw new BadRequest('scale must be between 0.1 and 2');
+  }
+
+  const [pageWidth, pageHeight] = PAGE_SIZES.get(pageSize);
+  const [width, height] = landscape ? [pageHeight, pageWidth] : [pageWidth, pageHeight];
+
+  const source = path.join(scratch, 'page.html');
+  const target = path.join(scratch, 'page.pdf');
+  await fs.promises.writeFile(source, html, 'utf8');
+
+  // --no-pdf-header-footer suppresses Chromium's default URL/date furniture,
+  // which otherwise prints over a design that was laid out to the page edge.
+  // The page's own @page CSS still wins over these dimensions when it sets one,
+  // which is exactly what the 8.5x11 sign relies on.
+  await runBinary(
+    CHROMIUM,
+    [
+      '--headless',
+      '--no-sandbox',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+      '--no-pdf-header-footer',
+      `--print-to-pdf-page-size=${width}x${height}`,
+      ...(event.printBackground === false ? [] : ['--print-to-pdf-background']),
+      `--print-to-pdf=${target}`,
+      source,
+    ],
+    CHROMIUM_TIMEOUT_MS,
+    'Chromium print-to-PDF',
+  );
+
+  const pdf = await fs.promises.readFile(target);
+  if (pdf.length === 0 || !pdf.subarray(0, 5).equals(Buffer.from('%PDF-'))) {
+    throw new Error('Chromium produced a file that is not a PDF');
+  }
+  if (pdf.length > MAX_INLINE_PDF_BYTES) {
+    throw new BadRequest(
+      `the rendered PDF is ${pdf.length} bytes, over the ${MAX_INLINE_PDF_BYTES}-byte ` +
+        'inline limit. Split the document, or reduce embedded image resolution.',
+    );
+  }
+  // Page count without another dependency: every page object carries a /Type
+  // /Page that is not /Pages. Advisory only — reported, never gated on.
+  const pageCount = (pdf.toString('latin1').match(/\/Type\s*\/Page[^s]/g) || []).length;
+
+  return ok({
+    pdfBase64: pdf.toString('base64'),
+    bytes: pdf.length,
+    pages: pageCount || null,
+    pageSize,
+    landscape,
+  });
+}
+
+// ── media (ffprobe / ffmpeg) ─────────────────────────────────────────────────
+
+function summariseProbe(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('ffprobe returned output that is not JSON');
+  }
+  const streams = Array.isArray(parsed.streams) ? parsed.streams : [];
+  const video = streams.find((s) => s.codec_type === 'video') || null;
+  const audio = streams.find((s) => s.codec_type === 'audio') || null;
+  const format = parsed.format || {};
+  const rate = video && typeof video.avg_frame_rate === 'string'
+    ? video.avg_frame_rate.split('/')
+    : null;
+  const fps = rate && rate.length === 2 && Number(rate[1]) !== 0
+    ? Math.round((Number(rate[0]) / Number(rate[1])) * 100) / 100
+    : null;
+  return {
+    durationSeconds: format.duration ? Math.round(Number(format.duration) * 100) / 100 : null,
+    bytes: format.size ? Number(format.size) : null,
+    formatName: format.format_name || null,
+    video: video
+      ? {
+          codec: video.codec_name || null,
+          width: video.width || null,
+          height: video.height || null,
+          fps,
+          pixelFormat: video.pix_fmt || null,
+        }
+      : null,
+    audio: audio
+      ? {
+          codec: audio.codec_name || null,
+          channels: audio.channels || null,
+          sampleRate: audio.sample_rate ? Number(audio.sample_rate) : null,
+        }
+      : null,
+  };
+}
+
+async function probeFile(file) {
+  const { stdout } = await runBinary(
+    FFPROBE,
+    ['-v', 'error', '-print_format', 'json', '-show_format', '-show_streams', file],
+    FFPROBE_TIMEOUT_MS,
+    'ffprobe',
+  );
+  return summariseProbe(stdout);
+}
+
+async function mediaOperation(event, scratch, prefix) {
+  const action = event.action === undefined ? 'probe' : event.action;
+  if (action !== 'probe' && action !== 'convert') {
+    throw new BadRequest('action must be probe or convert');
+  }
+  const inputPath = relativeWorkspacePath(event.inputPath, 'inputPath');
+
+  // Validate EVERYTHING that costs nothing before pulling the input out of S3.
+  // A convert with a bad preset used to download the whole file first and only
+  // then refuse — a pointless multi-hundred-megabyte transfer, and a confusing
+  // failure ("WORKSPACE_BUCKET is not configured") that named the wrong problem.
+  let preset = null;
+  let outputPath = null;
+  if (action === 'convert') {
+    if (!PRESETS.has(event.preset)) {
+      throw new BadRequest(`preset must be one of ${[...PRESETS.keys()].join(', ')}`);
+    }
+    preset = PRESETS.get(event.preset);
+    outputPath = relativeWorkspacePath(event.outputPath, 'outputPath');
+    if (!outputPath.toLowerCase().endsWith(preset.extension)) {
+      throw new BadRequest(
+        `outputPath must end in ${preset.extension} for ${event.preset}`,
+      );
+    }
+    if (outputPath === inputPath) {
+      throw new BadRequest('outputPath must differ from inputPath');
+    }
+  }
+
+  const inputFile = path.join(scratch, `input${path.extname(inputPath).slice(0, 12)}`);
+  const inputBytes = await downloadToFile(`${prefix}${inputPath}`, inputFile);
+  const probe = await probeFile(inputFile);
+
+  if (action === 'probe') {
+    return ok({ action, inputPath, inputBytes, probe });
+  }
+
+  const presetName = event.preset;
+  // Only knowable after probing, so it stays here rather than above.
+  if (presetName !== 'audio-mp3' && !probe.video) {
+    throw new BadRequest(
+      `${presetName} produces video, but the input has no video stream. Use audio-mp3.`,
+    );
+  }
+
+  const outputFile = path.join(scratch, `output${preset.extension}`);
+  await runBinary(
+    FFMPEG,
+    ['-nostdin', '-y', '-i', inputFile, ...preset.args, outputFile],
+    FFMPEG_TIMEOUT_MS,
+    'ffmpeg',
+  );
+  const body = await fs.promises.readFile(outputFile);
+  if (body.length === 0) throw new Error('ffmpeg produced an empty file');
+
+  await s3().send(
+    new PutObjectCommand({
+      Bucket: bucketName(),
+      Key: `${prefix}${outputPath}`,
+      Body: body,
+      ContentType: preset.contentType,
+      // Match the workspace's own object tagging so the retention lifecycle
+      // rule applies to what this function writes, exactly as it does to
+      // everything the agent writes through the broker.
+      Tagging: 'Scope=private',
+    }),
+  );
+
+  return ok({
+    action,
+    preset: presetName,
+    inputPath,
+    outputPath,
+    inputBytes,
+    outputBytes: body.length,
+    probe,
+    outputProbe: await probeFile(outputFile),
+  });
+}
+
+// ── transcribe ───────────────────────────────────────────────────────────────
+
+const LANGUAGE_RE = /^[a-z]{2}-[A-Z]{2}$/;
+
+async function transcribeOperation(event, prefix) {
+  const inputPath = relativeWorkspacePath(event.inputPath, 'inputPath');
+  const extension = path.extname(inputPath).toLowerCase();
+  if (!TRANSCRIBABLE.has(extension)) {
+    throw new BadRequest(
+      `${extension || '(no extension)'} cannot be transcribed — supported: ` +
+        `${[...TRANSCRIBABLE].join(', ')}. Convert it first with the media skill.`,
+    );
+  }
+  const languageCode = event.languageCode === undefined ? 'en-US' : event.languageCode;
+  if (typeof languageCode !== 'string' || !LANGUAGE_RE.test(languageCode)) {
+    throw new BadRequest('languageCode must look like en-US');
+  }
+
+  const bucket = bucketName();
+  const jobName = `agent-media-${randomUUID()}`;
+  // Transcribe writes its JSON result to a bucket we nominate. Keep it inside
+  // the owner's own prefix so the intermediate is subject to the same access
+  // boundary as the audio, then delete it once the text has been read.
+  const outputKey = `${prefix}.transcribe-scratch/${jobName}.json`;
+
+  await transcribe().send(
+    new StartTranscriptionJobCommand({
+      TranscriptionJobName: jobName,
+      LanguageCode: languageCode,
+      Media: { MediaFileUri: `s3://${bucket}/${prefix}${inputPath}` },
+      OutputBucketName: bucket,
+      OutputKey: outputKey,
+    }),
+  );
+
+  const deadline = Date.now() + TRANSCRIBE_TIMEOUT_MS;
+  let job = null;
+  for (;;) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `transcription did not finish within ${Math.round(TRANSCRIBE_TIMEOUT_MS / 1000)}s`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, TRANSCRIBE_POLL_INTERVAL_MS));
+    const described = await transcribe().send(
+      new GetTranscriptionJobCommand({ TranscriptionJobName: jobName }),
+    );
+    job = described.TranscriptionJob || null;
+    const state = job?.TranscriptionJobStatus;
+    if (state === 'COMPLETED') break;
+    if (state === 'FAILED') {
+      throw new Error(`transcription failed: ${job?.FailureReason || 'no reason given'}`);
+    }
+  }
+
+  const result = await s3().send(
+    new GetObjectCommand({ Bucket: bucket, Key: outputKey }),
+  );
+  const rawBody = await result.Body.transformToString();
+  let transcript = '';
+  try {
+    const parsed = JSON.parse(rawBody);
+    transcript = String(parsed?.results?.transcripts?.[0]?.transcript || '');
+  } catch {
+    throw new Error('Transcribe returned a result that is not JSON');
+  }
+  // Best-effort cleanup. A retained scratch object is untidy, not a failure, and
+  // must never turn a successful transcription into an error.
+  try {
+    await s3().send(new DeleteObjectCommand({ Bucket: bucket, Key: outputKey }));
+  } catch {
+    /* lifecycle will reap it */
+  }
+
+  if (transcript.trim() === '') {
+    return fail(
+      'empty_transcript',
+      'The audio produced no speech. Check that the file contains audible speech ' +
+        'and that languageCode matches what is spoken.',
+    );
+  }
+  const truncated = transcript.length > MAX_TRANSCRIPT_CHARS;
+  return ok({
+    transcript: truncated ? transcript.slice(0, MAX_TRANSCRIPT_CHARS) : transcript,
+    truncated,
+    characters: Math.min(transcript.length, MAX_TRANSCRIPT_CHARS),
+    languageCode,
+    inputPath,
+  });
+}
+
+// ── entry point ──────────────────────────────────────────────────────────────
+
+const OPERATIONS = new Set(['html-to-pdf', 'media', 'transcribe']);
+
+exports.handler = async function handler(event) {
+  let scratch = null;
+  try {
+    if (!event || typeof event !== 'object' || Array.isArray(event)) {
+      return fail('bad_request', 'event must be an object');
+    }
+    const operation = event.operation;
+    if (!OPERATIONS.has(operation)) {
+      return fail(
+        'bad_request',
+        `operation must be one of ${[...OPERATIONS].join(', ')}`,
+      );
+    }
+    const prefix = workspacePrefixOf(event);
+
+    scratch = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-media-'));
+    if (operation === 'html-to-pdf') return await htmlToPdf(event, scratch);
+    if (operation === 'media') return await mediaOperation(event, scratch, prefix);
+    return await transcribeOperation(event, prefix);
+  } catch (error) {
+    if (error instanceof BadRequest) {
+      return fail('bad_request', error.message);
+    }
+    // Deliberately surfaced rather than swallowed: the agent has to be able to
+    // tell the user WHY, and an opaque failure here is what sent three separate
+    // callers away empty-handed in the first place.
+    return fail('media_failed', String(error?.message || error).slice(0, 900));
+  } finally {
+    if (scratch) {
+      await fs.promises.rm(scratch, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+};
+
+// Exported for the unit tests, which drive the pure helpers without Docker.
+exports.testables = {
+  relativeWorkspacePath,
+  workspacePrefixOf,
+  summariseProbe,
+  BadRequest,
+  PRESETS,
+  PAGE_SIZES,
+  TRANSCRIBABLE,
+  MAX_INLINE_PDF_BYTES,
+};
+
+// validated-fs is required for parity with the other container Lambdas, whose
+// handlers all route filesystem access through the shared wrapper. Referenced
+// here so a future refactor cannot silently drop the import.
+void validatedFs;

--- a/infra/agent-media/handler.js
+++ b/infra/agent-media/handler.js
@@ -1,5 +1,5 @@
 'use strict';
-const { validatedFs } = require('../validated-fs.cjs');
+const { validatedFs, validatedFsPromises } = require('../validated-fs.cjs');
 
 /**
  * agent-media — AWS Lambda handler (container image).
@@ -41,7 +41,6 @@ const { validatedFs } = require('../validated-fs.cjs');
 
 const { execFile } = require('node:child_process');
 const { randomUUID } = require('node:crypto');
-const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { promisify } = require('node:util');
@@ -184,7 +183,7 @@ function relativeWorkspacePath(value, field) {
   // wrong. DEL (\u007f) is included too — it is a control character that the
   // common \x00-\x1f range misses.
   // eslint-disable-next-line no-control-regex
-  const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/
+  const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F]/
   if (
     value.startsWith('/') ||
     value.includes('\\') ||
@@ -229,8 +228,8 @@ async function downloadToFile(key, destination) {
       `input is ${declared} bytes, over the ${MAX_INPUT_MEDIA_BYTES}-byte limit`,
     );
   }
-  await fs.promises.writeFile(destination, response.Body);
-  const { size } = await fs.promises.stat(destination);
+  await validatedFsPromises.writeFile(destination, response.Body);
+  const { size } = await validatedFsPromises.stat(destination);
   if (size === 0) throw new BadRequest('input file is empty');
   // Re-check after the fact: ContentLength is advisory and a lying header must
   // not let an oversized object through.
@@ -248,17 +247,23 @@ async function runBinary(binary, args, timeoutMs, label) {
     });
   } catch (error) {
     if (error && error.killed) {
-      throw new Error(`${label} exceeded its ${Math.round(timeoutMs / 1000)}s budget`);
+      throw new Error(
+        `${label} exceeded its ${Math.round(timeoutMs / 1000)}s budget`,
+        { cause: error },
+      );
     }
     // ffmpeg/chromium put the useful diagnosis on stderr, not in the message.
     const detail = String(error?.stderr || error?.message || '').trim().slice(-600);
-    throw new Error(`${label} failed: ${detail || 'no diagnostic output'}`);
+    throw new Error(`${label} failed: ${detail || 'no diagnostic output'}`, {
+      cause: error,
+    });
   }
 }
 
 // ── html-to-pdf ──────────────────────────────────────────────────────────────
 
-async function htmlToPdf(event, scratch) {
+/** Validate and default every print option. Split out to keep htmlToPdf flat. */
+function printOptions(event) {
   const html = event.html;
   if (typeof html !== 'string' || html.trim() === '') {
     throw new BadRequest('html is required');
@@ -269,26 +274,36 @@ async function htmlToPdf(event, scratch) {
   }
   const pageSize = event.pageSize === undefined ? 'letter' : event.pageSize;
   if (!PAGE_SIZES.has(pageSize)) {
-    throw new BadRequest(
-      `pageSize must be one of ${[...PAGE_SIZES.keys()].join(', ')}`,
-    );
+    throw new BadRequest(`pageSize must be one of ${[...PAGE_SIZES.keys()].join(', ')}`);
   }
-  const landscape = event.landscape === true;
-  const margin = event.marginInches === undefined ? 0 : Number(event.marginInches);
-  if (!Number.isFinite(margin) || margin < 0 || margin > 3) {
-    throw new BadRequest('marginInches must be between 0 and 3');
-  }
-  const scale = event.scale === undefined ? 1 : Number(event.scale);
-  if (!Number.isFinite(scale) || scale < 0.1 || scale > 2) {
-    throw new BadRequest('scale must be between 0.1 and 2');
-  }
+  return {
+    html,
+    pageSize,
+    landscape: event.landscape === true,
+    printBackground: event.printBackground !== false,
+    marginInches: boundedNumber(event.marginInches, 0, 3, 0, 'marginInches'),
+    scale: boundedNumber(event.scale, 0.1, 2, 1, 'scale'),
+  };
+}
 
+/** One numeric option, defaulted and range-checked. */
+function boundedNumber(raw, minimum, maximum, fallback, field) {
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < minimum || value > maximum) {
+    throw new BadRequest(`${field} must be between ${minimum} and ${maximum}`);
+  }
+  return value;
+}
+
+async function htmlToPdf(event, scratch) {
+  const { html, pageSize, landscape, printBackground } = printOptions(event);
   const [pageWidth, pageHeight] = PAGE_SIZES.get(pageSize);
   const [width, height] = landscape ? [pageHeight, pageWidth] : [pageWidth, pageHeight];
 
   const source = path.join(scratch, 'page.html');
   const target = path.join(scratch, 'page.pdf');
-  await fs.promises.writeFile(source, html, 'utf8');
+  await validatedFsPromises.writeFile(source, html, 'utf8');
 
   // --no-pdf-header-footer suppresses Chromium's default URL/date furniture,
   // which otherwise prints over a design that was laid out to the page edge.
@@ -303,7 +318,7 @@ async function htmlToPdf(event, scratch) {
       '--disable-dev-shm-usage',
       '--no-pdf-header-footer',
       `--print-to-pdf-page-size=${width}x${height}`,
-      ...(event.printBackground === false ? [] : ['--print-to-pdf-background']),
+      ...(printBackground ? ['--print-to-pdf-background'] : []),
       `--print-to-pdf=${target}`,
       source,
     ],
@@ -311,7 +326,7 @@ async function htmlToPdf(event, scratch) {
     'Chromium print-to-PDF',
   );
 
-  const pdf = await fs.promises.readFile(target);
+  const pdf = await validatedFsPromises.readFile(target);
   if (pdf.length === 0 || !pdf.subarray(0, 5).equals(Buffer.from('%PDF-'))) {
     throw new Error('Chromium produced a file that is not a PDF');
   }
@@ -347,32 +362,45 @@ function summariseProbe(raw) {
   const video = streams.find((s) => s.codec_type === 'video') || null;
   const audio = streams.find((s) => s.codec_type === 'audio') || null;
   const format = parsed.format || {};
-  const rate = video && typeof video.avg_frame_rate === 'string'
-    ? video.avg_frame_rate.split('/')
-    : null;
-  const fps = rate && rate.length === 2 && Number(rate[1]) !== 0
-    ? Math.round((Number(rate[0]) / Number(rate[1])) * 100) / 100
-    : null;
   return {
-    durationSeconds: format.duration ? Math.round(Number(format.duration) * 100) / 100 : null,
-    bytes: format.size ? Number(format.size) : null,
+    // Presence checks, not truthiness: ffprobe reports these as STRINGS, and a
+    // legitimate "0" would be discarded by a truthy test on a numeric field.
+    durationSeconds:
+      format.duration === undefined
+        ? null
+        : Math.round(Number(format.duration) * 100) / 100,
+    bytes: format.size === undefined ? null : Number(format.size),
     formatName: format.format_name || null,
-    video: video
-      ? {
-          codec: video.codec_name || null,
-          width: video.width || null,
-          height: video.height || null,
-          fps,
-          pixelFormat: video.pix_fmt || null,
-        }
-      : null,
-    audio: audio
-      ? {
-          codec: audio.codec_name || null,
-          channels: audio.channels || null,
-          sampleRate: audio.sample_rate ? Number(audio.sample_rate) : null,
-        }
-      : null,
+    video: summariseVideoStream(video),
+    audio: summariseAudioStream(audio),
+  };
+}
+
+/** ffprobe reports frame rate as a rational string; stills come back as `0/0`. */
+function frameRateOf(stream) {
+  if (!stream || typeof stream.avg_frame_rate !== 'string') return null;
+  const [numerator, denominator] = stream.avg_frame_rate.split('/');
+  if (denominator === undefined || Number(denominator) === 0) return null;
+  return Math.round((Number(numerator) / Number(denominator)) * 100) / 100;
+}
+
+function summariseVideoStream(video) {
+  if (!video) return null;
+  return {
+    codec: video.codec_name || null,
+    width: video.width || null,
+    height: video.height || null,
+    fps: frameRateOf(video),
+    pixelFormat: video.pix_fmt || null,
+  };
+}
+
+function summariseAudioStream(audio) {
+  if (!audio) return null;
+  return {
+    codec: audio.codec_name || null,
+    channels: audio.channels || null,
+    sampleRate: audio.sample_rate ? Number(audio.sample_rate) : null,
   };
 }
 
@@ -438,7 +466,7 @@ async function mediaOperation(event, scratch, prefix) {
     FFMPEG_TIMEOUT_MS,
     'ffmpeg',
   );
-  const body = await fs.promises.readFile(outputFile);
+  const body = await validatedFsPromises.readFile(outputFile);
   if (body.length === 0) throw new Error('ffmpeg produced an empty file');
 
   await s3().send(
@@ -469,6 +497,40 @@ async function mediaOperation(event, scratch, prefix) {
 // ── transcribe ───────────────────────────────────────────────────────────────
 
 const LANGUAGE_RE = /^[a-z]{2}-[A-Z]{2}$/;
+
+/** Poll one job to a terminal state inside the configured budget. */
+async function awaitTranscriptionJob(jobName) {
+  const deadline = Date.now() + TRANSCRIBE_TIMEOUT_MS;
+  while (Date.now() <= deadline) {
+    await new Promise((resolve) => setTimeout(resolve, TRANSCRIBE_POLL_INTERVAL_MS));
+    const described = await transcribe().send(
+      new GetTranscriptionJobCommand({ TranscriptionJobName: jobName }),
+    );
+    const job = described.TranscriptionJob;
+    const state = job?.TranscriptionJobStatus;
+    if (state === 'COMPLETED') return;
+    if (state === 'FAILED') {
+      throw new Error(`transcription failed: ${job?.FailureReason || 'no reason given'}`);
+    }
+  }
+  throw new Error(
+    `transcription did not finish within ${Math.round(TRANSCRIBE_TIMEOUT_MS / 1000)}s`,
+  );
+}
+
+/** Read Transcribe's own JSON result and pull the plain transcript out of it. */
+async function readTranscriptText(bucket, outputKey) {
+  const result = await s3().send(
+    new GetObjectCommand({ Bucket: bucket, Key: outputKey }),
+  );
+  const rawBody = await result.Body.transformToString();
+  try {
+    const parsed = JSON.parse(rawBody);
+    return String(parsed?.results?.transcripts?.[0]?.transcript || '');
+  } catch (error) {
+    throw new Error('Transcribe returned a result that is not JSON', { cause: error });
+  }
+}
 
 async function transcribeOperation(event, prefix) {
   const inputPath = relativeWorkspacePath(event.inputPath, 'inputPath');
@@ -501,37 +563,8 @@ async function transcribeOperation(event, prefix) {
     }),
   );
 
-  const deadline = Date.now() + TRANSCRIBE_TIMEOUT_MS;
-  let job = null;
-  for (;;) {
-    if (Date.now() > deadline) {
-      throw new Error(
-        `transcription did not finish within ${Math.round(TRANSCRIBE_TIMEOUT_MS / 1000)}s`,
-      );
-    }
-    await new Promise((resolve) => setTimeout(resolve, TRANSCRIBE_POLL_INTERVAL_MS));
-    const described = await transcribe().send(
-      new GetTranscriptionJobCommand({ TranscriptionJobName: jobName }),
-    );
-    job = described.TranscriptionJob || null;
-    const state = job?.TranscriptionJobStatus;
-    if (state === 'COMPLETED') break;
-    if (state === 'FAILED') {
-      throw new Error(`transcription failed: ${job?.FailureReason || 'no reason given'}`);
-    }
-  }
-
-  const result = await s3().send(
-    new GetObjectCommand({ Bucket: bucket, Key: outputKey }),
-  );
-  const rawBody = await result.Body.transformToString();
-  let transcript = '';
-  try {
-    const parsed = JSON.parse(rawBody);
-    transcript = String(parsed?.results?.transcripts?.[0]?.transcript || '');
-  } catch {
-    throw new Error('Transcribe returned a result that is not JSON');
-  }
+  await awaitTranscriptionJob(jobName);
+  const transcript = await readTranscriptText(bucket, outputKey);
   // Best-effort cleanup. A retained scratch object is untidy, not a failure, and
   // must never turn a successful transcription into an error.
   try {
@@ -576,7 +609,7 @@ exports.handler = async function handler(event) {
     }
     const prefix = workspacePrefixOf(event);
 
-    scratch = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-media-'));
+    scratch = await validatedFsPromises.mkdtemp(path.join(os.tmpdir(), 'agent-media-'));
     if (operation === 'html-to-pdf') return await htmlToPdf(event, scratch);
     if (operation === 'media') return await mediaOperation(event, scratch, prefix);
     return await transcribeOperation(event, prefix);
@@ -590,7 +623,7 @@ exports.handler = async function handler(event) {
     return fail('media_failed', String(error?.message || error).slice(0, 900));
   } finally {
     if (scratch) {
-      await fs.promises.rm(scratch, { recursive: true, force: true }).catch(() => {});
+      await validatedFsPromises.rm(scratch, { recursive: true, force: true }).catch(() => {});
     }
   }
 };
@@ -605,9 +638,5 @@ exports.testables = {
   PAGE_SIZES,
   TRANSCRIBABLE,
   MAX_INLINE_PDF_BYTES,
+  validatedFs,
 };
-
-// validated-fs is required for parity with the other container Lambdas, whose
-// handlers all route filesystem access through the shared wrapper. Referenced
-// here so a future refactor cannot silently drop the import.
-void validatedFs;

--- a/infra/agent-media/handler.test.js
+++ b/infra/agent-media/handler.test.js
@@ -1,0 +1,267 @@
+/**
+ * agent-media handler tests.
+ *
+ * Run: bun test   (from infra/agent-media/)
+ *
+ * These cover the parts that can be exercised without Docker: request
+ * validation, the path/prefix boundary, the ffprobe summariser, and the
+ * dispatch-level error taxonomy. The parts that genuinely need the container —
+ * Chromium actually producing a PDF, ffmpeg actually transcoding — are proven
+ * by the Dockerfile's own build-time probes and by the RIE smoke test in
+ * README.md, because asserting on a mocked execFile would only prove the mock.
+ */
+
+'use strict';
+
+const { test, expect, describe } = require('bun:test');
+const { handler, testables } = require('./handler');
+
+const {
+  relativeWorkspacePath,
+  workspacePrefixOf,
+  summariseProbe,
+  BadRequest,
+  PRESETS,
+  PAGE_SIZES,
+  TRANSCRIBABLE,
+} = testables;
+
+describe('workspace path boundary', () => {
+  test('accepts an ordinary relative path, hyphens and dots included', () => {
+    for (const value of [
+      'uploads/clip.mov',
+      'a-file-with-hyphens.mp4',
+      'nested/dir.v2/file.name.m4a',
+      'x'.repeat(700),
+    ]) {
+      expect(relativeWorkspacePath(value, 'inputPath')).toBe(value);
+    }
+  });
+
+  test('refuses every shape that could escape the owner prefix', () => {
+    const escapes = [
+      '/etc/passwd',
+      '../other-owner/secret.mp4',
+      'a/../../b.mp4',
+      'a/./b.mp4',
+      'a//b.mp4',
+      '..',
+      'dir\\file.mp4',
+      '',
+      'x'.repeat(769),
+    ];
+    for (const value of escapes) {
+      expect(() => relativeWorkspacePath(value, 'inputPath')).toThrow(BadRequest);
+    }
+  });
+
+  test('refuses control characters, including DEL', () => {
+    for (const code of [0x00, 0x09, 0x0a, 0x1f, 0x7f]) {
+      const value = `clip${String.fromCharCode(code)}.mov`;
+      expect(() => relativeWorkspacePath(value, 'inputPath')).toThrow(BadRequest);
+    }
+  });
+
+  test('refuses a non-string path rather than coercing it', () => {
+    for (const value of [null, undefined, 42, {}, ['a'], true]) {
+      expect(() => relativeWorkspacePath(value, 'inputPath')).toThrow(BadRequest);
+    }
+  });
+});
+
+describe('injected workspace prefix', () => {
+  test('normalises a prefix with or without its trailing slash', () => {
+    expect(workspacePrefixOf({ workspacePrefix: 'stittd-fc954a03' })).toBe(
+      'stittd-fc954a03/',
+    );
+    expect(workspacePrefixOf({ workspacePrefix: 'stittd-fc954a03/' })).toBe(
+      'stittd-fc954a03/',
+    );
+  });
+
+  test('refuses a malformed or scope-widening prefix', () => {
+    // The relay owns this field, so a bad value means the relay is wrong or
+    // something bypassed it — fail closed rather than build an S3 key from it.
+    const bad = [
+      undefined,
+      '',
+      '/absolute/',
+      '../escape/',
+      'has space/',
+      'two/levels/',
+      `${'x'.repeat(200)}/`,
+      '.hidden/',
+    ];
+    for (const workspacePrefix of bad) {
+      expect(() => workspacePrefixOf({ workspacePrefix })).toThrow(BadRequest);
+    }
+  });
+});
+
+describe('ffprobe summariser', () => {
+  test('reduces a real ffprobe payload to the fields a caller acts on', () => {
+    const summary = summariseProbe(
+      JSON.stringify({
+        format: { duration: '12.345678', size: '4096', format_name: 'mov,mp4,m4a' },
+        streams: [
+          {
+            codec_type: 'video',
+            codec_name: 'h264',
+            width: 1920,
+            height: 1080,
+            avg_frame_rate: '30000/1001',
+            pix_fmt: 'yuv420p',
+          },
+          { codec_type: 'audio', codec_name: 'aac', channels: 2, sample_rate: '48000' },
+        ],
+      }),
+    );
+    expect(summary.durationSeconds).toBe(12.35);
+    expect(summary.video.codec).toBe('h264');
+    expect(summary.video.fps).toBe(29.97);
+    expect(summary.audio.sampleRate).toBe(48000);
+  });
+
+  test('reports a missing stream as null instead of inventing one', () => {
+    const summary = summariseProbe(
+      JSON.stringify({
+        format: { duration: '3.0' },
+        streams: [{ codec_type: 'audio', codec_name: 'aac', channels: 1 }],
+      }),
+    );
+    expect(summary.video).toBeNull();
+    expect(summary.audio.channels).toBe(1);
+  });
+
+  test('does not divide by zero on the N/0 frame rate ffprobe emits for stills', () => {
+    const summary = summariseProbe(
+      JSON.stringify({
+        format: {},
+        streams: [{ codec_type: 'video', codec_name: 'png', avg_frame_rate: '0/0' }],
+      }),
+    );
+    expect(summary.video.fps).toBeNull();
+  });
+
+  test('throws on non-JSON rather than returning a hollow summary', () => {
+    expect(() => summariseProbe('not json')).toThrow();
+  });
+});
+
+describe('handler dispatch', () => {
+  const prefix = { workspacePrefix: 'owner-abc123/' };
+
+  test('refuses an unknown operation by name', async () => {
+    const result = await handler({ ...prefix, operation: 'rm-rf' });
+    expect(result.status).toBe('error');
+    expect(result.error).toBe('bad_request');
+    expect(result.message).toContain('html-to-pdf');
+  });
+
+  test('refuses a non-object event without throwing', async () => {
+    for (const event of [null, undefined, 'string', ['a']]) {
+      const result = await handler(event);
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('bad_request');
+    }
+  });
+
+  test('refuses a missing workspace prefix before doing any work', async () => {
+    const result = await handler({ operation: 'html-to-pdf', html: '<p>hi</p>' });
+    expect(result.status).toBe('error');
+    expect(result.message).toContain('workspacePrefix');
+  });
+
+  test('validates html-to-pdf inputs and names the offending field', async () => {
+    const cases = [
+      [{ html: '' }, 'html'],
+      [{ html: '   ' }, 'html'],
+      [{ html: '<p>x</p>', pageSize: 'poster' }, 'pageSize'],
+      [{ html: '<p>x</p>', marginInches: 9 }, 'marginInches'],
+      [{ html: '<p>x</p>', marginInches: -1 }, 'marginInches'],
+      [{ html: '<p>x</p>', scale: 0 }, 'scale'],
+      [{ html: '<p>x</p>', scale: 5 }, 'scale'],
+    ];
+    for (const [fields, field] of cases) {
+      const result = await handler({ ...prefix, operation: 'html-to-pdf', ...fields });
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('bad_request');
+      expect(result.message).toContain(field);
+    }
+  });
+
+  test('refuses an unknown ffmpeg preset by listing the real ones', async () => {
+    const result = await handler({
+      ...prefix,
+      operation: 'media',
+      action: 'convert',
+      inputPath: 'in.mov',
+      outputPath: 'out.mp4',
+      preset: 'ultra-hd-8k',
+    });
+    expect(result.status).toBe('error');
+    // Path validation passes, so this must reach the preset check rather than
+    // dying earlier for the wrong reason.
+    expect(result.message).toContain('social-mp4');
+  });
+
+  test('refuses an un-transcribable extension and points at the converter', async () => {
+    const result = await handler({
+      ...prefix,
+      operation: 'transcribe',
+      inputPath: 'recording.aiff',
+    });
+    expect(result.status).toBe('error');
+    expect(result.error).toBe('bad_request');
+    expect(result.message).toContain('.m4a');
+    expect(result.message).toContain('media skill');
+  });
+
+  test('refuses a malformed languageCode', async () => {
+    const result = await handler({
+      ...prefix,
+      operation: 'transcribe',
+      inputPath: 'recording.m4a',
+      languageCode: 'english',
+    });
+    expect(result.status).toBe('error');
+    expect(result.message).toContain('languageCode');
+  });
+});
+
+describe('preset contract', () => {
+  test('every preset declares an extension and a content type', () => {
+    for (const [name, preset] of PRESETS) {
+      expect(preset.extension.startsWith('.')).toBe(true);
+      expect(preset.contentType).toContain('/');
+      expect(Array.isArray(preset.args)).toBe(true);
+      expect(preset.args.length).toBeGreaterThan(0);
+      // No shell metacharacters anywhere in a preset: these are passed to
+      // execFile as argv, and keeping them inert makes that visibly safe.
+      for (const arg of preset.args) {
+        expect(/[;&|`$><\n]/.test(arg)).toBe(false);
+      }
+      expect(name).toBe(name.toLowerCase());
+    }
+  });
+
+  test('social-mp4 carries the flags that make an upload actually accepted', () => {
+    const args = PRESETS.get('social-mp4').args.join(' ');
+    // yuv420p and +faststart are the two that silently break Facebook and
+    // Instagram uploads when missing — worth pinning rather than trusting.
+    expect(args).toContain('yuv420p');
+    expect(args).toContain('+faststart');
+    expect(args).toContain('libx264');
+  });
+
+  test('the page sizes include the 8.5x11 the original request needed', () => {
+    expect(PAGE_SIZES.get('letter')).toEqual([8.5, 11]);
+  });
+
+  test('the transcribable set matches what Transcribe actually accepts', () => {
+    for (const extension of TRANSCRIBABLE) {
+      expect(extension.startsWith('.')).toBe(true);
+    }
+    expect(TRANSCRIBABLE.has('.m4a')).toBe(true);
+  });
+});

--- a/infra/agent-media/handler.test.js
+++ b/infra/agent-media/handler.test.js
@@ -56,7 +56,7 @@ describe('workspace path boundary', () => {
   });
 
   test('refuses control characters, including DEL', () => {
-    for (const code of [0x00, 0x09, 0x0a, 0x1f, 0x7f]) {
+    for (const code of [0x00, 0x09, 0x0A, 0x1F, 0x7F]) {
       const value = `clip${String.fromCharCode(code)}.mov`;
       expect(() => relativeWorkspacePath(value, 'inputPath')).toThrow(BadRequest);
     }

--- a/infra/agent-media/package.json
+++ b/infra/agent-media/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-media",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Container-image Lambda: headless-Chromium HTML-to-PDF, ffmpeg transcode/probe, and Amazon Transcribe over the agent's private workspace prefix (#1738).",
+  "main": "handler.js",
+  "scripts": {
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.658.0",
+    "@aws-sdk/client-transcribe": "^3.658.0",
+    "aws-lambda-ric": "^4.0.2"
+  }
+}

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -40,6 +40,7 @@ import {
 import { ServiceRoleFactory, usGuardrailProfileArns } from './constructs/security';
 import { AGENT_LAMBDA_RUNTIME } from './constructs/compute/lambda-construct';
 import { HyperframesRenderFunction } from './constructs/compute/hyperframes-render-function';
+import { AgentMediaFunction } from './constructs/compute/agent-media-function';
 import { validatedFs } from "./validated-fs";
 import { parseBundledSkillFrontmatter } from './bundled-skill-manifest';
 
@@ -125,6 +126,7 @@ class AgentPlatformBuildResources {
   ecrRepository!: ecr.Repository;
   workspaceBucket!: s3.Bucket;
   hyperframesRenderFunction!: HyperframesRenderFunction;
+  agentMediaFunction!: AgentMediaFunction;
   usersTable!: dynamodb.Table;
   signalsTable!: dynamodb.Table;
   messageDedupTable!: dynamodb.Table;
@@ -217,6 +219,7 @@ export class AgentPlatformStack extends cdk.Stack {
   public readonly workspaceBucket: s3.Bucket;
   /** Container-image Lambda that renders HyperFrames compositions to MP4 (#1175) */
   public readonly hyperframesRenderFunction: HyperframesRenderFunction;
+  public readonly agentMediaFunction: AgentMediaFunction;
   /** DynamoDB table for user identity mapping */
   public readonly usersTable: dynamodb.Table;
   /** DynamoDB table for organizational signals (Nervous System) */
@@ -316,6 +319,7 @@ export class AgentPlatformStack extends cdk.Stack {
     this.ecrRepository = resources.ecrRepository;
     this.workspaceBucket = resources.workspaceBucket;
     this.hyperframesRenderFunction = resources.hyperframesRenderFunction;
+    this.agentMediaFunction = resources.agentMediaFunction;
     this.usersTable = resources.usersTable;
     this.signalsTable = resources.signalsTable;
     this.messageDedupTable = resources.messageDedupTable;
@@ -500,6 +504,20 @@ export class AgentPlatformStack extends cdk.Stack {
     resources.hyperframesRenderFunction = new HyperframesRenderFunction(this, 'HyperframesRender', {
       environment,
       functionName: `psd-hyperframes-render-${environment}`,
+      workspaceBucket: resources.workspaceBucket,
+      region: this.region,
+      account: this.account,
+    });
+
+    // agent-media (#1738): HTML-to-PDF, ffmpeg transcode/probe and Transcribe.
+    // A SEPARATE function from the renderer above even though both carry
+    // Chromium and FFmpeg — the renderer's role may write only to
+    // public-images/, while this one reads and writes owners' PRIVATE workspace
+    // prefixes and is explicitly denied public-images/. Merging them would
+    // widen a production role to save an image.
+    resources.agentMediaFunction = new AgentMediaFunction(this, 'AgentMedia', {
+      environment,
+      functionName: `psd-agent-media-${environment}`,
       workspaceBucket: resources.workspaceBucket,
       region: this.region,
       account: this.account,
@@ -1667,6 +1685,18 @@ export class AgentPlatformStack extends cdk.Stack {
       resources: [resources.hyperframesRenderFunction.function.functionArn],
     }));
 
+    // agent-media invocation (#1738). Same shape as the render grant above:
+    // scoped to one function ARN, invoked only by the root-owned loopback
+    // relay, which never hands credential material to the model UID and never
+    // accepts a caller-selected target. The media function owns its own S3
+    // access, so the model-facing role gains none.
+    resources.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'AgentMediaInvoke',
+      effect: iam.Effect.ALLOW,
+      actions: ['lambda:InvokeFunction'],
+      resources: [resources.agentMediaFunction.function.functionArn],
+    }));
+
     // ECR pull for agent images
     resources.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
       sid: 'ECRPullAccess',
@@ -1998,6 +2028,7 @@ export class AgentPlatformStack extends cdk.Stack {
       // select a function; the grant is the HyperframesRenderInvoke statement
       // on the AgentCore execution role.
       HYPERFRAMES_RENDER_FUNCTION: resources.hyperframesRenderFunction.function.functionName,
+      AGENT_MEDIA_FUNCTION: resources.agentMediaFunction.function.functionName,
       GUARDRAIL_ARN: props.guardrailArn,
       SKILL_BUILDER_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:${resources.skillBuilderFunctionName}`,
       APP_BASE_URL: props.appBaseUrl ?? '',

--- a/infra/lib/constructs/compute/agent-media-function.ts
+++ b/infra/lib/constructs/compute/agent-media-function.ts
@@ -1,0 +1,199 @@
+import * as path from "node:path"
+import * as cdk from "aws-cdk-lib"
+import * as lambda from "aws-cdk-lib/aws-lambda"
+import * as iam from "aws-cdk-lib/aws-iam"
+import * as logs from "aws-cdk-lib/aws-logs"
+import * as s3 from "aws-cdk-lib/aws-s3"
+import { Platform } from "aws-cdk-lib/aws-ecr-assets"
+import { Construct } from "constructs"
+import { ServiceRoleFactory } from "../security"
+import { Environment } from "../security/types"
+
+/**
+ * agent-media — container-image Lambda behind the root-owned loopback relay,
+ * giving the agent HTML-to-PDF, ffmpeg transcode/probe, and Amazon Transcribe
+ * (issue #1738). See infra/agent-media/README.md for the operation contract.
+ *
+ * Container image, not a zip: Chromium + FFmpeg blow the 250 MB zip ceiling and
+ * sit comfortably under the 10 GB image limit. They cannot live in the agent
+ * image at all — the AgentCore Firecracker snapshotter cannot carry that native
+ * stack, and that image is near its 54-layer ceiling.
+ *
+ * x86_64 to match hyperframes-render and because the Debian chromium package is
+ * the reliable arm64-free choice here; the platform is pinned so the image is
+ * reproducible when built from an arm64 host.
+ */
+export interface AgentMediaFunctionProps {
+  /** Deployment environment — drives tags, log retention, and IAM tag conditions. */
+  environment: Environment
+  /** Physical Lambda function name (e.g. `psd-agent-media-dev`). */
+  functionName: string
+  /** Workspace bucket holding each owner's private prefix. */
+  workspaceBucket: s3.IBucket
+  region: string
+  account: string
+  /** Lambda memory in MB. Transcode and Chromium are CPU-bound; more memory = more vCPU. */
+  memorySize?: number
+  /** Invoke timeout. Default 900 s (Lambda max) — a long transcription can use it. */
+  timeout?: cdk.Duration
+  /** /tmp size in MB for input, output and Chromium scratch. */
+  ephemeralStorageMiB?: number
+  /**
+   * Cap on parallel jobs. Each is an expensive multi-GB container, so bound it
+   * so a burst cannot drain the account's shared Lambda concurrency pool.
+   */
+  reservedConcurrency?: number
+}
+
+export class AgentMediaFunction extends Construct {
+  public readonly function: lambda.DockerImageFunction
+  public readonly logGroup: logs.LogGroup
+
+  constructor(scope: Construct, id: string, props: AgentMediaFunctionProps) {
+    super(scope, id)
+
+    const {
+      environment,
+      functionName,
+      workspaceBucket,
+      region,
+      account,
+      memorySize = 4096,
+      timeout = cdk.Duration.seconds(900),
+      ephemeralStorageMiB = 6144,
+      reservedConcurrency = 5,
+    } = props
+
+    // The function reads a caller's input and writes its output inside that
+    // owner's own private workspace prefix. The prefix is not known at synth
+    // time — it is whichever owner the relay verified for this invocation — so
+    // the object-level grant covers the bucket, and the OWNER boundary is
+    // enforced upstream: the relay injects a web-verified workspacePrefix and
+    // the handler refuses any relative path that tries to escape it.
+    //
+    // The explicit Deny is the part worth reading twice. This function must
+    // never write to public-images/, because a scanned IEP or a staff recording
+    // must not become a public-by-link object. Stating that as a Deny makes it
+    // an IAM property rather than a code convention, so it holds even if the
+    // handler is later changed by someone who has not read why.
+    //
+    // Deliberately NO aws:ResourceTag condition on PutObject: an object-level
+    // PutObject presents no resource tags at authorization time (the object does
+    // not exist yet), so such a condition is never satisfiable and every write
+    // is denied. Documented at length on the hyperframes-render construct and
+    // observed live in the #1138 follow-up.
+    const workspaceObjectPolicy = new iam.PolicyDocument({
+      statements: [
+        new iam.PolicyStatement({
+          sid: "ReadWriteOwnerWorkspaceObjects",
+          effect: iam.Effect.ALLOW,
+          actions: ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+          resources: [`${workspaceBucket.bucketArn}/*`],
+        }),
+        new iam.PolicyStatement({
+          sid: "NeverTouchPublicArtifacts",
+          effect: iam.Effect.DENY,
+          actions: ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+          resources: [`${workspaceBucket.bucketArn}/public-images/*`],
+        }),
+      ],
+    })
+
+    // Transcribe scoped to the job-name prefix the handler mints
+    // (`agent-media-<uuid>`), so this role cannot read or disturb transcription
+    // jobs started by anything else in the account. demontek's 2026-09-03
+    // failure was precisely this permission being absent
+    // ("no AWS Transcribe IAM permission on the execution role").
+    const transcribePolicy = new iam.PolicyDocument({
+      statements: [
+        new iam.PolicyStatement({
+          sid: "RunAgentMediaTranscriptionJobs",
+          effect: iam.Effect.ALLOW,
+          actions: [
+            "transcribe:StartTranscriptionJob",
+            "transcribe:GetTranscriptionJob",
+          ],
+          resources: [
+            `arn:aws:transcribe:${region}:${account}:transcription-job/agent-media-*`,
+          ],
+        }),
+      ],
+    })
+
+    const role = ServiceRoleFactory.createLambdaRole(this, "Role", {
+      functionName,
+      environment,
+      region,
+      account,
+      vpcEnabled: false,
+      additionalPolicies: [workspaceObjectPolicy, transcribePolicy],
+    })
+
+    // Explicit, retention-managed log group named to match the function so the
+    // ServiceRoleFactory base policy's `/aws/lambda/${functionName}` grant lines
+    // up and Lambda does not auto-create an unmanaged group.
+    this.logGroup = new logs.LogGroup(this, "LogGroup", {
+      logGroupName: `/aws/lambda/${functionName}`,
+      retention:
+        environment === "prod" ? logs.RetentionDays.ONE_MONTH : logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    })
+
+    // The handler imports ../validated-fs.cjs from /var/task, so the build
+    // context must include the canonical infra/validated-fs.cjs beside
+    // agent-media/. Keep the context narrow: without these exclusions every
+    // unrelated infra change would rebuild a 2 GB image and CDK would stage
+    // infra/node_modules.
+    const imageAssetRoot = path.join(__dirname, "..", "..", "..")
+    this.function = new lambda.DockerImageFunction(this, "Function", {
+      functionName,
+      description: `Agent media: HTML-to-PDF, ffmpeg, Transcribe (#1738) — ${environment}`,
+      code: lambda.DockerImageCode.fromImageAsset(imageAssetRoot, {
+        file: "agent-media/Dockerfile",
+        exclude: [
+          "**",
+          "!validated-fs.cjs",
+          "!agent-media/",
+          "!agent-media/Dockerfile",
+          "!agent-media/entrypoint.sh",
+          "!agent-media/handler.js",
+          "!agent-media/package.json",
+          // Docker-ignore negations re-include siblings when their parent is
+          // traversed. Exclude non-build inputs again so docs and tests do not
+          // churn the multi-gigabyte Lambda asset hash.
+          "agent-media/.gitignore",
+          "agent-media/README.md",
+          "agent-media/handler.test.js",
+          "agent-media/node_modules",
+        ],
+        ignoreMode: cdk.IgnoreMode.DOCKER,
+        platform: Platform.LINUX_AMD64,
+      }),
+      architecture: lambda.Architecture.X86_64,
+      role,
+      memorySize,
+      timeout,
+      reservedConcurrentExecutions: reservedConcurrency,
+      ephemeralStorageSize: cdk.Size.mebibytes(ephemeralStorageMiB),
+      logGroup: this.logGroup,
+      environment: {
+        WORKSPACE_BUCKET: workspaceBucket.bucketName,
+        // Leave headroom under the Lambda timeout so a stuck transcode or
+        // transcription returns a clean, attributable error instead of being
+        // cut off mid-flight by the platform, which surfaces to the agent as an
+        // opaque invoke failure with nothing to tell the user.
+        MEDIA_FFMPEG_TIMEOUT_MS: String(
+          Math.max(timeout.toMilliseconds() - 180_000, 60_000),
+        ),
+        MEDIA_TRANSCRIBE_TIMEOUT_MS: String(
+          Math.max(timeout.toMilliseconds() - 180_000, 60_000),
+        ),
+      },
+    })
+
+    cdk.Tags.of(this.function).add("Environment", environment)
+    cdk.Tags.of(this.function).add("ManagedBy", "cdk")
+    cdk.Tags.of(this.logGroup).add("Environment", environment)
+    cdk.Tags.of(this.logGroup).add("ManagedBy", "cdk")
+  }
+}

--- a/lib/agent-workspace/workspace-policy.json
+++ b/lib/agent-workspace/workspace-policy.json
@@ -45,6 +45,7 @@
       "exec-approvals.json.doctor-importing"
     ],
     "relativePrefixes": [
+      ".media-scratch/",
       "openclaw.json",
       "openclaw.json.bak",
       "agents/main/agent/models.json",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:skill:workspace": "cd infra/agent-image/skills/psd-workspace && bun test common.test.js",
     "test:lambda:router": "cd infra/lambdas/agent-router && bun test",
     "test:lambda:cron": "cd infra/lambdas/agent-cron && bun test",
+    "test:lambda:media": "cd infra/agent-media && bun test",
     "test:skill:publish-file": "cd infra/agent-image/skills/psd-publish-file && bun test",
     "test:skill:directory": "cd infra/agent-image/skills/psd-directory && bun test run.test.js",
     "test:skill:workflows": "cd infra/agent-image/skills/psd-workflows && node --test",


### PR DESCRIPTION
Closes item 7 of the week's agent-failure work: the three capabilities the agent kept having to refuse.

## The refusals this ends

Pulled from prod `agent_failures` rather than summarised, because the detail changed the design:

| user | what they asked for | what happened |
|---|---|---|
| **nashs** ×2, 09-01 | an HTML sign saved as an **8.5×11 printable PDF** | no browser in the container. The PyMuPDF fallback ignored flexbox, dropped the base64 logo, substituted the web fonts, and produced a **400×600pt** page. The advice given was "open the link and Print > Save as PDF yourself" |
| **kinneyk**, 09-01 | a **.mov** converted and verified for Facebook/Instagram | no ffmpeg, no ffprobe. Could neither answer nor convert |
| **demontek**, 09-03 | an **.m4a** turned into a printable script | no Whisper key, **no Transcribe permission on the execution role**, and the Bedrock model takes text and images but not audio |

OCR — the fourth ask — shipped in #1736 and is already live.

## Design

**One new container Lambda** (`infra/agent-media/`) with three operations, behind the existing root-owned loopback relay.

**Separate from `hyperframes-render`, deliberately**, despite the overlapping Chromium+FFmpeg toolset. The reason is IAM, not convenience: that function's role may write **only** to `public-images/`. This one reads and writes owners' **private** workspace prefixes and carries an explicit **DENY** on `public-images/`, so "a scanned IEP never becomes a public-by-link object" is an IAM property rather than a code convention that lasts only as long as nobody edits the handler. Merging them would widen a production role to save an image.

**The function never accepts an identity.** The relay injects `workspacePrefix` from the web-verified invocation context; the model supplies only workspace-relative paths, validated against absolute forms, `..`, backslashes and control characters at *two* independent layers. A caller cannot reach another owner's workspace because it never states who it is. Identity fields in the payload are **rejected**, not silently overwritten — an attempt to reach elsewhere should be visible, not quietly corrected.

**`_resolve_invocation_identity` has no old-tier fallback**, unlike its owner-only sibling. The prefix decides whose objects the function may touch, so if the web tier is too old to return it, media stays unavailable until the deploy catches up.

**Transport:** bytes go through the workspace broker into `.media-scratch/`, newly added to `checkpointExclusions`. That is load-bearing. An ad-hoc upload into a checkpoint-**managed** path is deleted by the next `ensureWorkspaceCheckpoint`, which rolls the workspace back to its manifest and delete-markers anything unexpected — scratch would vanish mid-turn. Exclusion also keeps it out of the container, which is correct for a transport. Scratch is removed on every exit path; for `psd-transcribe` that matters beyond tidiness, because the transport copy is someone's voice.

**Presets, never caller-supplied ffmpeg argv.** Arbitrary arguments into ffmpeg are a command-injection and resource-exhaustion surface, and every real request so far has been one of three shapes. A test asserts no preset argument contains a shell metacharacter.

## Verified against the running container, not just unit tests

**html-to-pdf** — reproduced nashs's sign (flexbox, `@page`, embedded base64 image, web font stack) through the Lambda Runtime Interface Emulator:

```
status: ok   bytes: 20924   pages: 1   header: %PDF-1.4
MediaBox: 612 x 792 pt
```

612×792pt is exactly 8.5×11. Rendered it to PNG and looked at it: full-bleed gradient, `space-between` layout, the embedded image, the serif font — every element the old fallback destroyed.

**social-mp4** — ProRes `.mov` → `h264 High / yuv420p` + `aac`, 3.5 MB → 54 KB. Checked the `+faststart` claim empirically rather than trusting the flag: **`moov` at byte 36, `mdat` at 3591**. That ordering is what stops uploaders rejecting a file as corrupt.

**Error paths through the real container** — an `.aiff` refusal that hands over the exact conversion command, and `../escape.mov` stopped at the traversal check.

**The relay's path regex** — proven against 13 escape attempts before being trusted.

**Re-verified after refactoring.** I split three over-complex functions to clear the zero-warning lint gate, then **rebuilt the image and re-ran the smoke test**, because the earlier pass no longer described the code. Byte-identical result.

The Dockerfile also fails the build if Chromium cannot emit a `%PDF-` or the static ffmpeg cannot execute, so a broken image never reaches a push.

## Things worth a reviewer's attention

- **A test caught a real flaw of mine**: an unknown ffmpeg preset was validated *after* the input was pulled from S3, so a typo would download hundreds of megabytes and then fail with `WORKSPACE_BUCKET is not configured` — the wrong error for the wrong reason. Everything free to check now runs before any I/O.
- **Lint warnings were fixed, not suppressed.** The `security/detect-non-literal-fs-filename` warnings were pointing at something real: I had imported the shared `validated-fs` wrapper and then used raw `fs` anyway. All filesystem access moved onto the wrapper, matching every other handler and skill.
- `cdk synth` succeeds. The two new `AgentMedia` IAM warnings are the same LOW tag-condition class the existing `HyperframesRender` role already carries, for the documented reason that an object-level `s3:PutObject` presents no resource tags at authorization time.

## Deploy order

Same web-tier-first rule as #1736, and here it is enforced rather than merely documented: the relay fails closed if `/api/agent/invocation-identity` does not yet return `workspacePrefix`.

1. web tier (identity route + policy exclusion)
2. `AIStudio-AgentPlatformStack` with the new agent image and the media Lambda

The three evals are **L2/capability**, matching `psd-hyperframes` — they exercise a deployed function, so they skip until it exists rather than failing red.

## Verification

`bun run lint` clean (zero warnings) · `bun run typecheck` clean · 5,918 jest · 904 agent-image Python (+9 new relay boundary tests) · 21 handler tests · `cdk synth` green.

Also wired agent-media into CI **with its own dependency install** — the same gap that left the agent-cron suite running nowhere until CI caught it in #1736.
