### PR TITLE
fix(agent): stop the agent telling users they interrupted it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           infra/agent-image/test_workspace_contract.py \
           infra/agent-image/test_check_bootstrap_budget.py \
           infra/agent-image/test_check_config_consistency.py \
+          infra/agent-image/test_openclaw_tool_policy.py \
           infra/agent-image/test_candidate_matrix.py \
           infra/agent-image/test_workspace_sync.py \
           infra/agent-image/test_chat_format.py \

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1565,6 +1565,23 @@ class OpenClawAdapter(HarnessAdapter):
         agent inventing an abort they never performed. They were right that
         they never aborted anything; we did, on every turn.
 
+        THAT FIX NEVER WORKED, AND `ask_user` IS NOW DENIED.
+        The resolve targets a question held in the gateway's memory, and this
+        runtime stops the gateway after every turn — so by the time the answer
+        arrives the question is gone. Prod 2026-08-31..09-05: nineteen
+        attempts, nineteen `ok=False`, every one
+        `errorCode=INVALID_REQUEST errorMessage=question '<id>' was not found`.
+        Zero successes in the retained history. `ask_user` is therefore in
+        `tools.deny` (openclaw.json) — see test_openclaw_tool_policy.py for the
+        full failure chain, including the synthetic transcript-repair result
+        that made the model tell users they had interrupted it.
+
+        This path is kept, not deleted: the gateway can raise questions from
+        sources other than `ask_user` (see _build_question_answers), and it is
+        the only correct handling if the denial is ever lifted. It should now
+        be effectively unreachable — a `question.resolve` line in the logs is a
+        signal that something re-introduced a question-asking tool.
+
         Params are exactly QuestionResolveParamsSchema:
             { id, answers: { answers: { <questionId>: [<text>] } }, resolvedBy }
         which is the same shape OpenClaw's own plain-text claim path sends.

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -66,7 +66,7 @@
         "cacheTtlMinutes": 15
       }
     },
-    "deny": ["cron", "nodes", "gateway", "sessions", "agents"]
+    "deny": ["cron", "nodes", "gateway", "sessions", "agents", "ask_user"]
   },
   "skills": {
     "load": {

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -466,6 +466,19 @@ compromise:
   CURRENT user message. If it does not say stop, you are inventing it — delete
   the sentence and finish the work.
 
+  **One in-context signal looks like proof of a stop and is not.** A tool result
+  reading `[openclaw] missing tool result in session history; inserted synthetic
+  error result for transcript repair.` is the runtime repairing its own
+  transcript: an earlier tool call lost its result when the container recycled
+  between turns. It is bookkeeping about a tool, never a statement about the
+  user. On 2026-09-06 that marker sat in a session and the agent answered
+  "Got it — pausing since you interrupted that run" to a user whose actual
+  message was "Never mind, that makes sense … can you make me a pdf of the ion
+  sudoku". Read the marker as "that one tool produced nothing — redo it or work
+  around it", then answer the CURRENT message. Never mention the marker, and
+  never turn it into a claim that the user stopped, interrupted, or aborted
+  anything.
+
 **Why:** "I'll notify you when it's done" is only true if the platform's own
 promotion path is doing the notifying. Running long composes with it. Anything
 that ends your turn early — a promise, a spawned child, a deferral — breaks it.

--- a/infra/agent-image/test_openclaw_tool_policy.py
+++ b/infra/agent-image/test_openclaw_tool_policy.py
@@ -1,0 +1,101 @@
+"""Tool-policy contracts that keep the agent from inventing user interruptions.
+
+`ask_user` is a BLOCKING tool: it registers a question on the OpenClaw gateway
+and waits for `question.resolve`. That contract cannot hold here, because this
+runtime stops the gateway after every turn (harness_adapter "Stopping OpenClaw
+gateway", ~3ms after the final event) and starts a fresh one for the next
+invocation. The question dies with the gateway it was registered on.
+
+Measured on prod between 2026-08-31 and 2026-09-05: nineteen `question.resolve`
+attempts, nineteen `ok=False`, every one paired with
+`errorCode=INVALID_REQUEST errorMessage=question '<id>' was not found`. Zero
+successes in the whole retained log history.
+
+The cost is not the failed resolve, it is the wreckage it leaves. The assistant
+turn keeps its `ask_user` toolCall and never gets a toolResult, so on EVERY
+later turn OpenClaw repairs the pairing with a synthetic `isError: true` result
+reading "[openclaw] missing tool result in session history; inserted synthetic
+error result for transcript repair." The model reads its own question coming
+back as an error and concludes the user stopped it. Observed verbatim in dev
+session 5a1baef7 on 2026-09-06: the thinking block "The user stopped their
+request" (the user had said "It's in a private collection"), and four turns
+later "Got it — pausing since you interrupted that run." The scar is permanent
+for the life of the session, which is why it reads as the agent doing this
+"all the time" rather than once.
+
+Asking in prose loses nothing: the question text is delivered to Google Chat
+either way, and Chat renders no option chips for `ask_user`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+
+SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(SOURCE_DIR, "openclaw.json")
+RULES_PATH = os.path.join(SOURCE_DIR, "skills", "psd-rules", "SKILL.md")
+
+# The literal OpenClaw inserts for an orphaned tool call
+# (DEFAULT_MISSING_TOOL_RESULT_TEXT in the shipped ai-transport-runtime-host
+# bundle). psd-rules quotes it so the model can recognise the marker; if
+# upstream ever reworks the wording the rule silently stops matching, so the
+# two are pinned together here.
+SYNTHETIC_REPAIR_MARKER = (
+    "[openclaw] missing tool result in session history; "
+    "inserted synthetic error result for transcript repair."
+)
+
+
+def _load_config() -> dict:
+    with open(CONFIG_PATH, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+class AskUserIsDenied(unittest.TestCase):
+    def test_ask_user_is_in_the_tool_deny_list(self):
+        deny = _load_config()["tools"]["deny"]
+        self.assertIn(
+            "ask_user",
+            deny,
+            "ask_user must stay denied: the gateway is restarted between "
+            "turns, so its question can never be resolved and the orphaned "
+            "tool call poisons the session with a synthetic error result the "
+            "model reports as the user interrupting it",
+        )
+
+    def test_the_existing_denials_survive(self):
+        # A replacement rather than an append would silently hand the model
+        # back cron/gateway/nodes/sessions/agents.
+        deny = set(_load_config()["tools"]["deny"])
+        self.assertLessEqual(
+            {"cron", "nodes", "gateway", "sessions", "agents"},
+            deny,
+        )
+
+    def test_the_deny_name_matches_the_registered_tool_name(self):
+        # The shipped gate is
+        #   isToolAllowedByPolicyName("ask_user", { deny })
+        # in shouldIncludeAskUserToolForOpenClawTools, and that matcher
+        # compares NORMALIZED names. A near-miss spelling ("askUser",
+        # "ask-user") denies nothing and fails open.
+        deny = _load_config()["tools"]["deny"]
+        self.assertNotIn("askUser", deny)
+        self.assertNotIn("ask-user", deny)
+
+
+class RulesNameTheRepairMarker(unittest.TestCase):
+    def test_psd_rules_quotes_the_synthetic_repair_text_verbatim(self):
+        # Denying ask_user stops new orphans; it does not clean the ones
+        # already sitting in long-lived sessions, and a turn killed at the
+        # AgentCore deadline can still orphan a tool call. The rule is what
+        # covers those, and it only works if it quotes the exact string.
+        with open(RULES_PATH, encoding="utf-8") as handle:
+            rules = handle.read()
+        collapsed = " ".join(rules.split())
+        self.assertIn(SYNTHETIC_REPAIR_MARKER, collapsed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Kris: *"They constantly think I am interrupting them or stopping their work or whatever and that's never the case."*

The agent is not inventing it. Something in its own context says so, on every turn of an affected session, and it is reporting it faithfully.

## What actually happens

`ask_user` is a **blocking** tool: it registers a question on the OpenClaw gateway and waits for `question.resolve`. That contract cannot hold in this runtime. AgentCore gives us one container per invocation, so `harness_adapter` stops the gateway when the turn ends — measured **3 ms** after the final event — and starts a fresh one for the next message. The question dies with the gateway that held it.

Prod, 2026-08-31 → 09-05: **nineteen** `question.resolve` attempts, **nineteen** `ok=False`, each paired with

```
errorCode=INVALID_REQUEST errorMessage=question '<id>' was not found
```

**Zero** successes in the entire retained log history. `_resolve_pending_question` was written to close exactly this hole and never once closed it.

The failed resolve is not the damage. The damage is the wreckage it leaves: the assistant turn keeps its `ask_user` toolCall and never receives a toolResult, so from then on OpenClaw repairs the pairing on **every** subsequent turn with a synthetic `isError: true` result reading

```
[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.
```

The model watches its own question to the user come back as an error and draws the obvious conclusion. Dev session `5a1baef7`, 2026-09-06, straight out of the transcript — the thinking block immediately after that synthetic result:

> *"The user stopped their request, so I should ask what they'd like me to help with instead of continuing to guess."*

Kris had said *"It's in a private collection, it may be called csd as an abbreviation."*

Four turns later, with the same synthetic result still sitting at index 14 of a 31-message context, he asked for a PDF of the Ion Sudoku artifact and got the message in the report:

> *"Got it — pausing since you interrupted that run. Where do you want to pick back up?"*

The scar lasts for the life of the session. That is why it reads as constant rather than occasional.

## The fix

**Deny `ask_user`.** Verified against the shipped bundle rather than assumed — a probe of the real matcher, `isToolAllowedByPolicyName("ask_user", { deny })`, which is the exact predicate `shouldIncludeAskUserToolForOpenClawTools` calls:

```
deny: ["cron","nodes","gateway","sessions","agents","ask_user"]
deny   ask_user          <- with this change
ALLOW  ask_user          <- with HEAD's deny list (negative control)
ALLOW  exec / read / write / web_search / web_fetch / message / update_plan
```

Nothing else moves.

**Nothing is lost.** The question was never interactive here. Turn 1 of that session delivered 969 characters to Chat, and 681 (prose) + 143 (question) + 134 (three option labels) + separators is exactly 969 — Google Chat was already flattening the tool's question and its options into plain text. The agent will now write the same sentence itself, which is what `psd-rules` already asks for.

**`psd-rules` gains a short rule naming the marker verbatim.** Denying the tool stops new orphans; it does not clean the ones already sitting in long-lived sessions, and a turn killed at the AgentCore deadline can still orphan a call. The rule tells the model the marker is the runtime repairing its own bookkeeping, never a statement about the user. A test pins the quoted literal to the string upstream actually emits, so the two cannot drift apart silently.

**`_resolve_pending_question` is kept, not deleted** — the gateway can raise questions from sources other than `ask_user`, and it is the right handling if the denial is ever lifted. Its docstring now records that it has never succeeded and why. A `question.resolve` line in the logs is now a signal that something re-introduced a question-asking tool.

## A theory I chased and rejected

OpenClaw injects `"Note: The previous agent run was aborted by the user. Resume carefully or ask for clarification."` whenever `abortedLastRun` is set, and `markStartupOrphanedMainSessionsForRecovery` arms that flag on **every one** of our gateway restarts — `marked 1 startup-orphaned main session(s) for restart recovery` is in the log for all six turns of that session. It looked like a perfect match.

It is not the cause. The `prompt.submitted` trajectory records carry the body actually submitted for each turn, and none of the six has the prefix. Left alone rather than "fixed" on a good story.

## Known residual

Sessions that already contain an orphaned `ask_user` keep the marker until compaction ages it out. The new rule is what covers them; `/new` clears it outright. Repairing existing transcripts would mean inserting a `toolResult` mid-list in the SQLite event chain, with seq renumbering and parentId rechaining on a live workspace — more risk than the symptom warrants.

## Verification

`bun run lint` clean (zero warnings) · `bun run typecheck` clean · 5,918 jest · 325 agent-image python (harness/reply-replay/config) · 93 eval-coverage · bootstrap budget 44,947 / 80,000 · `check_config_consistency.py` and `check_eval_coverage.py` pass.

The new suite is wired into CI with its own line in the unittest list — new tests under `infra/` otherwise run nowhere.

## Deploy

Agent image rebuild only; no web-tier or CDK change. `openclaw.json` and `psd-rules` are baked into the image at build time.
