### PR TITLE
fix(agent-media): let Chromium start inside the Lambda sandbox

### DIFF
--- a/infra/agent-media/README.md
+++ b/infra/agent-media/README.md
@@ -36,9 +36,18 @@ act through `psd-publish-file`, which carries its own sensitivity gate.
 
 ## Local smoke test (pre-deploy)
 
-The build itself proves the two native tools work — `RUN` probes fail the build
-if Chromium can't emit a `%PDF-` or if the static ffmpeg/ffprobe can't execute.
-To exercise the handler the way Lambda does:
+**A local pass does not mean it works in Lambda.** On 2026-09-06 the build
+probes passed, the smoke test below returned a correct 612x792pt PDF, and the
+deployed function could not print a single page: Lambda's sandbox refuses
+Chromium's GPU-process spawn, its zygote fork, and crashpad's ptrace attach.
+None of that reproduces in Docker Desktop — not even with `--cap-drop=ALL
+--security-opt no-new-privileges`. Local runs prove **output quality**
+(geometry, layout, codecs). They prove nothing about whether the binary can
+start where it has to. For that, see *Post-deploy check* below, and run it.
+
+With that understood — the build itself proves the two native tools can execute
+(`RUN` probes fail the build if Chromium can't emit a `%PDF-` or the static
+ffmpeg/ffprobe can't run). To exercise the handler the way Lambda does:
 
 ```bash
 cd infra && docker build --platform linux/amd64 -f agent-media/Dockerfile -t agent-media:smoke .
@@ -79,6 +88,22 @@ Verified on 2026-09-05 against this image: a ProRes `.mov` through the
 at byte 36, ahead of `mdat` at 3591 — `+faststart` doing its job. That ordering
 is what stops Facebook and Instagram rejecting an upload as corrupt, so it is
 worth re-checking whenever the preset changes.
+
+## Post-deploy check (the one that actually proves Chromium starts)
+
+Required after every deploy that touches the Dockerfile, the Chromium flags, or
+the base image. It is the only test that runs inside the sandbox that broke
+this function once already, and it takes seconds:
+
+```bash
+aws lambda invoke --function-name psd-agent-media-dev --cli-read-timeout 200 \
+  --payload '{"operation":"html-to-pdf","workspacePrefix":"probe/","userEmail":"probe@psd401.net","html":"<!doctype html><h1>probe</h1>","pageSize":"letter"}' \
+  /tmp/agent-media-probe.json >/dev/null && python3 -c "import json;d=json.load(open('/tmp/agent-media-probe.json'));print(d['status'], d.get('bytes') or d.get('message'))"
+```
+
+`ok <bytes>` means Chromium started and printed. Anything else prints the real
+diagnostic — and since 2026-09-06 the same text is also in the function's
+CloudWatch log group, which until then held nothing but `START`/`END`/`REPORT`.
 
 ## Caps
 

--- a/infra/agent-media/handler.js
+++ b/infra/agent-media/handler.js
@@ -76,6 +76,23 @@ const MAX_HTML_BYTES = 4 * 1024 * 1024;
 const MAX_INPUT_MEDIA_BYTES = 512 * 1024 * 1024;
 const MAX_TRANSCRIPT_CHARS = 600_000;
 const CHROMIUM_TIMEOUT_MS = 120_000;
+
+// What it takes to start Chromium inside a Lambda sandbox. Every entry after
+// --headless is load-bearing; see the block comment in htmlToPdf for the
+// captured stderr each one answers. Kept as a named constant so a test can
+// assert they survive, because losing any one of them fails at runtime only,
+// in production only, with no local reproduction.
+const CHROMIUM_SANDBOX_FLAGS = Object.freeze([
+  '--headless',
+  '--no-sandbox',
+  '--disable-gpu',
+  '--disable-software-rasterizer',
+  '--in-process-gpu',
+  '--no-zygote',
+  '--single-process',
+  '--disable-crash-reporter',
+  '--disable-dev-shm-usage',
+]);
 const FFPROBE_TIMEOUT_MS = 60_000;
 const FFMPEG_TIMEOUT_MS = Number(process.env.MEDIA_FFMPEG_TIMEOUT_MS || 600_000);
 const TRANSCRIBE_POLL_INTERVAL_MS = 5_000;
@@ -239,14 +256,21 @@ async function downloadToFile(key, destination) {
   return size;
 }
 
-async function runBinary(binary, args, timeoutMs, label) {
+async function runBinary(binary, args, timeoutMs, label, extraEnv) {
   try {
     return await execFileAsync(binary, args, {
       timeout: timeoutMs,
       maxBuffer: 16 * 1024 * 1024,
+      // Only when a caller asks. Chromium needs HOME and the XDG paths pointed
+      // at /tmp because Lambda's filesystem is read-only everywhere else;
+      // ffmpeg needs nothing and inherits the ambient environment.
+      ...(extraEnv ? { env: { ...process.env, ...extraEnv } } : {}),
     });
   } catch (error) {
     if (error && error.killed) {
+      console.error(
+        `[agent-media] ${label} exceeded ${Math.round(timeoutMs / 1000)}s`,
+      );
       throw new Error(
         `${label} exceeded its ${Math.round(timeoutMs / 1000)}s budget`,
         { cause: error },
@@ -254,6 +278,13 @@ async function runBinary(binary, args, timeoutMs, label) {
     }
     // ffmpeg/chromium put the useful diagnosis on stderr, not in the message.
     const detail = String(error?.stderr || error?.message || '').trim().slice(-600);
+    // CloudWatch, not just the caller. The 2026-09-06 Chromium failure returned
+    // this text to the agent, which relayed it to the user in chat — and the
+    // function's own log group held nothing but START/END/REPORT, so the only
+    // record of why production was broken was a screenshot of a chat message.
+    // Logged at full length; the throw below is what gets truncated for the
+    // user-facing reply.
+    console.error(`[agent-media] ${label} failed:`, String(error?.stderr || error?.message || ''));
     throw new Error(`${label} failed: ${detail || 'no diagnostic output'}`, {
       cause: error,
     });
@@ -303,19 +334,51 @@ async function htmlToPdf(event, scratch) {
 
   const source = path.join(scratch, 'page.html');
   const target = path.join(scratch, 'page.pdf');
+  const userDataDir = path.join(scratch, 'chrome-user-data');
+  await validatedFsPromises.mkdir(userDataDir, { recursive: true });
   await validatedFsPromises.writeFile(source, html, 'utf8');
 
   // --no-pdf-header-footer suppresses Chromium's default URL/date furniture,
   // which otherwise prints over a design that was laid out to the page edge.
   // The page's own @page CSS still wins over these dimensions when it sets one,
   // which is exactly what the 8.5x11 sign relies on.
+  //
+  // EVERY OTHER FLAG HERE EXISTS BECAUSE OF ONE STDERR, captured 2026-09-06 by
+  // invoking the DEPLOYED psd-agent-media-dev rather than a local container:
+  //
+  //   GPU process launch failed: error_code=1002
+  //   FATAL: GPU process isn't usable. Goodbye.
+  //   ptrace: Operation not permitted (1)
+  //   Zygote could not fork: process_type utility numfds 6 child_pid -1
+  //
+  // Three separate subprocess spawns that Lambda's sandbox refuses, so:
+  //   --in-process-gpu           `--disable-gpu` disables GPU RENDERING; the
+  //                              GPU process is still spawned, and its failure
+  //                              is FATAL. This keeps it in-process.
+  //   --disable-software-rasterizer  no SwiftShader fallback process either.
+  //   --no-zygote                the zygote cannot fork here; let the browser
+  //                              fork children directly.
+  //   --single-process           belt to the --no-zygote braces. print-to-PDF
+  //                              is a one-shot non-interactive load, which is
+  //                              the workload single-process is safe for.
+  //   --disable-crash-reporter   crashpad's ptrace attach is denied; the only
+  //                              thing it produces here is noise in the error
+  //                              the user reads.
+  //   --user-data-dir/--crash-dumps-dir + HOME/XDG_* below: the filesystem is
+  //                              read-only except /tmp, and Chromium's default
+  //                              profile path is $HOME/.config/chromium.
+  //
+  // None of this reproduces locally. Docker Desktop still renders a correct PDF
+  // with `--cap-drop=ALL --security-opt no-new-privileges`, which is why both
+  // the build probe and the RIE smoke test passed a build that could not print
+  // a single page in production. Verify a change here by invoking the deployed
+  // function; local runs prove output quality only.
   await runBinary(
     CHROMIUM,
     [
-      '--headless',
-      '--no-sandbox',
-      '--disable-gpu',
-      '--disable-dev-shm-usage',
+      ...CHROMIUM_SANDBOX_FLAGS,
+      `--user-data-dir=${userDataDir}`,
+      `--crash-dumps-dir=${scratch}`,
       '--no-pdf-header-footer',
       `--print-to-pdf-page-size=${width}x${height}`,
       ...(printBackground ? ['--print-to-pdf-background'] : []),
@@ -324,6 +387,7 @@ async function htmlToPdf(event, scratch) {
     ],
     CHROMIUM_TIMEOUT_MS,
     'Chromium print-to-PDF',
+    { HOME: scratch, XDG_CONFIG_HOME: scratch, XDG_CACHE_HOME: scratch },
   );
 
   const pdf = await validatedFsPromises.readFile(target);
@@ -619,7 +683,10 @@ exports.handler = async function handler(event) {
     }
     // Deliberately surfaced rather than swallowed: the agent has to be able to
     // tell the user WHY, and an opaque failure here is what sent three separate
-    // callers away empty-handed in the first place.
+    // callers away empty-handed in the first place. Also logged, because the
+    // caller's copy lives in a chat message and CloudWatch is where anyone
+    // debugging this will actually look.
+    console.error('[agent-media] operation failed:', error?.stack || String(error));
     return fail('media_failed', String(error?.message || error).slice(0, 900));
   } finally {
     if (scratch) {
@@ -638,5 +705,6 @@ exports.testables = {
   PAGE_SIZES,
   TRANSCRIBABLE,
   MAX_INLINE_PDF_BYTES,
+  CHROMIUM_SANDBOX_FLAGS,
   validatedFs,
 };

--- a/infra/agent-media/handler.test.js
+++ b/infra/agent-media/handler.test.js
@@ -5,10 +5,18 @@
  *
  * These cover the parts that can be exercised without Docker: request
  * validation, the path/prefix boundary, the ffprobe summariser, and the
- * dispatch-level error taxonomy. The parts that genuinely need the container —
- * Chromium actually producing a PDF, ffmpeg actually transcoding — are proven
- * by the Dockerfile's own build-time probes and by the RIE smoke test in
- * README.md, because asserting on a mocked execFile would only prove the mock.
+ * dispatch-level error taxonomy.
+ *
+ * WHAT THESE — AND EVERY LOCAL CHECK — CANNOT PROVE.
+ * This header used to claim Chromium's behaviour was "proven by the
+ * Dockerfile's own build-time probes and by the RIE smoke test". Both passed
+ * on 2026-09-06 for a build that could not print a single page in production:
+ * Lambda's sandbox refuses the GPU-process spawn, the zygote fork, and
+ * crashpad's ptrace attach, and none of that reproduces in Docker Desktop —
+ * not even with `--cap-drop=ALL --security-opt no-new-privileges`. A local run
+ * proves OUTPUT QUALITY (geometry, layout, codecs) and nothing about whether
+ * the binary can start where it has to. The only test for that is invoking the
+ * deployed function; see README.md.
  */
 
 'use strict';
@@ -24,7 +32,41 @@ const {
   PRESETS,
   PAGE_SIZES,
   TRANSCRIBABLE,
+  CHROMIUM_SANDBOX_FLAGS,
 } = testables;
+
+describe('Chromium can start inside a Lambda sandbox', () => {
+  // Captured 2026-09-06 by invoking the DEPLOYED psd-agent-media-dev. Each
+  // flag answers one line of that stderr. Losing any of them fails at runtime,
+  // in production only, with no local reproduction — so pin them here.
+  const REQUIRED = {
+    '--no-sandbox': 'setuid sandbox is unavailable',
+    '--in-process-gpu': 'GPU process launch failed: error_code=1002 (FATAL)',
+    '--disable-software-rasterizer': 'no SwiftShader fallback process either',
+    '--no-zygote': 'Zygote could not fork: child_pid -1',
+    '--single-process': 'belt to the --no-zygote braces',
+    '--disable-crash-reporter': 'crashpad ptrace: Operation not permitted',
+    '--disable-dev-shm-usage': '/dev/shm is too small to render into',
+  };
+
+  for (const [flag, why] of Object.entries(REQUIRED)) {
+    test(`${flag} — ${why}`, () => {
+      expect(CHROMIUM_SANDBOX_FLAGS).toContain(flag);
+    });
+  }
+
+  test('--disable-gpu alone is not enough, so it never stands alone', () => {
+    // The original build had --disable-gpu and still died: it disables GPU
+    // RENDERING, not the GPU process spawn. This asserts the pairing rather
+    // than the flag, because the flag on its own is what shipped broken.
+    expect(CHROMIUM_SANDBOX_FLAGS).toContain('--disable-gpu');
+    expect(CHROMIUM_SANDBOX_FLAGS).toContain('--in-process-gpu');
+  });
+
+  test('the set is frozen so a caller cannot mutate it between invocations', () => {
+    expect(Object.isFrozen(CHROMIUM_SANDBOX_FLAGS)).toBe(true);
+  });
+});
 
 describe('workspace path boundary', () => {
   test('accepts an ordinary relative path, hyphens and dots included', () => {


### PR DESCRIPTION
`psd-print-pdf` shipped in #1738 and **never printed a page in production.** Found when Kris re-tested the interruption fix and asked for a PDF of the Ion Sudoku artifact.

The agent was blameless — it has no local Chromium and correctly called the relay. `psd-agent-media-dev` was invoked 5 times: one that hung to the 120s Chromium timeout, then four ~1s failures.

## The actual error

Not inferred. Captured by invoking the **deployed** function directly with a minimal payload:

```
GPU process launch failed: error_code=1002
FATAL: GPU process isn't usable. Goodbye.
ptrace: Operation not permitted (1)
Zygote could not fork: process_type utility numfds 6 child_pid -1
write: Broken pipe (32)
```

Three subprocess spawns Lambda's sandbox refuses. Each new flag answers one line of that stderr:

| flag | the line it answers |
|---|---|
| `--in-process-gpu` | `GPU process launch failed` — **`--disable-gpu` was already there and is not enough**: it disables GPU *rendering*, the GPU *process* is still spawned, and its failure is FATAL |
| `--disable-software-rasterizer` | no SwiftShader fallback process either |
| `--no-zygote` | `Zygote could not fork: child_pid -1` |
| `--single-process` | belt to those braces |
| `--disable-crash-reporter` | crashpad's `ptrace: Operation not permitted` |
| `--user-data-dir` / `--crash-dumps-dir` + `HOME`/`XDG_*` → `/tmp` | read-only filesystem; Chromium's default profile is `$HOME/.config/chromium` |

Held as a frozen `CHROMIUM_SANDBOX_FLAGS` with **a test per flag naming the stderr line it answers**, because dropping any one fails at runtime, in production, silently.

## The function logged nothing

Its entire CloudWatch group held `START`/`END`/`REPORT` and not one application line. The diagnostic went to the caller — so the only record of why production was broken was a screenshot of a chat message. `runBinary` and the top-level catch now `console.error` before returning.

## Why the gates passed a build that couldn't print

The Dockerfile probe runs during `docker build`; the smoke test runs the RIE under Docker Desktop. Both are ordinary containers. Real Lambda is a locked-down microVM — and **this does not reproduce locally**. I checked: with `--cap-drop=ALL --security-opt no-new-privileges`, Docker still writes a correct PDF.

So a local pass proves **output quality** and nothing about whether the binary can start. The test-file header and README claimed otherwise; both now say so plainly, and README gains a **Post-deploy check** — an `aws lambda invoke` one-liner, required after any change to the Dockerfile, the flags, or the base image. It is the only test that runs inside the sandbox that broke this.

## Verified

Local runs prove the half they can. The new flag set renders nashs's actual sign (flexbox, `@page`, embedded base64 image, serif stack) end-to-end through the RIE:

```
status: ok
bytes: 20924  pages: 1  MediaBox: 612 x 792 pt
```

**Byte-identical in size to the pre-change output**, so `--single-process` costs nothing here. I rendered it to PNG and looked at it — gradient, `space-between` layout, embedded image, font all intact.

**Known trade-off:** under `--single-process` Chromium can't resolve `@font-face { src: local(...) }` — it needs the browser process's font service — and logs a warning. Generated artifacts embed or link their fonts, and a missing `local()` face is a smaller loss than no PDF at all.

The remaining unknown is honest: only the deploy proves Chromium starts. I'll run the post-deploy probe against dev the moment it's up.

`bun run lint` clean (zero warnings) · `bun run typecheck` clean · 5,918 jest · 30 agent-media bun tests (+9 new) · `cdk synth` green, only the pre-existing LOW tag-condition warnings.

## Deploy

**No agent-image rebuild.** The media Lambda is a CDK `DockerImageAsset` — `cdk deploy AIStudio-AgentPlatformStack-*` builds and pushes it. Nothing to hand off from `build-and-push.sh` this time.
