### PR TITLE
fix(agent): release the workspace mutex when no microVM ever started

### DIFF
--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -41,6 +41,7 @@ const {
   markPromotedTurnRecoveredWithDependencies,
   btwSlashCommandId,
   recordIfHeadedForDlq,
+  agentCoreHttpFailure,
 } = agentRouterTestHelpers
 
 type OwnerHuman = Parameters<typeof invokeOwnerAgentWithDependencies>[0]
@@ -2432,5 +2433,98 @@ describe("dead-letter telemetry", () => {
       { recordFailure: async () => { throw new Error("pool exhausted") } },
     )
     expect(c.errors.length).toBeGreaterThan(0)
+  })
+})
+
+describe("front-door rejections and the owner workspace mutex", () => {
+  const httpFailure = (status: number, body = "") =>
+    agentCoreHttpFailure(
+      {
+        status,
+        text: async () => body,
+      } as unknown as Parameters<typeof agentCoreHttpFailure>[0],
+      TEST_LOG
+    )
+
+  // A status in this set never reached a microVM, so nothing can be writing to
+  // the workspace and the owner's mutex must be dropped immediately. Retaining
+  // it made every later turn for that owner defer on `workspace-contended`
+  // until the 30-minute TTL lapsed.
+  test.each([
+    [502, "an edge failure that never reaches the runtime"],
+    [429, "a throttle refused before scheduling"],
+    [503, "an unavailable front door"],
+  ])("releases the workspace lock after %i (%s)", async status => {
+    const result = await httpFailure(status)
+
+    expect(result.failed).toBe(true)
+    expect(result.workspaceFinalizationConfirmed).toBe(true)
+  })
+
+  // The other half of the contract: these may have left a microVM mid-write,
+  // so the conservative retention has to survive.
+  test.each([
+    [504, "the gateway can time out while a long turn is still running"],
+    [424, "the wrapper boots and restores the workspace before readiness fails"],
+    [500, "an opaque server error proves nothing about the runtime"],
+  ])("retains the workspace lock after %i (%s)", async status => {
+    const result = await httpFailure(status)
+
+    expect(result.failed).toBe(true)
+    expect(result.workspaceFinalizationConfirmed).toBe(false)
+  })
+
+  test("keeps the 502 error class distinct from a throttle", async () => {
+    const throttle = await httpFailure(503)
+    const edge = await httpFailure(502)
+
+    expect(throttle.errorClass).toBe("AgentCoreThrottled_503")
+    expect(edge.errorClass).toBe("AgentCoreHttpError_502")
+  })
+
+  test("an edge 502 actually frees the lease rather than only reporting it safe", async () => {
+    const released: string[] = []
+
+    await invokeWithSessionLockLease(
+      { sessionId: "workspace-lock", ownerEmail: "owner@psd401.net" },
+      "lock-token",
+      TEST_LOG,
+      async () => httpFailure(502),
+      {
+        renewSessionLock: async () => true,
+        releaseSessionLock: async sessionId => {
+          released.push(sessionId)
+        },
+        scheduler: {
+          start: () => "renewal-timer",
+          stop: () => {},
+        },
+      }
+    )
+
+    expect(released).toEqual(["workspace-lock"])
+  })
+
+  test("a 504 still retains the lease so a finalizing microVM is not raced", async () => {
+    const released: string[] = []
+
+    await invokeWithSessionLockLease(
+      { sessionId: "workspace-lock", ownerEmail: "owner@psd401.net" },
+      "lock-token",
+      TEST_LOG,
+      async () => httpFailure(504),
+      {
+        renewSessionLock: async () => true,
+        releaseSessionLock: async sessionId => {
+          released.push(sessionId)
+        },
+        scheduler: {
+          start: () => "renewal-timer",
+          stop: () => {},
+        },
+      }
+    )
+
+    expect(released).toEqual([])
   })
 })

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -2326,6 +2326,31 @@ async function fetchAgentCoreResponse(
   });
 }
 
+/**
+ * Statuses that prove AgentCore rejected the call at its front door, before
+ * any microVM was started.
+ *
+ * 429 and 503 are refusals to schedule the invocation at all. 502 is an edge
+ * failure: the body is an nginx error page rather than an AgentCore response,
+ * and the call never appears in the runtime's own Invocations metric — the
+ * 2026-09-10 incident produced two of these, each failing in ~1.2s, and
+ * AgentCore counted neither as an invocation.
+ *
+ * Deliberately absent:
+ *
+ *  - 504, which the gateway can return while a microVM is still working. Turns
+ *    of 80-200s are normal here, so a gateway timeout is precisely the "may
+ *    still be finalizing" case the lock retention exists to protect.
+ *  - 424 ("An error occurred when starting the runtime"). By the time
+ *    readiness fails the wrapper has already booted and restored the
+ *    workspace: the 2026-09-10 runtime logs show BUILD_MARKER, the Mantle
+ *    proxy, and workspace restore all completing first. A container that
+ *    reached that point may have written to the workspace.
+ */
+const FRONT_DOOR_REJECTION_STATUSES: ReadonlySet<number> = new Set([
+  429, 502, 503,
+]);
+
 async function agentCoreHttpFailure(
   response: Awaited<ReturnType<typeof undiciFetch>>,
   log: ReturnType<typeof createLogger>
@@ -2336,13 +2361,25 @@ async function agentCoreHttpFailure(
     body: errorBody.substring(0, 500),
   });
   const throttled = response.status === 503 || response.status === 429;
+  // A front-door rejection never reached a microVM, so no workspace write can
+  // be in flight and the owner's mutex must not be held for its full 30-minute
+  // TTL. This is the `workspaceFinalizationConfirmed` contract's own "a local
+  // rejection before any runtime call is also safe" branch, the same one
+  // AgentNotDeployed already takes. Before this, a 1.2s edge 502 retained the
+  // lock and every later turn for that owner deferred on `workspace-contended`
+  // until the TTL lapsed — on 2026-09-10 that silently froze two users' threads
+  // for 30 minutes each, with no signal beyond one generic error.
+  const rejectedAtFrontDoor = FRONT_DOOR_REJECTION_STATUSES.has(
+    response.status
+  );
   return failedAgentCoreResult(
     throttled
       ? "I'm temporarily busy. Please try again in a moment."
       : 'I encountered an error processing your message. Please try again.',
     throttled
       ? `AgentCoreThrottled_${response.status}`
-      : `AgentCoreHttpError_${response.status}`
+      : `AgentCoreHttpError_${response.status}`,
+    rejectedAtFrontDoor
   );
 }
 
@@ -5751,6 +5788,7 @@ async function processRecord(
 }
 
 export const agentRouterTestHelpers = {
+  agentCoreHttpFailure,
   dmSpaceForUserRecord,
   userActivityUpdate,
   normalizeChatEvent,


### PR DESCRIPTION
## The bug

A **1.2-second** gateway failure silently froze a user's agent for **30 minutes**.

On 2026-09-10 two prod turns took an HTTP 502 from AgentCore's front door — 19:53:05 (`hagelk@`) and 19:54:32 (`kinneys@`). Both failed in ~1.2s with an **nginx error page** rather than an AgentCore response, and neither appears in the runtime's `Invocations` metric (`Errors`, `SystemErrors`, `Throttles` all 0 for the window). The request died at the edge — **no microVM was ever started**.

But the router had already taken the owner-wide workspace mutex. `agentCoreHttpFailure()` returned `workspaceFinalizationConfirmed` at its default `false`, so the lease's `finally` took the conservative branch and **retained the lock for the full 30-minute TTL**.

For those 30 minutes every turn for that owner failed `tryAcquireSessionLock()` and threw `WorkspaceTurnDeferredError('workspace-contended')`, requeuing at 60s intervals. One message reached **`deferAttempt` 16** before the TTL lapsed; the cap is 180 attempts / 3 hours.

From the user's side the thread just went dead — one generic error, then silence, with no hint it would recover on its own.

## The fix

**The retention is correct and stays.** Its doc comment names the hazard exactly: *"The remote microVM may still be finalizing after this Lambda has stopped receiving bytes."* What was wrong is that it fired for failures where that hazard **cannot exist**.

The type contract already carved this out — `workspaceFinalizationConfirmed` is documented as *"True when deleting the lock is safe… A local rejection before any runtime call is also safe"* — and `AgentNotDeployed` already passes `true` on that basis. This extends the same reasoning rather than adding a new concept.

**Released** (front-door rejection, no microVM):

| Status | Why |
|---|---|
| 429 / 503 | Refused before the invocation was scheduled |
| 502 | Edge failure — nginx body, absent from `Invocations` |

**Still retained** (a microVM may be mid-write):

| Status | Why |
|---|---|
| 504 | The gateway can time out while a turn is still running. Turns of 80–200s are normal here — this *is* the "may still be finalizing" case |
| 424 | By the time readiness fails the wrapper has booted and restored the workspace — the runtime logs show `BUILD_MARKER`, Mantle proxy start and workspace restore all completing first |
| other 5xx | Opaque; proves nothing about the runtime |

## Blast radius

`workspaceFinalizationConfirmed` is read in exactly **two** places, both lock releases (`invokeWithSessionLockLease`, and `job-main.ts`'s `finally`), so widening it has no other effect.

Error classes and user strings are **untouched** — a 502 still reports `AgentCoreHttpError_502`, not `AgentCoreThrottled_502` — so existing telemetry and dashboards keep their meaning.

## Tests

Added to `index.test.ts` (bun:test): 502/429/503 release and 504/424/500 retain, asserted both at the `agentCoreHttpFailure` level and end-to-end through `invokeWithSessionLockLease`, plus a guard that the 502 error class stays distinct from a throttle.

- `test:lambda:router` — **146 pass / 0 fail**
- `test:ci` — 613 suites, **5918 pass**
- `tsc --noEmit` — clean at repo root **and** in `infra/lambdas/agent-router`
- `eslint --max-warnings 0` — clean

## Not addressed here

Deliberately out of scope, worth separate work:

1. A 502 still shows "I encountered an error processing your message" with **no retry** — only 503/429 get the "temporarily busy" wording, and neither actually retries.
2. A `workspace-contended` deferral is still **invisible to the user**.

## Note

Pushed with `SKIP_E2E=1`. This changes a Lambda that Playwright never exercises, and the suite already had an unrelated failing spec (`atrium-meridian-rich.spec.ts`). Flagging rather than burying it.
